### PR TITLE
Fix mesh upside down after window resize - issue fix #90

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -191,6 +191,7 @@ class OpenGLRenderer(hub: Hub, applicationName: String, scene: Scene, width: Int
             pbos[1] = 0
 
             embedIn?.let { panel ->
+                panel.imageView.scaleY = -1.0
                 panel.prefWidth = window.width.toDouble()
                 panel.prefHeight = window.height.toDouble()
             }


### PR DESCRIPTION
I noticed that when the panel is created, the Y axis is inverted, but, when the window is resized, the panel is updated, but the Y axis is not inverted. Maybe this is not the right solution, but this fixed the problem.