### PR TITLE
Fixes for command buffer caching

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -41,20 +41,6 @@ open class VulkanObjectState : NodeMetadata {
 
     var textureDescriptorSet: Long = -1L
 
-    private val currentInCommandBuffer = HashMap<VulkanCommandBuffer, Boolean>(3)
-
-    fun setCommandBufferUpdated(commandBuffer: VulkanCommandBuffer, isUpdated: Boolean) {
-        currentInCommandBuffer.put(commandBuffer, isUpdated)
-    }
-
-    fun setAllCommandBufferUpdated(isUpdated: Boolean) {
-        currentInCommandBuffer.entries.forEach { it.setValue(isUpdated) }
-    }
-
-    fun isCurrentInCommandBuffer(commandBuffer: VulkanCommandBuffer): Boolean {
-        return currentInCommandBuffer.getOrPut(commandBuffer, { true })
-    }
-
     fun texturesToDescriptorSet(device: VulkanDevice, descriptorSetLayout: Long, descriptorPool: Long, targetBinding: Int = 0): Long {
         val descriptorSet = if(textureDescriptorSet == -1L) {
             val pDescriptorSetLayout = memAllocLong(1)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -52,7 +52,7 @@ open class VulkanRenderpass(val name: String, config: RenderConfigReader.RenderC
             commandBufferBacking.put(b)
         }
 
-    private var commandBufferBacking = RingBuffer(size = 2,
+    private var commandBufferBacking = RingBuffer(size = 3,
         default = { VulkanCommandBuffer(device, null, true) })
 
     var semaphore = -1L
@@ -60,13 +60,12 @@ open class VulkanRenderpass(val name: String, config: RenderConfigReader.RenderC
     var passConfig: RenderConfigReader.RenderpassConfig = config.renderpasses.get(name)!!
 
     var isViewportRenderpass = false
-    var commandBufferCount = 2
+    var commandBufferCount = 3
         set(count) {
             // clean up old backing
             (1..commandBufferBacking.size).forEach { commandBufferBacking.get().close() }
             commandBufferBacking.reset()
 
-            this.isViewportRenderpass = true
             field = count
 
             commandBufferBacking = RingBuffer(size = count,
@@ -85,7 +84,8 @@ open class VulkanRenderpass(val name: String, config: RenderConfigReader.RenderC
                               var renderArea: VkRect2D = VkRect2D.calloc(),
                               var renderPassBeginInfo: VkRenderPassBeginInfo = VkRenderPassBeginInfo.calloc(),
                               var uboOffsets: IntBuffer = memAllocInt(16),
-                              var eye: IntBuffer = memAllocInt(1)): AutoCloseable {
+                              var eye: IntBuffer = memAllocInt(1),
+                              var renderLists: HashMap<VulkanCommandBuffer, Array<Node>> = HashMap()): AutoCloseable {
 
         override fun close() {
             memFree(descriptorSets)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -178,6 +178,8 @@ open class VulkanSwapchain(open val device: VulkanDevice,
             val imageCount = VU.getInts("Getting swapchain images", 1,
                 { KHRSwapchain.vkGetSwapchainImagesKHR(device.vulkanDevice, handle, this, null) })
 
+            logger.info("Got ${imageCount.get(0)} swapchain images")
+
             val swapchainImages = VU.getLongs("Getting swapchain images", imageCount.get(0),
                 { KHRSwapchain.vkGetSwapchainImagesKHR(device.vulkanDevice, handle, imageCount, this) }, {})
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanUBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanUBO.kt
@@ -101,10 +101,10 @@ open class VulkanUBO(val device: VulkanDevice, var backingBuffer: VulkanBuffer? 
     }
 
     override fun close() {
-        logger.debug("Closing UBO $this ...")
+        logger.trace("Closing UBO $this ...")
         if(backingBuffer == null) {
             ownedBackingBuffer?.let {
-                logger.debug("Destroying self-owned buffer of $this/$it  ${it.memory.toHexString()})...")
+                logger.trace("Destroying self-owned buffer of $this/$it  ${it.memory.toHexString()})...")
                 it.close()
             }
         }


### PR DESCRIPTION
* command buffers are now invalidated for the right render pass
* command buffer metadata has been moved from VulkanRenderer to
  VulkanRenderpass
* VulkanObjectState no longer stores references to command buffers