### PR TITLE
Do not set prefWidth/Height in renderer

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -191,11 +191,6 @@ class OpenGLRenderer(hub: Hub,
 
             drawable?.setSurfaceSize(window.width, window.height)
 
-            embedIn?.let { panel ->
-                panel.prefWidth = window.width.toDouble()
-                panel.prefHeight = window.height.toDouble()
-            }
-
             lastResize = -1L
         }
     }
@@ -317,11 +312,6 @@ class OpenGLRenderer(hub: Hub,
                         panel.heightProperty()?.addListener { _, _, newHeight ->
                             resizeHandler.lastHeight = newHeight.toInt()
                         }
-
-                        panel.minWidth = 100.0
-                        panel.minHeight = 100.0
-                        panel.prefWidth = window.width.toDouble()
-                        panel.prefHeight = window.height.toDouble()
                     }
 
                     window = SceneryWindow.JavaFXStage(embedIn!!)

--- a/src/main/kotlin/graphics/scenery/utils/SceneryPanel.kt
+++ b/src/main/kotlin/graphics/scenery/utils/SceneryPanel.kt
@@ -6,9 +6,7 @@ import com.sun.javafx.sg.prism.NGRegion
 import com.sun.prism.Graphics
 import com.sun.prism.Texture
 import javafx.scene.image.ImageView
-import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Pane
-import javafx.scene.layout.Region
 import java.nio.ByteBuffer
 import java.util.*
 
@@ -53,6 +51,9 @@ class SceneryPanel(var imageWidth: Int, var imageHeight: Int) : Pane() {
 
         width = imageWidth.toDouble()
         height = imageHeight.toDouble()
+
+        minWidth = 1.0
+        minHeight = 1.0
 
         children.add(imageView)
     }


### PR DESCRIPTION
The renderer should not modify properties of the scenery panel, thus remove all calls to `panel.{pref,min}{Width,Height}` in `OpenGLRenderer.kt`. Still, the minimum width and height need to be larger than zero to avoid zero length rendering buffers. This is handled in the `SceneryPanel` constructor.