### PR TITLE
Introduce caching of already-compiled shader modules

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -539,11 +539,11 @@ class OpenGLRenderer(hub: Hub,
 
         shaders.forEach {
             if (baseClass.getResource("shaders/" + it) != null) {
-                val m = OpenGLShaderModule(gl, "main", baseClass, "shaders/" + it)
+                val m = OpenGLShaderModule.getFromCacheOrCreate(gl, "main", baseClass, "shaders/" + it)
                 modules.put(m.shaderType, m)
             } else {
                 if(Renderer::class.java.getResource("shaders/" + it) != null && baseClass !is Renderer) {
-                    val m = OpenGLShaderModule(gl, "main", Renderer::class.java, "shaders/" + it)
+                    val m = OpenGLShaderModule.getFromCacheOrCreate(gl, "main", Renderer::class.java, "shaders/" + it)
                     modules.put(m.shaderType, m)
                 } else {
                     logger.warn("Shader not found: shaders/$it")

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
@@ -10,6 +10,7 @@ import graphics.scenery.spirvcrossj.*
 import graphics.scenery.utils.LazyLogger
 import java.nio.ByteBuffer
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.LinkedHashMap
 
 
@@ -346,5 +347,23 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, clazz: Class<*>, shad
 
     override fun toString(): String {
         return "$shader: $shaderType with UBOs ${uboSpecs.keys.joinToString(", ") }}"
+    }
+
+    companion object {
+        private data class ShaderSignature(val gl: GL4, val clazz: Class<*>, val shaderCodePath: String)
+        private val shaderModuleCache = ConcurrentHashMap<ShaderSignature, OpenGLShaderModule>()
+
+        fun getFromCacheOrCreate(gl: GL4, entryPoint: String, clazz: Class<*>, shaderCodePath: String): OpenGLShaderModule {
+            val signature = ShaderSignature(gl, clazz, shaderCodePath)
+
+            return if(shaderModuleCache.containsKey(signature)) {
+                shaderModuleCache[signature]!!
+            } else {
+                val module = OpenGLShaderModule(gl, entryPoint, clazz, shaderCodePath)
+                shaderModuleCache[signature] = module
+
+                module
+            }
+        }
     }
 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -849,7 +849,7 @@ open class VulkanRenderer(hub: Hub,
                     logger.debug("Shaders are: ${shaders.joinToString(", ")}")
 
                     pass.value.initializePipeline("preferred-${node.name}",
-                        shaders.map { VulkanShaderModule(device, "main", node.javaClass, "shaders/" + it) },
+                        shaders.map { VulkanShaderModule.getFromCacheOrCreate(device, "main", node.javaClass, "shaders/" + it) },
 
                         settings = { pipeline ->
                             if (node.material.doubleSided) {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -268,7 +268,7 @@ open class VulkanRenderpass(val name: String, config: RenderConfigReader.RenderC
     }
 
     fun initializeDefaultPipeline() {
-        initializePipeline("default", passConfig.shaders.map { VulkanShaderModule(device, "main", Renderer::class.java, "shaders/" + it) })
+        initializePipeline("default", passConfig.shaders.map { VulkanShaderModule.getFromCacheOrCreate(device, "main", Renderer::class.java, "shaders/" + it) })
     }
 
     fun initializePipeline(pipelineName: String = "default", shaders: List<VulkanShaderModule>,


### PR DESCRIPTION
This PR introduces a simple caching mechanism for shaders, such that they are only compiled once, when they are encountered. Works with both OpenGLRenderer and VulkanRenderer.