### PR TITLE
Add shutdown hook to SceneryBase

### DIFF
--- a/src/main/kotlin/graphics/scenery/Hub.kt
+++ b/src/main/kotlin/graphics/scenery/Hub.kt
@@ -26,6 +26,10 @@ class Hub {
         obj.hub = this
     }
 
+    fun addApplication(application: SceneryBase) {
+        elements.put(SceneryElement.Application, application)
+    }
+
     /**
      * Query the Hub for a given type of [SceneryElement]
      *

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -12,7 +12,6 @@ import graphics.scenery.net.NodeSubscriber
 import graphics.scenery.repl.REPL
 import graphics.scenery.utils.LazyLogger
 import graphics.scenery.utils.Statistics
-import org.lwjgl.system.MemoryUtil
 import org.scijava.ui.behaviour.ClickBehaviour
 import java.lang.management.ManagementFactory
 import kotlin.concurrent.thread
@@ -89,6 +88,7 @@ open class SceneryBase(var applicationName: String,
      *
      */
     open fun main() {
+        hub.addApplication(this)
         logger.info("Started application as PID ${getProcessID()}")
 
         val master = System.getProperty("scenery.master")?.toBoolean() ?: false
@@ -268,5 +268,12 @@ open class SceneryBase(var applicationName: String,
 
     protected fun getProcessID(): Int {
         return Integer.parseInt(ManagementFactory.getRuntimeMXBean().name.split("@".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[0])
+    }
+
+    /**
+     * Sets the shouldClose flag on renderer, causing it to shut down and thereby ending the main loop.
+     */
+    fun close() {
+        renderer?.shouldClose = true
     }
 }

--- a/src/main/kotlin/graphics/scenery/SceneryElement.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryElement.kt
@@ -6,6 +6,8 @@ package graphics.scenery
 * @author Ulrik Günther <hello@ulrik.is>
 */
 enum class SceneryElement {
+    /** The application base object itself */
+    Application,
     /** Element for any renderers */
     Renderer,
     /** Element for any HMD input devices */

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -1088,7 +1088,11 @@ class OpenGLRenderer(hub: Hub,
         hub?.getWorkingHMD()?.update()
 
         if (shouldClose) {
-            joglDrawable?.animator?.stop()
+            try {
+                joglDrawable?.animator?.stop()
+            } catch(e: ThreadDeath) {
+                logger.debug("Caught JOGL ThreadDeath, ignoring.")
+            }
             return
         }
 


### PR DESCRIPTION
This adds a shutdown hook to `SceneryBase`, in the form of the `close()` method. It also adds the `Application` type to Hub, such that the application object can be made available in the hub and accessed (and closed, for that matter).

The PR also introduces a small fix in OpenGLRenderer which should handle closing JOGL windows more gracefully.