### PR TITLE
Custom attachment sizes

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
+++ b/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
@@ -22,7 +22,7 @@ fun RenderConfigReader.RenderConfig.getOutputOfPass(passname: String): String? {
 }
 
 fun RenderConfigReader.RenderConfig.getInputsOfTarget(targetName: String): Set<String> {
-    rendertargets?.let { rts ->
+    rendertargets.let { rts ->
         return rts.filter {
             it.key == renderpasses.filter { it.value.output == targetName }.keys.first()
         }.keys
@@ -89,12 +89,13 @@ class RenderConfigReader {
         var sRGB: Boolean = false,
         var description: String?,
         var stereoEnabled: Boolean = false,
-        var rendertargets: Map<String, Map<String, AttachmentConfig>>?,
+        var rendertargets: Map<String, RendertargetConfig> = emptyMap(),
         var renderpasses: Map<String, RenderpassConfig>)
 
-    data class AttachmentConfig(
-        @JsonDeserialize(using = FloatPairDeserializer::class) var size: Pair<Float, Float>,
-        var format: TargetFormat)
+    data class RendertargetConfig(
+        @JsonDeserialize(using = FloatPairDeserializer::class) var size: Pair<Float, Float> = Pair(1.0f, 1.0f),
+        val attachments: Map<String, TargetFormat> = emptyMap()
+    )
 
     data class RenderpassConfig(
         var type: RenderpassType,

--- a/src/main/kotlin/graphics/scenery/backends/UBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/UBO.kt
@@ -18,6 +18,8 @@ open class UBO {
     protected var members = LinkedHashMap<String, () -> Any>()
     protected var memberOffsets = HashMap<String, Int>()
     protected val logger by LazyLogger()
+    var hash: Int = 0
+        private set
 
     protected var sizeCached = -1
 
@@ -145,11 +147,16 @@ open class UBO {
 
             val (size, alignment) = getSizeAndAlignment(value)
 
-            logger.trace("Populating {} of type {} size={} alignment={}", it.key, value.javaClass.simpleName, size, alignment)
+            if(logger.isTraceEnabled) {
+                logger.trace("Populating {} of type {} size={} alignment={}", it.key, value.javaClass.simpleName, size, alignment)
+            }
 
             if(memberOffsets[it.key] != null) {
                 // position in buffer is known, use it
-                logger.trace("{} goes to {}", it.key, memberOffsets[it.key]!!)
+                if(logger.isTraceEnabled) {
+                    logger.trace("{} goes to {}", it.key, memberOffsets[it.key]!!)
+                }
+
                 pos = (originalPos + memberOffsets[it.key]!!)
                 data.position(pos)
             } else {
@@ -226,6 +233,14 @@ open class UBO {
 
     fun members(): String {
         return members.keys.joinToString(", ")
+    }
+
+    fun getMembersHash(): Int {
+        return members.hashCode()
+    }
+
+    fun updateHash() {
+        hash = members.hashCode()
     }
 
     fun get(name: String): (() -> Any)? {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
@@ -527,7 +527,7 @@ class VU {
         }
 
         fun createRenderTargetDescriptorSet(device: VulkanDevice, descriptorPool: Long, descriptorSetLayout: Long,
-                                             rt: Map<String, RenderConfigReader.AttachmentConfig>,
+                                             rt: Map<String, RenderConfigReader.TargetFormat>,
                                              target: VulkanFramebuffer, onlyFor: String? = null): Long {
 
             return stackPush().use { stack ->

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
@@ -65,7 +65,7 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
 
     var attachments = LinkedHashMap<String, VulkanFramebufferAttachment>()
 
-    protected fun createAttachment(format: Int, usage: Int): VulkanFramebufferAttachment {
+    protected fun createAttachment(format: Int, usage: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebufferAttachment {
         val a = VulkanFramebufferAttachment()
         var aspectMask: Int = 0
         var imageLayout: Int = 0
@@ -83,8 +83,8 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
         }
 
         val imageExtent = VkExtent3D.calloc()
-            .width(width)
-            .height(height)
+            .width(attachmentWidth)
+            .height(attachmentHeight)
             .depth(1)
 
         val image = VkImageCreateInfo.calloc()
@@ -150,227 +150,8 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
         return a
     }
 
-    fun addFloatBuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            16 -> VK_FORMAT_R16_SFLOAT
-            32 -> VK_FORMAT_R32_SFLOAT
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16_SFLOAT }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addFloatRGBuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            16 -> VK_FORMAT_R16G16_SFLOAT
-            32 -> VK_FORMAT_R32G32_SFLOAT
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16_SFLOAT }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addFloatRGBBuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            16 -> VK_FORMAT_R16G16B16_SFLOAT
-            32 -> VK_FORMAT_R32G32B32_SFLOAT
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_SFLOAT }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addFloatRGBABuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            16 -> VK_FORMAT_R16G16B16A16_SFLOAT
-            32 -> VK_FORMAT_R32G32B32A32_SFLOAT
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_SFLOAT }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addUnsignedByteRGBABuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            8 -> if(sRGB) { VK_FORMAT_R8G8B8A8_SRGB } else { VK_FORMAT_R8G8B8A8_UNORM }
-            16 -> VK_FORMAT_R16G16B16A16_UNORM
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_UINT }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addUnsignedByteRBuffer(name: String, channelDepth: Int): VulkanFramebuffer {
-        val format: Int = when(channelDepth) {
-            8 -> VK_FORMAT_R8_UNORM
-            16 -> VK_FORMAT_R16_UNORM
-            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16_UNORM }
-        }
-
-        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-
-        val (loadOp, stencilLoadOp) = if(!shouldClear) {
-            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
-        } else {
-            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
-        }
-
-        val initialImageLayout = if(!shouldClear) {
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        } else {
-            VK_IMAGE_LAYOUT_UNDEFINED
-        }
-
-        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
-            .loadOp(loadOp)
-            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
-            .stencilLoadOp(stencilLoadOp)
-            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(initialImageLayout)
-            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(format)
-
-        attachments.put(name, att)
-
-        return this
-    }
-
-    fun addDepthBuffer(name: String, depth: Int): VulkanFramebuffer {
-        val format: Int = when(depth) {
-            16 -> VK_FORMAT_D16_UNORM
-            24 -> VK_FORMAT_D24_UNORM_S8_UINT
-            32 -> VK_FORMAT_D32_SFLOAT
-            else -> { logger.warn("Unsupported channel depth $depth, using 32 bit."); VK_FORMAT_D32_SFLOAT }
-        }
-
-        val bestSupportedFormat = getBestDepthFormat(format).first()
-
-        val att = createAttachment(bestSupportedFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
+    private fun createAndAddDepthStencilAttachmentInternal(name: String, format: Int, attachmentWidth: Int, attachmentHeight: Int) {
+        val att = createAttachment(format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, attachmentWidth, attachmentHeight)
 
         val (loadOp, stencilLoadOp) = if(!shouldClear) {
             VK_ATTACHMENT_LOAD_OP_DONT_CARE to VK_ATTACHMENT_LOAD_OP_LOAD
@@ -387,11 +168,123 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
             .stencilStoreOp(VK_ATTACHMENT_STORE_OP_STORE)
             .initialLayout(initialImageLayout)
             .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-            .format(bestSupportedFormat)
+            .format(format)
 
         att.type = VulkanFramebufferType.DEPTH_ATTACHMENT
 
         attachments.put(name, att)
+    }
+
+    private fun createAndAddColorAttachmentInternal(name: String, format: Int, attachmentWidth: Int, attachmentHeight: Int) {
+        val att = createAttachment(format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, attachmentWidth, attachmentHeight)
+
+        val (loadOp, stencilLoadOp) = if(!shouldClear) {
+            VK_ATTACHMENT_LOAD_OP_LOAD to VK_ATTACHMENT_LOAD_OP_LOAD
+        } else {
+            VK_ATTACHMENT_LOAD_OP_CLEAR to VK_ATTACHMENT_LOAD_OP_DONT_CARE
+        }
+
+        val initialImageLayout = if(!shouldClear) {
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+        } else {
+            VK_IMAGE_LAYOUT_UNDEFINED
+        }
+
+        att.desc.samples(VK_SAMPLE_COUNT_1_BIT)
+            .loadOp(loadOp)
+            .storeOp(VK_ATTACHMENT_STORE_OP_STORE)
+            .stencilLoadOp(stencilLoadOp)
+            .stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
+            .initialLayout(initialImageLayout)
+            .finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+            .format(format)
+
+        attachments.put(name, att)
+    }
+
+    fun addFloatBuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            16 -> VK_FORMAT_R16_SFLOAT
+            32 -> VK_FORMAT_R32_SFLOAT
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16_SFLOAT }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addFloatRGBuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            16 -> VK_FORMAT_R16G16_SFLOAT
+            32 -> VK_FORMAT_R32G32_SFLOAT
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16_SFLOAT }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addFloatRGBBuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            16 -> VK_FORMAT_R16G16B16_SFLOAT
+            32 -> VK_FORMAT_R32G32B32_SFLOAT
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_SFLOAT }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addFloatRGBABuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            16 -> VK_FORMAT_R16G16B16A16_SFLOAT
+            32 -> VK_FORMAT_R32G32B32A32_SFLOAT
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_SFLOAT }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addUnsignedByteRGBABuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            8 -> if(sRGB) { VK_FORMAT_R8G8B8A8_SRGB } else { VK_FORMAT_R8G8B8A8_UNORM }
+            16 -> VK_FORMAT_R16G16B16A16_UNORM
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16G16B16A16_UINT }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addUnsignedByteRBuffer(name: String, channelDepth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(channelDepth) {
+            8 -> VK_FORMAT_R8_UNORM
+            16 -> VK_FORMAT_R16_UNORM
+            else -> { logger.warn("Unsupported channel depth $channelDepth, using 16 bit."); VK_FORMAT_R16_UNORM }
+        }
+
+        createAndAddColorAttachmentInternal(name, format, attachmentWidth, attachmentHeight)
+
+        return this
+    }
+
+    fun addDepthBuffer(name: String, depth: Int, attachmentWidth: Int = width, attachmentHeight: Int = height): VulkanFramebuffer {
+        val format: Int = when(depth) {
+            16 -> VK_FORMAT_D16_UNORM
+            24 -> VK_FORMAT_D24_UNORM_S8_UINT
+            32 -> VK_FORMAT_D32_SFLOAT
+            else -> { logger.warn("Unsupported channel depth $depth, using 32 bit."); VK_FORMAT_D32_SFLOAT }
+        }
+
+        val bestSupportedFormat = getBestDepthFormat(format).first()
+
+        createAndAddDepthStencilAttachmentInternal(name, bestSupportedFormat, attachmentWidth, attachmentHeight)
 
         return this
     }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -2228,6 +2228,24 @@ open class VulkanRenderer(hub: Hub,
 
             pass.vulkanMetadata.renderLists.put(commandBuffer, renderOrderList.toTypedArray())
             pass.vulkanMetadata.renderLists.keys.forEach { it.stale = true }
+
+            // if we are in a VR pass, invalidate passes for both eyes to prevent one of them housing stale data
+            if(renderConfig.stereoEnabled && (pass.name.contains("Left") || pass.name.contains("Right"))) {
+                val passLeft = if(pass.name.contains("Left")) {
+                    pass.name
+                } else {
+                    pass.name.substringBefore("Right") + "Left"
+                }
+
+                val passRight = if(pass.name.contains("Right")) {
+                    pass.name
+                } else {
+                    pass.name.substringBefore("Left") + "Right"
+                }
+
+                renderpasses[passLeft]?.vulkanMetadata?.renderLists?.keys?.forEach { it.stale = true }
+                renderpasses[passRight]?.vulkanMetadata?.renderLists?.keys?.forEach { it.stale = true }
+            }
         }
 
         // If the command buffer is not stale, though, we keep the cached one and return. This

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -154,7 +154,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
 
             val ds = if(inputFramebuffer.key.contains(".")) {
                 VU.createRenderTargetDescriptorSet(device, descriptorPool, dsl,
-                    config.rendertargets!![inputFramebuffer.key.substringBefore(".")]!!,
+                    config.rendertargets[inputFramebuffer.key.substringBefore(".")]!!.attachments,
                     inputFramebuffer.value, inputFramebuffer.key.substringAfter("."))
             } else {
                 inputFramebuffer.value.outputDescriptorSet
@@ -194,7 +194,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
                     else -> "Renderer.$name.${entry.key}"
                 }
 
-                if(!entry.key.startsWith("Global")) {
+                if(!entry.key.startsWith("Global.") && !entry.key.startsWith("Pass.")) {
                     settings.set(settingsKey, value)
                 }
 

--- a/src/main/resources/graphics/scenery/backends/DeferredShading.yml
+++ b/src/main/resources/graphics/scenery/backends/DeferredShading.yml
@@ -3,42 +3,32 @@ description: Deferred Shading, with HDR postprocessing and FXAA
 
 rendertargets:
   GeometryBuffer:
-    NormalsMaterial:
-      size: 1.0, 1.0
-      format: RGBA_Float16
-    DiffuseAlbedo:
-      size: 1.0, 1.0
-      format: RGBA_UInt8
-    ZBuffer:
-      size: 1.0, 1.0
-      format: Depth32
+    attachments:
+      NormalsMaterial: RGBA_Float16
+      DiffuseAlbedo: RGBA_UInt8
+      ZBuffer: Depth32
   ForwardBuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_Float32
+    attachments:
+      Color: RGBA_Float32
   DSSDOBuffer:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   DSSDOTemp1:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   DSSDOTemp2:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   HDRBuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_Float32
-    Depth:
-      size: 1.0, 1.0
-      format: Depth32
+    attachments:
+      Color: RGBA_Float32
+      Depth: Depth32
   FXAABuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_UInt8
+    attachments:
+      Color: RGBA_UInt8
 
 renderpasses:
   Scene:
@@ -52,8 +42,8 @@ renderpasses:
   DSSDO:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       ssaoRadius: 0.5
       ssaoSamples: 16
       maxDistance: 0.2
@@ -67,8 +57,8 @@ renderpasses:
   DSSDOBlurV:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       Direction: 0.0, 1.0
     shaders:
       - "FullscreenQuad.vert.spv"
@@ -80,8 +70,8 @@ renderpasses:
   DSSDOBlurH:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       Direction: 1.0, 0.0
     shaders:
       - "FullscreenQuad.vert.spv"

--- a/src/main/resources/graphics/scenery/backends/DeferredShadingStereo.yml
+++ b/src/main/resources/graphics/scenery/backends/DeferredShadingStereo.yml
@@ -4,42 +4,32 @@ stereoEnabled: true
 
 rendertargets:
   GeometryBuffer:
-    NormalsMaterial:
-      size: 1.0, 1.0
-      format: RGBA_Float16
-    DiffuseAlbedo:
-      size: 1.0, 1.0
-      format: RGBA_UInt8
-    ZBuffer:
-      size: 1.0, 1.0
-      format: Depth32
+    attachments:
+      NormalsMaterial: RGBA_Float16
+      DiffuseAlbedo: RGBA_UInt8
+      ZBuffer: Depth32
   ForwardBuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_Float32
+    attachments:
+      Color: RGBA_Float32
   DSSDOBuffer:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   DSSDOTemp1:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   DSSDOTemp2:
-    Occlusion:
-      size: 0.5, 0.5
-      format: RGBA_UInt8
+    size: 0.5, 0.5
+    attachments:
+      Occlusion: RGBA_UInt8
   HDRBuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_Float32
-    Depth:
-      size: 1.0, 1.0
-      format: Depth32
+    attachments:
+      Color: RGBA_Float32
+      Depth: Depth32
   FXAABuffer:
-    Color:
-      size: 1.0, 1.0
-      format: RGBA_UInt8
+    attachments:
+      Color: RGBA_UInt8
 
 renderpasses:
   leftEye:
@@ -67,8 +57,8 @@ renderpasses:
   DSSDO:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       ssaoRadius: 0.5
       ssaoSamples: 16
       maxDistance: 0.2
@@ -82,8 +72,8 @@ renderpasses:
   DSSDOBlurV:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       Direction: 0.0, 1.0
     shaders:
       - "FullscreenQuad.vert.spv"
@@ -95,8 +85,8 @@ renderpasses:
   DSSDOBlurH:
     type: quad
     parameters:
-      Global.displayWidth: 0
-      Global.displayHeight: 0
+      Pass.displayWidth: 0
+      Pass.displayHeight: 0
       Direction: 1.0, 0.0
     shaders:
       - "FullscreenQuad.vert.spv"


### PR DESCRIPTION
* introduces customizable framebuffer attachment sizes, such that e.g. AO can be done at a lower resolution
* simplifies the framebuffer attachment definition in the render config YAML files
* `VulkanRenderer`: Fixes an issue where stale command buffers would not be re-recorded in stereo mode
* `VulkanFramebuffer`: Refactoring to remove redundant code