### PR TITLE
OpenGLRenderer: Don't linearly sample uint volumes

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -2032,7 +2032,7 @@ class OpenGLRenderer(hub: Hub,
                                 dimensions.x().toInt(),
                                 dimensions.y().toInt(),
                                 dimensions.z().toInt() ?: 1,
-                                true,
+                                dimensions.z().toInt() <= 1,
                                 miplevels)
 
                             if (generateMipmaps) {


### PR DESCRIPTION
Fixes an issue in OpenGLRenderer, where on some platforms volumetric data would not show up due to linear sampling not being supported.