### PR TITLE
Allow SceneryBase and REPL to consume an existing SciJava context

### DIFF
--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -13,6 +13,7 @@ import graphics.scenery.repl.REPL
 import graphics.scenery.utils.LazyLogger
 import graphics.scenery.utils.Renderdoc
 import graphics.scenery.utils.Statistics
+import org.scijava.Context
 import org.scijava.ui.behaviour.ClickBehaviour
 import java.lang.management.ManagementFactory
 import java.util.*
@@ -31,10 +32,11 @@ import kotlin.concurrent.thread
  * @author Ulrik Günther <hello@ulrik.is>
  */
 
-open class SceneryBase(var applicationName: String,
+open class SceneryBase @JvmOverloads constructor(var applicationName: String,
                        var windowWidth: Int = 1024,
                        var windowHeight: Int = 1024,
-                       val wantREPL: Boolean = true) {
+                       val wantREPL: Boolean = true,
+                       val scijavaContext: Context? = null) {
 
     /** The scene used by the renderer in the application */
     protected val scene: Scene = Scene()
@@ -118,7 +120,7 @@ open class SceneryBase(var applicationName: String,
         settings.set("System.PID", getProcessID())
 
         if (wantREPL && !headless) {
-            repl = REPL(scene, stats, hub)
+            repl = REPL(scijavaContext, scene, stats, hub)
             repl?.addAccessibleObject(settings)
         }
 

--- a/src/main/kotlin/graphics/scenery/repl/REPL.kt
+++ b/src/main/kotlin/graphics/scenery/repl/REPL.kt
@@ -13,7 +13,7 @@ import java.util.*
  * @property[addAccessibleObject] A list of objects that should be accessible right away in the REPL
  * @constructor Returns a REPL, equipped with a window for input/output.
  */
-class REPL(vararg accessibleObjects: Any) {
+class REPL(scijavaContext: Context? = null, vararg accessibleObjects: Any) {
 
     /** SciJava context for the REPL */
     protected var context: Context
@@ -27,7 +27,7 @@ class REPL(vararg accessibleObjects: Any) {
     protected var startupScriptClass: Class<*> = REPL::class.java
 
     init {
-        context = Context()
+        context = scijavaContext ?: Context()
         interpreterWindow = InterpreterWindow(context)
         interpreterWindow.isVisible = false
 


### PR DESCRIPTION
As requested in #160. Is that approximately how you'd like it, @ctrueden?