### PR TITLE
VulkanRenderer: Descriptor set improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ scenery has been tested with a number of different systems and GPUs. If you have
 |:--|:--|:--|:--|:--|:--|
 | AMD Radeon R5 M230 (Caicos Pro) | ⛔ | ✅ | ⬜ | ⬜ | ⬜ |
 | AMD Radeon R9 390 (Hawaii Pro) | ✅ | ✅ | ⬜ | ⬜ | ⬜ |
-| AMD Radeon R9 Nano (Fiji XT) | ⛔ | ⛔ | ⬜ | ⬜ | ⬜ |
+| AMD Radeon R9 Nano (Fiji XT) | ✅ | ✅ | ⬜ | ⬜ | ⬜ |
 | AMD Radeon R9 M370X (Strato Pro) | ⬜ | ⬜ | ⬜ | ⬜ | ✅ |
 | AMD FirePro W9100 (Hawaii XT) | ✅ | ✅ | ⬜ | ⬜ | ⬜ |
 | Intel HD Graphics 4400 (Haswell) | ✅ | 🚫 | ✅ | ✅ | ⬜ |

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -317,6 +317,7 @@ open class VulkanRenderer(hub: Hub,
     protected var sceneUBOs = ArrayList<Node>()
     protected var semaphores = ConcurrentHashMap<StandardSemaphores, Array<Long>>()
     protected var buffers = ConcurrentHashMap<String, VulkanBuffer>()
+    protected var UBOs = ConcurrentHashMap<String, VulkanUBO>()
     protected var textureCache = ConcurrentHashMap<String, VulkanTexture>()
     protected var descriptorSetLayouts = ConcurrentHashMap<String, Long>()
     protected var descriptorSets = ConcurrentHashMap<String, Long>()
@@ -1042,7 +1043,7 @@ open class VulkanRenderer(hub: Hub,
 
         m.put("LightParameters", VU.createDescriptorSetLayout(
             device,
-            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1)),
+            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1)),
             0,
             VK_SHADER_STAGE_ALL))
 
@@ -1056,7 +1057,7 @@ open class VulkanRenderer(hub: Hub,
 
         m.put("VRParameters", VU.createDescriptorSetLayout(
             device,
-            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1)),
+            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1)),
             0,
             VK_SHADER_STAGE_ALL))
 
@@ -1074,15 +1075,42 @@ open class VulkanRenderer(hub: Hub,
                 descriptorSetLayouts["MaterialProperties"]!!, 1,
                 buffers["UBOBuffer"]!!))
 
+        val lightUbo = VulkanUBO(device)
+        lightUbo.add("ViewMatrix0", { GLMatrix.getIdentity() })
+        lightUbo.add("ViewMatrix1", { GLMatrix.getIdentity() })
+        lightUbo.add("InverseViewMatrix0", { GLMatrix.getIdentity() })
+        lightUbo.add("InverseViewMatrix1", { GLMatrix.getIdentity() })
+        lightUbo.add("ProjectionMatrix", { GLMatrix.getIdentity() })
+        lightUbo.add("InverseProjectionMatrix", { GLMatrix.getIdentity() })
+        lightUbo.add("CamPosition", { GLVector.getNullVector(3) })
+        lightUbo.createUniformBuffer()
+        lightUbo.populate()
+
+        UBOs.put("LightParameters", lightUbo)
+
         this.descriptorSets.put("LightParameters",
-            VU.createDescriptorSetDynamic(device, descriptorPool,
+            VU.createDescriptorSet(device, descriptorPool,
                 descriptorSetLayouts["LightParameters"]!!, 1,
-                buffers["LightParametersBuffer"]!!))
+                lightUbo.descriptor!!))
+
+        val vrUbo = VulkanUBO(device)
+
+        vrUbo.add("projection0", { GLMatrix.getIdentity() } )
+        vrUbo.add("projection1", { GLMatrix.getIdentity() } )
+        vrUbo.add("inverseProjection0", { GLMatrix.getIdentity() } )
+        vrUbo.add("inverseProjection1", { GLMatrix.getIdentity() } )
+        vrUbo.add("headShift", { GLMatrix.getIdentity() })
+        vrUbo.add("IPD", { 0.0f })
+        vrUbo.add("stereoEnabled", { 0 })
+        vrUbo.createUniformBuffer()
+        vrUbo.populate()
+
+        UBOs.put("VRParameters", vrUbo)
 
         this.descriptorSets.put("VRParameters",
-            VU.createDescriptorSetDynamic(device, descriptorPool,
+            VU.createDescriptorSet(device, descriptorPool,
                 descriptorSetLayouts["VRParameters"]!!, 1,
-                buffers["VRParametersBuffer"]!!))
+                vrUbo.descriptor!!))
     }
 
     protected fun prepareStandardVertexDescriptors(): ConcurrentHashMap<VertexDataKinds, VertexDescription> {
@@ -2471,11 +2499,11 @@ open class VulkanRenderer(hub: Hub,
                 val sets = specs.map { (name, _) ->
                     when {
                         name == "VRParameters" -> {
-                            DescriptorSet.DynamicSet(descriptorSets["VRParameters"]!!, offset = 0, setName = "VRParameters")
+                            DescriptorSet.Set(descriptorSets["VRParameters"]!!, setName = "VRParameters")
                         }
 
                         name == "LightParameters" -> {
-                            DescriptorSet.DynamicSet(descriptorSets["LightParameters"]!!, offset = 0, setName = "LightParameters")
+                            DescriptorSet.Set(descriptorSets["LightParameters"]!!, setName = "LightParameters")
                         }
 
                         name == "ObjectTextures" -> {
@@ -2634,15 +2662,7 @@ open class VulkanRenderer(hub: Hub,
                 requiredDynamicOffsets += 3
 
                 "Matrices"
-            } else if (name.startsWith("LightParameters")) {
-                logger.debug("Adding dynamic offset for LightParameters")
-                this.uboOffsets.put(0)
-                this.uboOffsets.put(0)
-                requiredDynamicOffsets++
-
-                name
             }
-
             else {
                 name
             }
@@ -2704,9 +2724,7 @@ open class VulkanRenderer(hub: Hub,
         cam.updateWorld(true, false)
 
         buffers["VRParametersBuffer"]!!.reset()
-        val vrUbo = VulkanUBO(device, backingBuffer = buffers["VRParametersBuffer"]!!)
-
-        vrUbo.createUniformBuffer()
+        val vrUbo = UBOs["VRParameters"]!!
         vrUbo.add("projection0", { (hmd?.getEyeProjection(0, cam.nearPlaneDistance, cam.farPlaneDistance)
             ?: cam.projection).applyVulkanCoordinateSystem() } )
         vrUbo.add("projection1", { (hmd?.getEyeProjection(1, cam.nearPlaneDistance, cam.farPlaneDistance)
@@ -2718,10 +2736,7 @@ open class VulkanRenderer(hub: Hub,
         vrUbo.add("headShift", { hmd?.getHeadToEyeTransform(0) ?: GLMatrix.getIdentity() })
         vrUbo.add("IPD", { hmd?.getIPD() ?: 0.05f })
         vrUbo.add("stereoEnabled", { renderConfig.stereoEnabled.toInt() })
-
         vrUbo.populate()
-        vrUbo.close()
-        buffers["VRParametersBuffer"]!!.copyFromStagingBuffer()
 
         buffers["UBOBuffer"]!!.reset()
         buffers["ShaderPropertyBuffer"]!!.reset()
@@ -2738,12 +2753,6 @@ open class VulkanRenderer(hub: Hub,
 
                 node.updateWorld(true, false)
 
-//                if (ubo.offsets.capacity() < 3) {
-//                    memFree(ubo.offsets)
-//                    ubo.offsets = memAllocInt(3)
-//                }
-//
-//                (0..2).forEach { ubo.offsets.put(it, 0) }
                 ubo.offsets.limit(1)
 
                 var bufferOffset = ubo.backingBuffer!!.advance()
@@ -2777,11 +2786,7 @@ open class VulkanRenderer(hub: Hub,
 
         buffers["UBOBuffer"]!!.copyFromStagingBuffer()
 
-        buffers["LightParametersBuffer"]!!.reset()
-
-        // val lights = sceneObjects.await().filter { node -> node is PointLight }
-
-        val lightUbo = VulkanUBO(device, backingBuffer = buffers["LightParametersBuffer"]!!)
+        val lightUbo = UBOs["LightParameters"]!!
         lightUbo.add("ViewMatrix0", { cam.getTransformationForEye(0) })
         lightUbo.add("ViewMatrix1", { cam.getTransformationForEye(1) })
         lightUbo.add("InverseViewMatrix0", { cam.getTransformationForEye(0).inverse })
@@ -2789,28 +2794,8 @@ open class VulkanRenderer(hub: Hub,
         lightUbo.add("ProjectionMatrix", { cam.projection.applyVulkanCoordinateSystem() })
         lightUbo.add("InverseProjectionMatrix", { cam.projection.applyVulkanCoordinateSystem().inverse })
         lightUbo.add("CamPosition", { cam.position })
-        /*lightUbo.add("numLights", { lights.size })
-
-        lights.forEachIndexed { i, light ->
-            val l = light as PointLight
-            l.updateWorld(true, false)
-
-            lightUbo.add("Linear-$i", { l.linear })
-            lightUbo.add("Quadratic-$i", { l.quadratic })
-            lightUbo.add("Intensity-$i", { l.intensity })
-            lightUbo.add("Radius-$i",
-                { ((-l.linear + Math.sqrt(l.linear * l.linear - 4 * l.quadratic * (1.0 - (256.0f / 5.0) * l.intensity)))/(2 * l.quadratic)).toFloat() })
-            lightUbo.add("Position-$i", { l.position })
-            lightUbo.add("Color-$i", { l.emissionColor })
-            lightUbo.add("filler-$i", { 0.0f })
-        }*/
-
-        lightUbo.createUniformBuffer()
         lightUbo.populate()
-        lightUbo.close()
 
-
-        buffers["LightParametersBuffer"]!!.copyFromStagingBuffer()
         buffers["ShaderPropertyBuffer"]!!.copyFromStagingBuffer()
 
         cam.lock.unlock()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -113,7 +113,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
 
         val lightParameters = VU.createDescriptorSetLayout(
             device,
-            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1)),
+            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1)),
             binding = 0, shaderStages = VK_SHADER_STAGE_ALL)
 
         descriptorSetLayouts.put("LightParameters", lightParameters)
@@ -128,7 +128,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
 
         val dslVRParameters = VU.createDescriptorSetLayout(
             device,
-            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1)),
+            listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1)),
             binding = 0, shaderStages = VK_SHADER_STAGE_ALL)
 
         descriptorSetLayouts.put("VRParameters", dslVRParameters)
@@ -373,9 +373,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
 
     private fun initializeDescriptorSetLayoutForSpec(spec: VulkanShaderModule.UBOSpec): Long {
         val contents = when {
-            spec.name == "LightParameters" ||
             spec.name == "Matrices" ||
-            spec.name == "VRParameters" ||
             spec.name == "MaterialProperties" -> listOf(Pair(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1))
 
             spec.name == "ObjectTextures" -> listOf(Pair(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 6),


### PR DESCRIPTION
Changes LightParameters and VRParameters to be regular uniform buffers without dynamic offsets. This lowers the number of dynamic uniform buffers required in the pipeline and causes less issues on some AMD cards.