### PR TITLE
Correct image flipping when rendering to a JavaFX SceneryPanel

### DIFF
--- a/src/main/kotlin/graphics/scenery/utils/SceneryPanel.kt
+++ b/src/main/kotlin/graphics/scenery/utils/SceneryPanel.kt
@@ -47,7 +47,6 @@ class SceneryPanel(var imageWidth: Int, var imageHeight: Int) : Pane() {
 
     init {
         imageView = ImageView(image)
-        imageView.scaleY = -1.0
 
         width = imageWidth.toDouble()
         height = imageHeight.toDouble()
@@ -101,16 +100,23 @@ class SceneryPanel(var imageWidth: Int, var imageHeight: Int) : Pane() {
     override fun impl_createPeer(): NGNode {
         return NGSceneryPanelRegion()
     }
-
+//
     private inner class NGSceneryPanelRegion: NGRegion() {
         override fun renderContent(g: Graphics) {
 
             logger.trace(" w x h : {} {} panel w x h : {} {} buffer sizes {} vs {}", imageWidth, imageHeight, width, height, latestImageSize, this@SceneryPanel.width*this@SceneryPanel.height*4)
             if (latestImageSize == this@SceneryPanel.width.toInt() * this@SceneryPanel.height.toInt() * 4 && imageBuffer != null) {
                 val t = g.resourceFactory.getCachedTexture(image.getWritablePlatformImage(image) as com.sun.prism.Image, Texture.WrapMode.CLAMP_TO_EDGE)
+                t.lock()
 
                 g.clearQuad(0.0f, 0.0f, width.toFloat(), height.toFloat())
-                g.drawTexture(t, 0.0f, 0.0f, width.toFloat(), height.toFloat())
+                if(imageView.scaleY < 0.0f) {
+                    g.drawTexture(t, 0.0f, 0.0f, width.toFloat(), height.toFloat(), 0.0f, height.toFloat(), width.toFloat(), 0.0f)
+                } else {
+                    g.drawTexture(t, 0.0f, 0.0f, width.toFloat(), height.toFloat())
+                }
+                
+                t.unlock()
            }
         }
     }


### PR DESCRIPTION
This PR corrects image flipping when rendering to a JavaFX SceneryPanel. OpenGL Y orientation was wrong before.