### PR TITLE
Headless Vulkan without surfaces

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/FXSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/FXSwapchain.kt
@@ -2,11 +2,8 @@ package graphics.scenery.backends.vulkan
 
 import graphics.scenery.backends.RenderConfigReader
 import graphics.scenery.backends.SceneryWindow
-import org.lwjgl.glfw.GLFW.*
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.vulkan.*
-import java.nio.ByteBuffer
-import java.nio.LongBuffer
 import javafx.stage.Stage
 import java.util.concurrent.CountDownLatch
 import com.sun.javafx.application.PlatformImpl
@@ -22,13 +19,12 @@ import javafx.scene.control.Label
 import javafx.scene.layout.*
 import javafx.scene.paint.Color
 import javafx.scene.text.TextAlignment
-import org.lwjgl.system.MemoryStack.stackPush
-import org.lwjgl.vulkan.VK10.*
 import java.util.concurrent.locks.ReentrantLock
 
 
 /**
- * Extended Vulkan swapchain compatible with JavaFX
+ * Extended Vulkan swapchain compatible with JavaFX, inherits from [HeadlessSwapchain], and
+ * adds JavaFX-specific functionality.
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
@@ -37,52 +33,11 @@ class FXSwapchain(device: VulkanDevice,
                   commandPool: Long,
                   renderConfig: RenderConfigReader.RenderConfig,
                   useSRGB: Boolean = true,
-                  @Suppress("unused") val useFramelock: Boolean = false,
-                  @Suppress("unused") val bufferCount: Int = 2) : VulkanSwapchain(device, queue, commandPool, renderConfig, useSRGB) {
-    lateinit var sharingBuffer: VulkanBuffer
-    lateinit var imageBuffer: ByteBuffer
+                  useFramelock: Boolean = false,
+                  bufferCount: Int = 2) : HeadlessSwapchain(device, queue, commandPool, renderConfig, useSRGB, useFramelock, bufferCount) {
     var lock = ReentrantLock()
 
-    private var glfwOffscreenWindow: Long = -1L
-    lateinit var stage: Stage
-    private var imagePanel: SceneryPanel? = null
-
-    lateinit var vulkanInstance: VkInstance
-    lateinit var vulkanSwapchainRecreator: VulkanRenderer.SwapchainRecreator
-
-    private val WINDOW_RESIZE_TIMEOUT = 400 * 10e6
-
-    inner class ResizeHandler {
-        @Volatile var lastResize = -1L
-        var lastWidth = 0
-        var lastHeight = 0
-
-        @Synchronized fun queryResize() {
-            if (lastWidth <= 0 || lastHeight <= 0) {
-                lastWidth = Math.max(1, lastWidth)
-                lastHeight = Math.max(1, lastHeight)
-                return
-            }
-
-            if (lastResize > 0L && lastResize + WINDOW_RESIZE_TIMEOUT < System.nanoTime()) {
-                lastResize = System.nanoTime()
-                return
-            }
-
-            if (lastWidth == window.width && lastHeight == window.height) {
-                return
-            }
-
-            window.width = lastWidth
-            window.height = lastHeight
-
-            vulkanSwapchainRecreator.mustRecreate = true
-
-            lastResize = -1L
-        }
-    }
-
-    var resizeHandler = ResizeHandler()
+    protected lateinit var stage: Stage
 
     override fun createWindow(win: SceneryWindow, swapchainRecreator: VulkanRenderer.SwapchainRecreator): SceneryWindow {
         vulkanInstance = device.instance
@@ -187,137 +142,8 @@ class FXSwapchain(device: VulkanDevice,
         return window
     }
 
-
-    override fun create(oldSwapchain: Swapchain?): Swapchain {
-        if (glfwOffscreenWindow != -1L) {
-            MemoryUtil.memFree(imageBuffer)
-            sharingBuffer.close()
-        }
-
-        val format = if(useSRGB) {
-            VK_FORMAT_B8G8R8A8_SRGB
-        } else {
-            VK_FORMAT_B8G8R8A8_UNORM
-        }
-        presentQueue = VU.createDeviceQueue(device, device.queueIndices.graphicsQueue)
-
-        val textureImages = (0..3).map {
-            val t = VulkanTexture(device, commandPool, queue, window.width, window.height, 1,
-                format, 1)
-            val image = t.createImage(window.width, window.height, 1, format,
-                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
-                VK_IMAGE_TILING_OPTIMAL, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, 1)
-            t to image
-        }
-
-        images = textureImages.map {
-            it.second.image
-        }.toLongArray()
-
-        imageViews = textureImages.map {
-            it.first.createImageView(it.second, format)
-        }.toLongArray()
-
-        logger.info("Created ${images?.size} swapchain images")
-
-        val imageByteSize = window.width * window.height * 4L
-        imageBuffer = MemoryUtil.memAlloc(imageByteSize.toInt())
-        sharingBuffer = VulkanBuffer(device,
-            imageByteSize,
-            VK10.VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-            VK10.VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT or VK10.VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-            wantAligned = true)
-
-        imagePanel?.prefWidth = window.width.toDouble()
-        imagePanel?.prefHeight = window.height.toDouble()
-
-        resizeHandler.lastWidth = window.width
-        resizeHandler.lastHeight = window.height
-
-        return this
-    }
-
-    var currentImage = 0
-    override fun next(timeout: Long, signalSemaphore: Long): Boolean {
-        stackPush().use { stack ->
-            vkQueueWaitIdle(presentQueue)
-
-            val signal = stack.callocLong(1)
-            signal.put(0, signalSemaphore)
-
-            with(VU.newCommandBuffer(device, commandPool, autostart = true)) {
-                this.endCommandBuffer(device, commandPool, presentQueue, signalSemaphores = signal,
-                    flush = true, dealloc = true)
-            }
-
-            currentImage = currentImage++ % (images?.size ?: 1)
-        }
-
-        return false
-    }
-
-    override fun present(waitForSemaphores: LongBuffer?) {
-        stackPush().use { stack ->
-            if (vulkanSwapchainRecreator.mustRecreate) {
-                return
-            }
-
-            val mask = stack.callocInt(1)
-            mask.put(0, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
-
-            with(VU.newCommandBuffer(device, commandPool, autostart = true)) {
-                this.endCommandBuffer(device, commandPool, presentQueue,
-                    waitSemaphores = waitForSemaphores, waitDstStageMask = mask,
-                    flush = true, dealloc = true)
-            }
-        }
-    }
-
     override fun postPresent(image: Int) {
-        if (vulkanSwapchainRecreator.mustRecreate && sharingBuffer.initialized()) {
-            return
-        }
-
-        with(VU.newCommandBuffer(device, commandPool, autostart = true)) {
-            val subresource = VkImageSubresourceLayers.calloc()
-                .aspectMask(VK10.VK_IMAGE_ASPECT_COLOR_BIT)
-                .mipLevel(0)
-                .baseArrayLayer(0)
-                .layerCount(1)
-
-            val regions = VkBufferImageCopy.calloc(1)
-                .bufferRowLength(0)
-                .bufferImageHeight(0)
-                .imageOffset(VkOffset3D.calloc().set(0, 0, 0))
-                .imageExtent(VkExtent3D.calloc().set(window.width, window.height, 1))
-                .imageSubresource(subresource)
-
-            val transferImage = images!![image]
-
-            VulkanTexture.transitionLayout(transferImage,
-                KHRSwapchain.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-                VK10.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                srcStage = VK10.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                dstStage = VK10.VK_PIPELINE_STAGE_TRANSFER_BIT,
-                commandBuffer = this)
-
-            VK10.vkCmdCopyImageToBuffer(this, transferImage,
-                VK10.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                sharingBuffer.vulkanBuffer,
-                regions)
-
-            VulkanTexture.transitionLayout(transferImage,
-                VK10.VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                KHRSwapchain.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-                srcStage = VK10.VK_PIPELINE_STAGE_TRANSFER_BIT,
-                dstStage = VK10.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                commandBuffer = this)
-
-            this.endCommandBuffer(device, commandPool, queue,
-                flush = true, dealloc = true)
-        }
-
-        VK10.vkQueueWaitIdle(queue)
+        super.postPresent(image)
 
         Platform.runLater {
             if (lock.tryLock() && !vulkanSwapchainRecreator.mustRecreate && sharingBuffer.initialized()) {
@@ -359,6 +185,5 @@ class FXSwapchain(device: VulkanDevice,
 
         sharingBuffer.close()
 
-        glfwDestroyWindow(glfwOffscreenWindow)
     }
 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/HeadlessSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/HeadlessSwapchain.kt
@@ -144,7 +144,7 @@ open class HeadlessSwapchain(device: VulkanDevice,
                     flush = true, dealloc = true)
             }
 
-            currentImage = currentImage++ % (images?.size ?: 1)
+            currentImage = ++currentImage % (images?.size ?: 1)
         }
 
         return false

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/OpenGLSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/OpenGLSwapchain.kt
@@ -304,8 +304,8 @@ class OpenGLSwapchain(val device: VulkanDevice,
     override fun postPresent(image: Int) {
     }
 
-    override fun next(timeout: Long, waitForSemaphore: Long): Boolean {
-        NVDrawVulkanImage.glSignalVkSemaphoreNV(waitForSemaphore)
+    override fun next(timeout: Long, signalSemaphore: Long): Boolean {
+        NVDrawVulkanImage.glSignalVkSemaphoreNV(signalSemaphore)
         return false
     }
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/Swapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/Swapchain.kt
@@ -21,7 +21,7 @@ interface Swapchain : AutoCloseable {
     fun create(oldSwapchain: Swapchain?): Swapchain
     fun present(waitForSemaphores: LongBuffer? = null)
     fun postPresent(image: Int)
-    fun next(timeout: Long = -1L, waitForSemaphore: Long = 0L): Boolean
+    fun next(timeout: Long = -1L, signalSemaphore: Long = 0L): Boolean
     override fun close()
     fun toggleFullscreen(hub: Hub, swapchainRecreator: VulkanRenderer.SwapchainRecreator)
     fun embedIn(panel: SceneryPanel?)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
@@ -22,27 +22,40 @@ import java.nio.IntBuffer
 import java.nio.LongBuffer
 
 /**
- * VU - Vulkan Utils
+ * Returns a given Long as hex-formatted string.
  *
- * A collection of convenience methods for various Vulkan-related tasks
- *
- * @author Ulrik Guenther <hello@ulrik.is>
+ * @returns The long value as hex string.
  */
-
 fun Long.toHexString(): String {
     return String.format("0x%X", this)
 }
 
+/**
+ * Returns a given BigInteger as hex-formatted string.
+ *
+ * @returns The BigInteger value as hex string.
+ */
 fun BigInteger.toHexString(): String {
     return "0x${this.toString(16)}"
 }
 
+/**
+ * Ends the recording of a command buffer.
+ */
 fun VkCommandBuffer.endCommandBuffer() {
     if(vkEndCommandBuffer(this) != VK_SUCCESS) {
         throw AssertionError("Failed to end command buffer $this")
     }
 }
 
+/**
+ * Ends the recording of a command buffer on the given [device] using [commandPool] on the queue [queue].
+ * If [flush] is set, ending the command buffer will trigger submission. If [dealloc] is set, the command buffer
+ * will be deallocated after running it.
+ *
+ * [submitInfoPNext], [signalSemaphores], [waitSemaphores] and [waitDstStageMask] can be used to further fine-grain
+ * the submission process.
+ */
 fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long,
                                      queue: VkQueue?, flush: Boolean = true,
                                      dealloc: Boolean = false,
@@ -66,6 +79,12 @@ fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long,
     }
 }
 
+/**
+ * Submits the given command buffer to the queue [queue].
+ *
+ * [submitInfoPNext], [signalSemaphores], [waitSemaphores] and [waitDstStageMask] can be used to further fine-grain
+ * the submission process.
+ */
 fun VkCommandBuffer.submit(queue: VkQueue, submitInfoPNext: Pointer? = null,
                            signalSemaphores: LongBuffer? = null, waitSemaphores: LongBuffer? = null,
                            waitDstStageMask: IntBuffer? = null,
@@ -94,6 +113,9 @@ fun VkCommandBuffer.submit(queue: VkQueue, submitInfoPNext: Pointer? = null,
     }
 }
 
+/**
+ * Converts a [Blending.BlendFactor] to a Vulkan-internal integer-based descriptor.
+ */
 fun Blending.BlendFactor.toVulkan() = when (this) {
     Blending.BlendFactor.Zero -> VK_BLEND_FACTOR_ZERO
     Blending.BlendFactor.One -> VK_BLEND_FACTOR_ONE
@@ -125,6 +147,9 @@ fun Blending.BlendFactor.toVulkan() = when (this) {
     Blending.BlendFactor.SrcAlphaSaturate -> VK_BLEND_FACTOR_SRC_ALPHA_SATURATE
 }
 
+/**
+ * Converts a [Blending.BlendOp] to a Vulkan-intenal integer-based descriptor.
+ */
 fun Blending.BlendOp.toVulkan() = when (this) {
     Blending.BlendOp.add -> VK_BLEND_OP_ADD
     Blending.BlendOp.subtract -> VK_BLEND_OP_SUBTRACT
@@ -133,11 +158,25 @@ fun Blending.BlendOp.toVulkan() = when (this) {
     Blending.BlendOp.reverse_subtract -> VK_BLEND_OP_REVERSE_SUBTRACT
 }
 
+/**
+ * VU - Vulkan Utils
+ *
+ * A collection of convenience methods for various Vulkan-related tasks
+ *
+ * @author Ulrik Guenther <hello@ulrik.is>
+ */
 class VU {
 
+    /**
+     * Companion object for [VU] to access methods statically.
+     */
     companion object VU {
         private val logger by LazyLogger()
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. Allowed error codes
+         * can be set in [allowedResults], for debugging, the call may be given a [name].
+         */
         inline fun run(name: String, function: () -> Int, allowedResults: List<Int> = emptyList()) {
             val result = function.invoke()
 
@@ -154,6 +193,10 @@ class VU {
             }
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. After the call, [cleanup] is run.
+         * For debugging, the call may be given a [name].
+         */
         inline fun run(name: String, function: () -> Int, cleanup: () -> Any) {
             val result = function.invoke()
 
@@ -168,6 +211,11 @@ class VU {
             cleanup.invoke()
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * an int, which is in turn returned by this function.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getInt(name: String, function: IntBuffer.() -> Int): Int {
             return stackPush().use { stack ->
                 val receiver = stack.callocInt(2)
@@ -187,6 +235,11 @@ class VU {
             }
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * an [IntBuffer], containing [count] elements, which is in turn returned by this function.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getInts(name: String, count: Int, function: IntBuffer.() -> Int): IntBuffer {
             val receiver = memAllocInt(count)
             val result = function.invoke(receiver)
@@ -202,6 +255,11 @@ class VU {
             return receiver
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * a long, which is in turn returned by this function. After the function has been run, [cleanup] is called.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getLong(name: String, function: LongBuffer.() -> Int, cleanup: LongBuffer.() -> Any): Long {
             return stackPush().use { stack ->
                 val receiver = stack.callocLong(1)
@@ -223,6 +281,12 @@ class VU {
             }
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * an [LongBuffer], containing [count] elements, which is in turn returned by this function. After running the
+         * function, [cleanup] is called.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getLongs(name: String, count: Int, function: LongBuffer.() -> Int, cleanup: LongBuffer.() -> Any): LongBuffer {
                 val receiver = memAllocLong(count)
                 val result = function.invoke(receiver)
@@ -240,6 +304,11 @@ class VU {
             return receiver
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * a pointer, which is in turn returned by this function as a long. After running the function, [cleanup] is called.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getPointer(name: String, function: PointerBuffer.() -> Int, cleanup: PointerBuffer.() -> Any): Long {
             return stackPush().use { stack ->
                 val receiver = stack.callocPointer(1)
@@ -259,6 +328,11 @@ class VU {
             }
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * a [PointerBuffer], containing [count] elements, which is in turn returned by this function.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getPointers(name: String, count: Int, function: PointerBuffer.() -> Int): PointerBuffer {
             val receiver = memAllocPointer(count)
             val result = function.invoke(receiver)
@@ -274,6 +348,12 @@ class VU {
             return receiver
         }
 
+        /**
+         * Runs a lambda [function] containing a Vulkan call, and checks it for errors. The Vulkan call will return
+         * a [PointerBuffer], containing [count] elements, which is in turn returned by this function. After running
+         * the function, [cleanup] is run.
+         * For debugging, the call may be given a [name].
+         */
         inline fun getPointers(name: String, count: Int, function: PointerBuffer.() -> Int, cleanup: PointerBuffer.() -> Any): PointerBuffer {
             val receiver = memAllocPointer(count)
             val result = function.invoke(receiver)
@@ -293,10 +373,7 @@ class VU {
         }
 
         /**
-         * Translates a Vulkan `VkResult` value to a String describing the result.
-
-         * @param result the `VkResult` value
-         * @return the result description
+         * Translates a Vulkan `VkResult` value given as [result] to a String describing the result.
          */
         fun translate(result: Int): String {
             when (result) {
@@ -331,6 +408,10 @@ class VU {
             }
         }
 
+        /**
+         * Transforms a Vulkan [image] from the old image layout [oldImageLayout] to the new [newImageLayout], taking into account the
+         * [VkImageSubresourceRange] given in [range]. This function can only be run within a [commandBuffer].
+         */
         fun setImageLayout(commandBuffer: VkCommandBuffer, image: Long, oldImageLayout: Int, newImageLayout: Int, range: VkImageSubresourceRange) {
             stackPush().use { stack ->
                 val imageMemoryBarrier = VkImageMemoryBarrier.callocStack(1, stack)
@@ -391,6 +472,11 @@ class VU {
             }
         }
 
+        /**
+         * Transforms a Vulkan [image] from the old image layout [oldImageLayout] to the new [newImageLayout], the
+         * [VkImageSubresourceRange] is constructed based on the image size, and only uses the base MIP level and array layer.
+         * This function can only be run within a [commandBuffer].
+         */
         fun setImageLayout(commandBuffer: VkCommandBuffer, image: Long, aspectMask: Int, oldImageLayout: Int, newImageLayout: Int) {
             stackPush().use { stack ->
                 val range = VkImageSubresourceRange.callocStack(stack)
@@ -403,6 +489,9 @@ class VU {
             }
         }
 
+        /**
+         * Creates a new Vulkan queue on [device] with the queue family index [queueFamilyIndex] and returns the queue.
+         */
         fun createDeviceQueue(device: VulkanDevice, queueFamilyIndex: Int): VkQueue {
             val queue = getPointer("Getting device queue for queueFamilyIndex=$queueFamilyIndex",
                 { vkGetDeviceQueue(device.vulkanDevice, queueFamilyIndex, 0, this); VK_SUCCESS }, {})
@@ -410,6 +499,10 @@ class VU {
             return VkQueue(queue, device.vulkanDevice)
         }
 
+        /**
+         * Creates and returns a new command buffer on [device], associated with [commandPool]. By default, it'll be a primary
+         * command buffer, that can be changed by setting [level] to [VK_COMMAND_BUFFER_LEVEL_SECONDARY].
+         */
         fun newCommandBuffer(device: VulkanDevice, commandPool: Long, level: Int = VK_COMMAND_BUFFER_LEVEL_PRIMARY): VkCommandBuffer {
             return stackPush().use { stack ->
                 val cmdBufAllocateInfo = VkCommandBufferAllocateInfo.callocStack(stack)
@@ -425,6 +518,11 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a new command buffer on [device], associated with [commandPool]. By default, it'll be a primary
+         * command buffer, that can be changed by setting [level] to [VK_COMMAND_BUFFER_LEVEL_SECONDARY]. If recording should
+         * be started automatically, set [autostart] to true.
+         */
         fun newCommandBuffer(device: VulkanDevice, commandPool: Long, level: Int = VK_COMMAND_BUFFER_LEVEL_PRIMARY, autostart: Boolean = false): VkCommandBuffer {
             val cmdBuf = newCommandBuffer(device, commandPool, level)
 
@@ -435,6 +533,10 @@ class VU {
             return cmdBuf
         }
 
+        /**
+         * Starts recording of [commandBuffer]. Usually called from [newCommandBuffer]. Additional [flags] may be set,
+         * e.g. for creating resettable or simultaneous use buffer.
+         */
         fun beginCommandBuffer(commandBuffer: VkCommandBuffer, flags: Int = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) {
             stackPush().use { stack ->
                 val cmdBufInfo = VkCommandBufferBeginInfo.callocStack(stack)
@@ -446,6 +548,11 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a new descriptor set layout on [device] with one member of [type], which is by default a
+         * dynamic uniform buffer. The [binding] and number of descriptors ([descriptorNum], [descriptorCount]) can be
+         * customized,  as well as the shader stages to which the DSL should be visible ([shaderStages]).
+         */
         fun createDescriptorSetLayout(device: VulkanDevice, type: Int = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, binding: Int = 0, descriptorNum: Int = 1, descriptorCount: Int = 1, shaderStages: Int = VK_SHADER_STAGE_ALL): Long {
             return stackPush().use { stack ->
                 val layoutBinding = VkDescriptorSetLayoutBinding.callocStack(descriptorNum, stack)
@@ -472,6 +579,11 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a new descriptor set layout on [device] with the members declared in [types], which is
+         * a [List] of a Pair of a type, associated with a count (e.g. Dynamic UBO to 1). The base binding can be set with [binding].
+         * The shader stages to which the DSL should be visible can be set via [shaderStages].
+         */
         fun createDescriptorSetLayout(device: VulkanDevice, types: List<Pair<Int, Int>>, binding: Int = 0, shaderStages: Int): Long {
             return stackPush().use { stack ->
                 val layoutBinding = VkDescriptorSetLayoutBinding.callocStack(types.size, stack)
@@ -499,6 +611,11 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a dynamic descriptor set allocated on [device] from the pool [descriptorPool], conforming
+         * to the existing descriptor set layout [descriptorSetLayout]. The number of bindings ([bindingCount]) and the
+         * associated [buffer] have to be given.
+         */
         fun createDescriptorSetDynamic(device: VulkanDevice, descriptorPool: Long, descriptorSetLayout: Long,
                                        bindingCount: Int, buffer: VulkanBuffer): Long {
             logger.debug("Creating dynamic descriptor set with $bindingCount bindings, DSL=${descriptorSetLayout.toHexString()}")
@@ -539,6 +656,11 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a new descriptor set, allocated on [device] from [descriptorPool], conforming to existing
+         * [descriptorSetLayout], a [bindingCount] needs to be given as well an an [ubo] to back the descriptor set.
+         * The default [type] is [VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER].
+         */
         fun createDescriptorSet(device: VulkanDevice, descriptorPool: Long, descriptorSetLayout: Long, bindingCount: Int,
                                 ubo: VulkanUBO.UBODescriptor, type: Int = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER): Long {
             logger.debug("Creating descriptor set with ${bindingCount} bindings, DSL=$descriptorSetLayout")
@@ -578,6 +700,12 @@ class VU {
             }
         }
 
+        /**
+         * Creates and returns a new descriptor set for a framebuffer given as [target]. The set will be allocated on [device],
+         * from [descriptorPool], and conforms to an existing descriptor set layout [descriptorSetLayout]. Additional
+         * metadata about the framebuffer needs to be given via [rt], and a subset of the framebuffer can be selected
+         * by setting [onlyFor] to the respective name of the attachment.
+         */
         fun createRenderTargetDescriptorSet(device: VulkanDevice, descriptorPool: Long, descriptorSetLayout: Long,
                                              rt: Map<String, RenderConfigReader.TargetFormat>,
                                              target: VulkanFramebuffer, onlyFor: String? = null): Long {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
@@ -43,7 +43,12 @@ fun VkCommandBuffer.endCommandBuffer() {
     }
 }
 
-fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long, queue: VkQueue?, flush: Boolean = true, dealloc: Boolean = false, submitInfoPNext: Pointer? = null, signalSemaphores: LongBuffer? = null, waitSemaphores: LongBuffer? = null) {
+fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long,
+                                     queue: VkQueue?, flush: Boolean = true,
+                                     dealloc: Boolean = false,
+                                     submitInfoPNext: Pointer? = null,
+                                     signalSemaphores: LongBuffer? = null, waitSemaphores: LongBuffer? = null,
+                                     waitDstStageMask: IntBuffer? = null) {
     if (this.address() == NULL) {
         return
     }
@@ -53,7 +58,7 @@ fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long, qu
     }
 
     if (flush && queue != null) {
-        this.submit(queue, submitInfoPNext, waitSemaphores = waitSemaphores, signalSemaphores = signalSemaphores)
+        this.submit(queue, submitInfoPNext, waitSemaphores = waitSemaphores, signalSemaphores = signalSemaphores, waitDstStageMask = waitDstStageMask)
     }
 
     if (dealloc) {
@@ -61,7 +66,10 @@ fun VkCommandBuffer.endCommandBuffer(device: VulkanDevice, commandPool: Long, qu
     }
 }
 
-fun VkCommandBuffer.submit(queue: VkQueue, submitInfoPNext: Pointer? = null, signalSemaphores: LongBuffer? = null, waitSemaphores: LongBuffer? = null, block: Boolean = true) {
+fun VkCommandBuffer.submit(queue: VkQueue, submitInfoPNext: Pointer? = null,
+                           signalSemaphores: LongBuffer? = null, waitSemaphores: LongBuffer? = null,
+                           waitDstStageMask: IntBuffer? = null,
+                           block: Boolean = true) {
     stackPush().use { stack ->
         val submitInfo = VkSubmitInfo.callocStack(1, stack)
         val commandBuffers = stack.callocPointer(1).put(0, this)
@@ -73,11 +81,11 @@ fun VkCommandBuffer.submit(queue: VkQueue, submitInfoPNext: Pointer? = null, sig
                 .pSignalSemaphores(signalSemaphores)
                 .pNext(submitInfoPNext?.address() ?: NULL)
 
-            if(waitSemaphores?.remaining() ?: 0 > 0) {
-                println("Will wait on ${waitSemaphores?.remaining()} semaphores")
+            if(waitSemaphores?.remaining() ?: 0 > 0 && waitSemaphores != null && waitDstStageMask != null) {
                 submitInfo
-                    .waitSemaphoreCount(waitSemaphores?.remaining() ?: 0)
+                    .waitSemaphoreCount(waitSemaphores.remaining())
                     .pWaitSemaphores(waitSemaphores)
+                    .pWaitDstStageMask(waitDstStageMask)
             }
 
             vkQueueSubmit(queue, submitInfo, VK_NULL_HANDLE)
@@ -137,7 +145,7 @@ class VU {
                 LoggerFactory.getLogger("VulkanRenderer").error("Call to $name failed: ${translate(result)}")
 
                 if(result < 0) {
-                    throw RuntimeException("Call to $name failed: ${translate(result)}")
+                   throw RuntimeException("Call to $name failed: ${translate(result)}")
                 }
             }
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1526,8 +1526,7 @@ open class VulkanRenderer(hub: Hub,
 
     private fun beginFrame() {
         swapchainRecreator.mustRecreate = swapchain!!.next(timeout = UINT64_MAX,
-            waitForSemaphore = semaphores[StandardSemaphores.PresentComplete]!![0])
-        logger.info("Beginning frame with ${semaphores[StandardSemaphores.PresentComplete]!![0].toHexString()}")
+            signalSemaphore = semaphores[StandardSemaphores.PresentComplete]!![0])
     }
 
     fun recordMovie() {
@@ -1798,7 +1797,6 @@ open class VulkanRenderer(hub: Hub,
                 .pWaitSemaphores(target.waitSemaphores)
 
             VU.run("Submit pass $t render queue", { vkQueueSubmit(queue, si, commandBuffer.getFence() )})
-            logger.info("Pass $t will wait on ${target.waitSemaphores.get(0).toHexString()} and signal ${target.signalSemaphores.get(0).toHexString()}")
 
             commandBuffer.submitted = true
             firstWaitSemaphore.put(0, target.semaphore)
@@ -1839,8 +1837,6 @@ open class VulkanRenderer(hub: Hub,
         ph.waitStages.put(0, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
         ph.signalSemaphore.put(0, semaphores[StandardSemaphores.RenderComplete]!![0])
         ph.waitSemaphore.put(0, firstWaitSemaphore.get(0))
-
-        logger.info("Frame will wait on ${firstWaitSemaphore.get(0).toHexString()} and signal ${semaphores[StandardSemaphores.RenderComplete]!![0].toHexString()}")
 
         submitFrame(queue, viewportPass, viewportCommandBuffer, ph)
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1527,6 +1527,7 @@ open class VulkanRenderer(hub: Hub,
     private fun beginFrame() {
         swapchainRecreator.mustRecreate = swapchain!!.next(timeout = UINT64_MAX,
             waitForSemaphore = semaphores[StandardSemaphores.PresentComplete]!![0])
+        logger.info("Beginning frame with ${semaphores[StandardSemaphores.PresentComplete]!![0].toHexString()}")
     }
 
     fun recordMovie() {
@@ -1797,6 +1798,7 @@ open class VulkanRenderer(hub: Hub,
                 .pWaitSemaphores(target.waitSemaphores)
 
             VU.run("Submit pass $t render queue", { vkQueueSubmit(queue, si, commandBuffer.getFence() )})
+            logger.info("Pass $t will wait on ${target.waitSemaphores.get(0).toHexString()} and signal ${target.signalSemaphores.get(0).toHexString()}")
 
             commandBuffer.submitted = true
             firstWaitSemaphore.put(0, target.semaphore)
@@ -1837,6 +1839,8 @@ open class VulkanRenderer(hub: Hub,
         ph.waitStages.put(0, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
         ph.signalSemaphore.put(0, semaphores[StandardSemaphores.RenderComplete]!![0])
         ph.waitSemaphore.put(0, firstWaitSemaphore.get(0))
+
+        logger.info("Frame will wait on ${firstWaitSemaphore.get(0).toHexString()} and signal ${semaphores[StandardSemaphores.RenderComplete]!![0].toHexString()}")
 
         submitFrame(queue, viewportPass, viewportCommandBuffer, ph)
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -361,13 +361,13 @@ open class VulkanSwapchain(open val device: VulkanDevice,
         }
     }
 
-    override fun next(timeout: Long, waitForSemaphore: Long): Boolean {
+    override fun next(timeout: Long, signalSemaphore: Long): Boolean {
         // wait for the present queue to become idle - by doing this here
         // we avoid stalling the GPU and gain a few FPS
         VK10.vkQueueWaitIdle(presentQueue)
 
         val err = vkAcquireNextImageKHR(device.vulkanDevice, handle, timeout,
-            waitForSemaphore,
+            signalSemaphore,
             VK10.VK_NULL_HANDLE, swapchainImage)
 
         if (err == KHRSwapchain.VK_ERROR_OUT_OF_DATE_KHR || err == KHRSwapchain.VK_SUBOPTIMAL_KHR) {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -239,7 +239,7 @@ open class VulkanSwapchain(open val device: VulkanDevice,
         }
     }
 
-    private fun getColorFormatAndSpace(): ColorFormatAndSpace {
+    protected fun getColorFormatAndSpace(): ColorFormatAndSpace {
         return stackPush().use { stack ->
             val queueFamilyPropertyCount = stack.callocInt(1)
             VK10.vkGetPhysicalDeviceQueueFamilyProperties(device.physicalDevice, queueFamilyPropertyCount, null)

--- a/src/test/tests/graphics/scenery/tests/examples/stresstests/RunAllExamples.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/stresstests/RunAllExamples.kt
@@ -38,7 +38,8 @@ class RunAllExamples {
             "EyeTrackingExample",
             "ARExample",
             "SponzaExample",
-            "ReadModelExample")
+            "ReadModelExample",
+            "ProceduralVolumeExample")
 
         // find all basic and advanced examples, exclude blacklist
         val examples = reflections
@@ -100,9 +101,6 @@ class RunAllExamples {
                     logger.info("JOGL threw ThreadDeath")
                 }
 
-                if(renderer == "VulkanRenderer") {
-                    glfwTerminate()
-                }
                 logger.info("${example.simpleName} closed ($renderer ran ${i+1}/${examples.size} so far).")
 
                 Thread.sleep(5000)


### PR DESCRIPTION
This PR removes all window surfaces from HeadlessSwapchain and FXSwapchain, potentially resulting in less issues when running in conjunction with JavaFX. FXSwapchain now inherits from HeadlessSwapchain, making their hierarchy more clear.

The changes also decrease the bandwidth usage of JavaFX windows substantially.