### PR TITLE
OpenGL dynamic buffer resizing, high CPU use fix & push mode fixes

### DIFF
--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -62,7 +62,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     protected val logger by LazyLogger()
 
     /** An optional update function to call during the main loop. */
-    var updateFunction: () -> Any = {}
+    var updateFunction: (() -> Any)? = null
 
     /** Flag to indicate whether this instance is currently running. */
     var running: Boolean = false
@@ -205,7 +205,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
             }
 
             if (renderer?.managesRenderLoop != false) {
-                Thread.sleep(2)
+                Thread.sleep(5)
             } else {
                 stats.addTimed("render", { renderer?.render() ?: 0.0f })
             }
@@ -231,7 +231,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
                     t += timeStep
                     accumulator -= timeStep
 
-                    stats.addTimed("Scene.Update", updateFunction)
+                    updateFunction?.let { update -> stats.addTimed("Scene.Update", update) }
                 }
 
                 val alpha = accumulator/timeStep

--- a/src/main/kotlin/graphics/scenery/backends/UBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/UBO.kt
@@ -32,7 +32,9 @@ open class UBO {
     /** Optional flag to indicate finished initialisation */
     var initialized: Boolean = false
 
-    protected var sizeCached = -1
+    /** Cached size of the UBO, -1 if the UBO has not been populated yet. */
+    var sizeCached = -1
+        protected set
 
     companion object {
         /** Cache for alignment data inside buffers */

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -236,7 +236,8 @@ open class OpenGLRenderer(hub: Hub,
          */
         fun resize(newSize: Int = (buffer.capacity() * 1.5f).roundToInt()): ByteBuffer {
             logger.debug("Resizing backing buffer of $this from ${buffer.capacity()} to $newSize")
-            MemoryUtil.memRealloc(buffer, newSize)
+
+            buffer = MemoryUtil.memRealloc(buffer, newSize) ?: throw RuntimeException("Could not resize buffer")
             size = buffer.capacity()
 
             return buffer

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -237,8 +237,14 @@ open class OpenGLRenderer(hub: Hub,
         fun resize(newSize: Int = (buffer.capacity() * 1.5f).roundToInt()): ByteBuffer {
             logger.debug("Resizing backing buffer of $this from ${buffer.capacity()} to $newSize")
 
+            // resize main memory-backed buffer
             buffer = MemoryUtil.memRealloc(buffer, newSize) ?: throw RuntimeException("Could not resize buffer")
             size = buffer.capacity()
+
+            // resize OpenGL buffer as well
+            gl.glBindBuffer(GL4.GL_UNIFORM_BUFFER, id[0])
+            gl.glBufferData(GL4.GL_UNIFORM_BUFFER, size * 1L, null, GL4.GL_DYNAMIC_DRAW)
+            gl.glBindBuffer(GL4.GL_UNIFORM_BUFFER, 0)
 
             return buffer
         }

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -334,8 +334,8 @@ open class OpenGLRenderer(hub: Hub,
 
                     addGLEventListener(this@OpenGLRenderer)
 
-                    animator = FPSAnimator(this, 600)
-                    animator.setUpdateFPSFrames(600, null)
+                    animator = FPSAnimator(this, 60)
+                    animator.setUpdateFPSFrames(60, null)
                     animator.start()
 
                     embedIn?.let { panel ->
@@ -1356,7 +1356,7 @@ open class OpenGLRenderer(hub: Hub,
         stats?.add("OpenGLRenderer.updateUBOs", System.nanoTime() - startUboUpdate)
 
         val actualSceneObjects = sceneObjects.await().toTypedArray()
-        val sceneUpdated = actualSceneObjects.contentDeepEquals(previousSceneObjects)
+        val sceneUpdated = !actualSceneObjects.contentDeepEquals(previousSceneObjects)
 
         previousSceneObjects = actualSceneObjects
 

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -241,7 +241,7 @@ open class OpenGLRenderer(hub: Hub,
             logger.debug("Resizing backing buffer of $this from ${buffer.capacity()} to $newSize")
 
             // resize main memory-backed buffer
-            buffer = MemoryUtil.memRealloc(buffer, newSize) ?: throw RuntimeException("Could not resize buffer")
+            buffer = MemoryUtil.memRealloc(buffer, newSize) ?: throw IllegalStateException("Could not resize buffer")
             size = buffer.capacity()
 
             // resize OpenGL buffer as well

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLUBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLUBO.kt
@@ -24,8 +24,14 @@ class OpenGLUBO(val backingBuffer: OpenGLRenderer.OpenGLBuffer? = null) : UBO() 
     @Suppress("UNUSED_PARAMETER")
     fun populate(offset: Long = 0): Boolean {
         backingBuffer?.let { data ->
+            val sizeRequired = if(sizeCached <= 0) {
+                data.alignment
+            } else {
+                sizeCached + data.alignment
+            }
+
             // check if we can fit this UBO, if not, resize it to 1.5x it's original size
-            if(sizeCached > -1 && data.remaining() < (sizeCached + data.alignment)) {
+            if(data.remaining() < sizeRequired) {
                 data.resize()
             }
 

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLUBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLUBO.kt
@@ -24,6 +24,11 @@ class OpenGLUBO(val backingBuffer: OpenGLRenderer.OpenGLBuffer? = null) : UBO() 
     @Suppress("UNUSED_PARAMETER")
     fun populate(offset: Long = 0): Boolean {
         backingBuffer?.let { data ->
+            // check if we can fit this UBO, if not, resize it to 1.5x it's original size
+            if(sizeCached > -1 && data.remaining() < (sizeCached + data.alignment)) {
+                data.resize()
+            }
+
             return super.populate(data.buffer, -1L, elements = null)
         }
 


### PR DESCRIPTION
This PR introduces dynamic resizing of OpenGL buffers, should they exceed their current size.

It also fixes a performance issue when running JavaFX (see scenerygraphics/SciView#99), and fixes a problem with push mode in OpenGL, where the scene would be marked update while it is not.