### PR TITLE
VulkanRenderer: nullability refactor

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/HeadlessSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/HeadlessSwapchain.kt
@@ -133,7 +133,7 @@ open class HeadlessSwapchain(device: VulkanDevice,
             it.first.createImageView(it.second, format)
         }.toLongArray()
 
-        logger.info("Created ${images?.size} swapchain images")
+        logger.info("Created ${images.size} swapchain images")
 
         val imageByteSize = window.width * window.height * 4L
         imageBuffer = MemoryUtil.memAlloc(imageByteSize.toInt())
@@ -171,7 +171,7 @@ open class HeadlessSwapchain(device: VulkanDevice,
                     flush = true, dealloc = true)
             }
 
-            currentImage = ++currentImage % (images?.size ?: 1)
+            currentImage = ++currentImage % images.size
         }
 
         return false
@@ -221,7 +221,7 @@ open class HeadlessSwapchain(device: VulkanDevice,
                 .imageExtent(VkExtent3D.calloc().set(window.width, window.height, 1))
                 .imageSubresource(subresource)
 
-            val transferImage = images!![image]
+            val transferImage = images[image]
 
             VulkanTexture.transitionLayout(transferImage,
                 KHRSwapchain.VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/OpenGLSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/OpenGLSwapchain.kt
@@ -49,9 +49,9 @@ class OpenGLSwapchain(val device: VulkanDevice,
     /** Swapchain handle. */
     override var handle: Long = 0L
     /** Array for rendered images. */
-    override var images: LongArray? = null
+    override var images: LongArray = LongArray(0)
     /** Array for image views. */
-    override var imageViews: LongArray? = null
+    override var imageViews: LongArray = LongArray(0)
     /** Number of frames presented with this swapchain. */
     protected var presentedFrames = 0L
 
@@ -306,29 +306,27 @@ class OpenGLSwapchain(val device: VulkanDevice,
 
         // note: glDrawVkImageNV expects the OpenGL screen space conventions,
         // so the Vulkan image's ST coordinates have to be flipped
-        images?.let { images ->
-            if (renderConfig.stereoEnabled) {
-                glDrawBuffer(GL_BACK_LEFT)
-                glClear(GL_COLOR_BUFFER_BIT)
-                glDisable(GL_DEPTH_TEST)
+        if (renderConfig.stereoEnabled) {
+            glDrawBuffer(GL_BACK_LEFT)
+            glClear(GL_COLOR_BUFFER_BIT)
+            glDisable(GL_DEPTH_TEST)
 
-                NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
-                    0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
-                    0.0f, 1.0f, 0.5f, 0.0f)
+            NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
+                0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
+                0.0f, 1.0f, 0.5f, 0.0f)
 
-                glDrawBuffer(GL_BACK_RIGHT)
-                glClear(GL_COLOR_BUFFER_BIT)
-                glDisable(GL_DEPTH_TEST)
+            glDrawBuffer(GL_BACK_RIGHT)
+            glClear(GL_COLOR_BUFFER_BIT)
+            glDisable(GL_DEPTH_TEST)
 
-                NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
-                    0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
-                    0.5f, 1.0f, 1.0f, 0.0f)
-            } else {
-                glClear(GL_COLOR_BUFFER_BIT)
-                NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
-                    0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
-                    0.0f, 1.0f, 1.0f, 0.0f)
-            }
+            NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
+                0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
+                0.5f, 1.0f, 1.0f, 0.0f)
+        } else {
+            glClear(GL_COLOR_BUFFER_BIT)
+            NVDrawVulkanImage.glDrawVkImageNV(images[0], 0,
+                0.0f, 0.0f, window.width.toFloat(), window.height.toFloat(), 0.0f,
+                0.0f, 1.0f, 1.0f, 0.0f)
         }
 
         glfwSwapBuffers(window.window)
@@ -414,8 +412,8 @@ class OpenGLSwapchain(val device: VulkanDevice,
      * Closes the swapchain, freeing all of its resources.
      */
     override fun close() {
-        imageViews?.forEach { vkDestroyImageView(device.vulkanDevice, it, null) }
-        images?.forEach { vkDestroyImage(device.vulkanDevice, it, null) }
+        imageViews.forEach { vkDestroyImageView(device.vulkanDevice, it, null) }
+        images.forEach { vkDestroyImage(device.vulkanDevice, it, null) }
 
         windowSizeCallback.close()
         glfwDestroyWindow(window.window)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/Swapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/Swapchain.kt
@@ -12,8 +12,8 @@ import java.nio.LongBuffer
  */
 interface Swapchain : AutoCloseable {
     var handle: Long
-    var images: LongArray?
-    var imageViews: LongArray?
+    var images: LongArray
+    var imageViews: LongArray
 
     var format: Int
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
@@ -365,8 +365,8 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
     fun addSwapchainAttachment(name: String, swapchain: Swapchain, index: Int): VulkanFramebuffer {
         val att = VulkanFramebufferAttachment()
 
-        att.image = swapchain.images!!.get(index)
-        att.imageView.put(0, swapchain.imageViews!!.get(index))
+        att.image = swapchain.images[index]
+        att.imageView.put(0, swapchain.imageViews[index])
         att.type = VulkanFramebufferType.COLOR_ATTACHMENT
         att.fromSwapchain = true
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -39,9 +39,9 @@ open class VulkanSwapchain(open val device: VulkanDevice,
     /** Swapchain handle. */
     override var handle: Long = 0L
     /** Array for rendered images. */
-    override var images: LongArray? = null
+    override var images: LongArray = LongArray(0)
     /** Array for image views. */
-    override var imageViews: LongArray? = null
+    override var imageViews: LongArray = LongArray(0)
     /** Number of frames presented with this swapchain. */
     protected var presentedFrames: Long = 0
 


### PR DESCRIPTION
This PR removes the nullability of `VulkanSwapchain.images`, `VulkanSwapchain.imageViews`, and `VulkanRenderer.swapchain`. It also addresses a few compiler warnings, mainly related to aforementioned nullability.