### PR TITLE
upgrade coremem dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,9 +267,9 @@
         </dependency>
 
         <dependency>
-            <groupId>net.coremem</groupId>
-            <artifactId>CoreMem</artifactId>
-            <version>0.4.3</version>
+            <groupId>net.clearcontrol</groupId>
+            <artifactId>coremem</artifactId>
+            <version>0.4.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.android.tools</groupId>


### PR DESCRIPTION
Hi @skalarproduktraum 

in order to integrate SciView / Scenery with Clearcontrol, I'm suggesting upgrading scenerys CoreMem version. I don't see any side effects but I'm also new to Scenery. Please check/test carefully before merging ;-)

Also: I'm just highlighting that groupId and artifactId of coremem changed. That might make things complicated as coremem.CoreMem and net.clearcontrol.coremem can coexist in one project. However both bring the same classes. Thus, further cleaning up the dependency tree might be necessary.

Thanks!

Cheers,
Robert