### PR TITLE
Upgrade spirvcrossj 1.1.106.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <cleargl.version>2.2.6</cleargl.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lwjgl.version>3.2.1</lwjgl.version>
-        <spirvcrossj.version>0.6.0-1.1.106.0-SNAPSHOT</spirvcrossj.version>
+        <spirvcrossj.version>0.6.0-1.1.106.0</spirvcrossj.version>
         <jvrpn.version>1.1.0</jvrpn.version>
         <jeromq.version>0.4.3</jeromq.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <cleargl.version>2.2.6</cleargl.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lwjgl.version>3.2.1</lwjgl.version>
-        <spirvcrossj.version>0.5.2-1.1.101.0</spirvcrossj.version>
+        <spirvcrossj.version>0.6.0-1.1.106.0-SNAPSHOT</spirvcrossj.version>
         <jvrpn.version>1.1.0</jvrpn.version>
         <jeromq.version>0.4.3</jeromq.version>
 

--- a/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
+++ b/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
@@ -61,7 +61,7 @@ data class ShaderPackage(val baseClass: Class<*>,
         val buffer = BufferUtils.allocateByteAndPut(spirv).asIntBuffer()
 
         while(buffer.hasRemaining()) {
-            bytecode.pushBack(1L*buffer.get())
+            bytecode.add(1L*buffer.get())
         }
 
         return bytecode

--- a/src/main/kotlin/graphics/scenery/backends/Shaders.kt
+++ b/src/main/kotlin/graphics/scenery/backends/Shaders.kt
@@ -245,7 +245,7 @@ sealed class Shaders {
 
     private fun compileFromSPIRVBytecode(shaderPackage: ShaderPackage, target: ShaderTarget): Pair<IntVec, String> {
         val bytecode = shaderPackage.getSPIRVBytecode() ?: throw IllegalStateException("SPIRV bytecode not found")
-        logger.debug("Using SPIRV version, ${bytecode.size()} opcodes")
+        logger.debug("Using SPIRV version, ${bytecode.size} opcodes")
         val compiler = CompilerGLSL(bytecode)
 
         val options = CompilerGLSL.Options()
@@ -261,7 +261,7 @@ sealed class Shaders {
                 options.vulkanSemantics = false
             }
         }
-        compiler.options = options
+        compiler.commonOptions = options
         val sourceCode = compiler.compile()
 
         return Pair(bytecode, sourceCode)
@@ -271,11 +271,11 @@ sealed class Shaders {
      * Converts an glslang-compatible IntVec to a [ByteBuffer].
      */
     protected fun IntVec.toByteBuffer(): ByteBuffer {
-        val buf = BufferUtils.allocateByte(this.size().toInt()*4)
+        val buf = BufferUtils.allocateByte(this.size*4)
         val ib = buf.asIntBuffer()
 
-        for (i in 0 until this.size()) {
-            ib.put(this[i.toInt()].toInt())
+        for (i in 0 until this.size) {
+            ib.put(this[i].toInt())
         }
 
         return buf

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
@@ -5,10 +5,10 @@ import cleargl.GLShaderType
 import com.jogamp.opengl.GL4
 import graphics.scenery.backends.ShaderPackage
 import graphics.scenery.backends.ShaderType
-import graphics.scenery.spirvcrossj.*
+import graphics.scenery.spirvcrossj.CompilerGLSL
+import graphics.scenery.spirvcrossj.Decoration
 import graphics.scenery.utils.LazyLogger
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.collections.LinkedHashMap
 
 
 /**
@@ -41,9 +41,9 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
 
         val uniformBuffers = compiler.shaderResources.uniformBuffers
         logger.debug("Analysing uniform buffers ...")
-        for(i in 0 until uniformBuffers.size()) {
-            logger.debug("Getting ${i.toInt()} for ${sp.toShortString()} (size: ${uniformBuffers.capacity()}/${uniformBuffers.size()})")
-            val res = uniformBuffers.get(i.toInt())
+        for(i in 0 until uniformBuffers.capacity()) {
+            logger.debug("Getting $i for ${sp.toShortString()} (size: ${uniformBuffers.capacity()}/${uniformBuffers.capacity()})")
+            val res = uniformBuffers.get(i)
             logger.debug("${res.name}, set=${compiler.getDecoration(res.id, Decoration.DecorationDescriptorSet)}, binding=${compiler.getDecoration(res.id, Decoration.DecorationBinding)}")
 
             val members = LinkedHashMap<String, UBOMemberSpec>()
@@ -51,8 +51,8 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
 
             // record all members of the UBO struct, order by index, and store them to UBOSpec.members
             // for further use
-            members.putAll((0 until activeRanges.size()).map {
-                val range = activeRanges.get(it.toInt())
+            members.putAll((0 until activeRanges.capacity()).map {
+                val range = activeRanges.get(it)
                 val name = compiler.getMemberName(res.baseTypeId, range.index)
 
                 name to UBOMemberSpec(
@@ -93,7 +93,7 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
                     members = LinkedHashMap<String, UBOMemberSpec>()))
          */
         // inputs are summarized into one descriptor set
-        if(compiler.shaderResources.sampledImages.size() > 0) {
+        if(compiler.shaderResources.sampledImages.capacity() > 0) {
             val res = compiler.shaderResources.sampledImages.get(0)
             if (res.name != "ObjectTextures") {
                 uboSpecs[res.name] = UBOSpec("inputs",
@@ -104,9 +104,9 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
         }
 
         val inputs = compiler.shaderResources.stageInputs
-        if(inputs.size() > 0) {
-            for (i in 0 until inputs.size()) {
-                logger.debug("${sp.toShortString()}: ${inputs.get(i.toInt()).name}")
+        if(inputs.capacity() > 0) {
+            for (i in 0 until inputs.capacity()) {
+                logger.debug("${sp.toShortString()}: ${inputs.get(i).name}")
             }
         }
 
@@ -114,7 +114,7 @@ open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
         options.version = 410
         options.es = false
         options.vulkanSemantics = false
-        compiler.options = options
+        compiler.commonOptions = options
 
         this.shaderType = sp.type
 


### PR DESCRIPTION
This PR upgrades spirvcrossj to 1.1.106.0 and makes the necessary changes to Shaders, ShaderPackage, OpenGLShaderModule, and VulkanShaderModule required by changes in SPIRV-cross.