### PR TITLE
VulkanRenderer: Bubble fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 
         <cleargl.version>2.2.6</cleargl.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <lwjgl.version>3.2.1</lwjgl.version>
+        <lwjgl.version>3.2.3</lwjgl.version>
         <spirvcrossj.version>0.6.0-1.1.106.0</spirvcrossj.version>
         <jvrpn.version>1.1.0</jvrpn.version>
         <jeromq.version>0.4.3</jeromq.version>

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
@@ -653,6 +653,7 @@ class VU {
                         .dstArrayElement(0)
                         .pBufferInfo(d)
                         .descriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)
+                        .descriptorCount(1)
                 }
 
                 vkUpdateDescriptorSets(device.vulkanDevice, writeDescriptorSet, null)
@@ -685,6 +686,7 @@ class VU {
                         .dstArrayElement(0)
                         .pBufferInfo(d)
                         .descriptorType(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)
+                        .descriptorCount(1)
                 }
 
                 vkUpdateDescriptorSets(device.vulkanDevice, writeDescriptorSet, null)
@@ -729,6 +731,7 @@ class VU {
                         .dstBinding(i)
                         .pBufferInfo(d)
                         .descriptorType(type)
+                        .descriptorCount(1)
                 }
 
                 vkUpdateDescriptorSets(device.vulkanDevice, writeDescriptorSet, null)
@@ -779,6 +782,7 @@ class VU {
                             .dstArrayElement(0)
                             .pImageInfo(d)
                             .descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+                            .descriptorCount(1)
                     }
                     writeDescriptorSet
                 } else {
@@ -801,6 +805,7 @@ class VU {
                             .dstArrayElement(0)
                             .pImageInfo(d)
                             .descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+                            .descriptorCount(1)
                     }
                     writeDescriptorSet
                 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -144,6 +144,7 @@ open class VulkanDevice(val instance: VkInstance, val physicalDevice: VkPhysical
             val enabledFeatures = VkPhysicalDeviceFeatures.callocStack(stack)
                 .samplerAnisotropy(true)
                 .largePoints(true)
+                .geometryShader(true)
 
             val deviceCreateInfo = VkDeviceCreateInfo.callocStack(stack)
                 .sType(VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -150,6 +150,7 @@ open class VulkanObjectState : NodeMetadata {
                 .dstArrayElement(i)
                 .pImageInfo(d[i])
                 .descriptorType(VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+                .descriptorCount(1)
 
             i++
         }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1684,8 +1684,6 @@ open class VulkanRenderer(hub: Hub,
         val startPresent = System.nanoTime()
         commandBuffer.submitted = true
         swapchain.present(ph.signalSemaphore)
-        // TODO: Figure out whether this waitForFence call is strictly necessary -- actually, the next renderloop iteration should wait for it.
-        commandBuffer.waitForFence()
 
         swapchain.postPresent(pass.getReadPosition())
 
@@ -2068,6 +2066,9 @@ open class VulkanRenderer(hub: Hub,
 
         val viewportPass = renderpasses.values.last()
         val viewportCommandBuffer = viewportPass.commandBuffer
+        if(viewportCommandBuffer.submitted) {
+            viewportCommandBuffer.waitForFence()
+        }
         logger.trace("Running viewport pass {}", renderpasses.keys.last())
 
         val start = System.nanoTime()


### PR DESCRIPTION
In VulkanRenderer, the presentation command buffer was waited for right after submission, creating GPU bubbles, because of unnecessary sync. With this PR, the presentation command buffer is only waited for right before re-recording, improving GPU utilisation (values from a GTX 1080Ti, taken over 100s after warmup, utilisation via NvAPI):

Test case | Frame Rate | GPU utilisation
----------|------------|--------
SponzaExample 720p (before) | 217-321fps | 44-62%
SponzaExample 4k (before) | 75-100fps | 74-86%
SponzaExample 4k stereo (before) | 80-108fps | 72-85%
 | | 
SponzaExample 720p | 354-434fps | 46-81%
SponzaExample 4k | 102-153fps | 76-96%
SponzaExample 4k stereo | 108-174 fps | 93-98%

In addition, this PR fixes two cases of API abuse:

* in VU and VulkanObjectState, `descriptorCount` is now set correctly when calling `vkUpdateDescriptorSets`
* in VulkanDevice, the `geometryShaders` feature is requested by default

And finally, bumps lwjgl to 3.2.3.