### PR TITLE
Volume repeat fix

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -1691,6 +1691,18 @@ open class OpenGLRenderer(hub: Hub,
                         Material.CullingMode.FrontAndBack -> gl.glCullFace(GL4.GL_FRONT_AND_BACK)
                     }
 
+                   val depthTest = when(n.material.depthTest) {
+                        Material.DepthTest.Less -> GL4.GL_LESS
+                        Material.DepthTest.Greater -> GL4.GL_GREATER
+                        Material.DepthTest.LessEqual -> GL4.GL_LEQUAL
+                        Material.DepthTest.GreaterEqual -> GL4.GL_GEQUAL
+                        Material.DepthTest.Always -> GL4.GL_ALWAYS
+                        Material.DepthTest.Never -> GL4.GL_NEVER
+                        Material.DepthTest.Equal -> GL4.GL_EQUAL
+                    }
+
+                    gl.glDepthFunc(depthTest)
+
                     if (n.material.blending.transparent) {
                         with(n.material.blending) {
                             gl.glBlendFuncSeparate(
@@ -1714,11 +1726,6 @@ open class OpenGLRenderer(hub: Hub,
                     }
 
                     val s = getOpenGLObjectStateFromNode(n)
-
-                    if (n is Skybox) {
-                        gl.glCullFace(GL4.GL_FRONT)
-                        gl.glDepthFunc(GL4.GL_LEQUAL)
-                    }
 
                     preDrawAndUpdateGeometryForNode(n)
 

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -607,7 +607,11 @@ open class Volume : Mesh("Volume") {
         val emptyBuffer = BufferUtils.allocateByteAndPut(byteArrayOf(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                                                      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0))
         val dim = GLVector(2.0f, 2.0f, 2.0f)
-        val gtv = GenericTexture("empty-volume", dim, 1, GLTypeEnum.UnsignedByte, emptyBuffer, false, false, normalized = true)
+        val gtv = GenericTexture("empty-volume", dim, 1, GLTypeEnum.UnsignedByte, emptyBuffer,
+            repeatS = false,
+            repeatT = false,
+            repeatU = false,
+            normalized = true)
 
         material.transferTextures.put("empty-volume", gtv)
         material.textures.put("VolumeTextures", "fromBuffer:empty-volume")
@@ -648,7 +652,11 @@ open class Volume : Mesh("Volume") {
 
         val dim = GLVector(dimensions[0].toFloat(), dimensions[1].toFloat(), dimensions[2].toFloat())
         val gtv = GenericTexture("VolumeTextures", dim,
-            1, descriptor.dataType.toGLType(), descriptor.data, false, false, normalized = true)
+            1, descriptor.dataType.toGLType(), descriptor.data,
+            repeatS = false,
+            repeatT = false,
+            repeatU = false,
+            normalized = true)
 
         boundingBox = generateBoundingBox()
 


### PR DESCRIPTION
This PR fixes:

* Volume: Texture would be repeated in Z direction, instead of being clamped
* OpenGLRenderer: Does not heed depth test mode specified in `Material.depthTest`