### PR TITLE
Wireframe rendering

### DIFF
--- a/src/main/kotlin/graphics/scenery/Material.kt
+++ b/src/main/kotlin/graphics/scenery/Material.kt
@@ -57,6 +57,9 @@ open class Material : Serializable {
     /** Flag to check whether the [transferTextures] need reloading */
     var needsTextureReload: Boolean = false
 
+    /** Flag to make the object wireframe */
+    var wireframe: Boolean = false
+
     /** Companion object for Material, emulating static methods */
     companion object Factory {
         /**
@@ -65,5 +68,15 @@ open class Material : Serializable {
          * @return Material with default properties
          */
         @JvmStatic fun DefaultMaterial(): Material = Material()
+    }
+
+    fun materialHashCode() : Int {
+        var result = blending.hashCode()
+        result = 31 * result + textures.hashCode()
+        result = 31 * result + transferTextures.hashCode()
+        result = 31 * result + cullingMode.hashCode()
+        result = 31 * result + depthTest.hashCode()
+        result = 31 * result + wireframe.hashCode()
+        return result
     }
 }

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -1082,7 +1082,7 @@ open class OpenGLRenderer(hub: Hub,
                 false
             }
 
-            nodeUpdated = if(node.material.hashCode() != s.materialHash) {
+            nodeUpdated = if(node.material.materialHashCode() != s.materialHash) {
                 s.initialized = false
                 initializeNode(node)
                 true
@@ -1708,6 +1708,12 @@ open class OpenGLRenderer(hub: Hub,
 
                     gl.glDepthFunc(depthTest)
 
+                    if(n.material.wireframe) {
+                        gl.glPolygonMode(GL4.GL_FRONT_AND_BACK, GL4.GL_LINE)
+                    } else {
+                        gl.glPolygonMode(GL4.GL_FRONT_AND_BACK, GL4.GL_FILL)
+                    }
+
                     if (n.material.blending.transparent) {
                         with(n.material.blending) {
                             gl.glBlendFuncSeparate(
@@ -2184,7 +2190,7 @@ open class OpenGLRenderer(hub: Hub,
 
         }
 
-        s.materialHash = node.material.hashCode()
+        s.materialHash = node.material.materialHashCode()
 
         val matricesUbo = OpenGLUBO(backingBuffer = buffers.UBOs)
         with(matricesUbo) {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -41,8 +41,8 @@ open class VulkanObjectState : NodeMetadata {
     /** [VulkanTexture]s used by the [graphics.scenery.Node] this metadata object is attached to. */
     var textures = ConcurrentHashMap<String, VulkanTexture>()
 
-    /** Hash code for the blending options used in the last command buffer recording. */
-    var blendingHashCode = 0
+    /** Material hash code, does not include textures. */
+    var materialHashCode = 0
 
     /** Whether this [graphics.scenery.Node] will use any default textures for any of its texture slots. */
     var defaultTexturesFor = HashSet<String>()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -805,7 +805,7 @@ open class VulkanRenderer(hub: Hub,
 
         loadTexturesForNode(node, s)
 
-        s.blendingHashCode = node.material.blending.hashCode()
+        s.materialHashCode = node.material.materialHashCode()
 
         val materialUbo = VulkanUBO(device, backingBuffer = buffers.UBOs)
         with(materialUbo) {
@@ -831,8 +831,15 @@ open class VulkanRenderer(hub: Hub,
 
     private fun initializeCustomShadersForNode(node: Node, addInitializer: Boolean = true): Boolean {
 
-        if(!(node.material.blending.transparent || node.material is ShaderMaterial || node.material.cullingMode != Material.CullingMode.Back)) {
+        if(!(node.material.blending.transparent || node.material is ShaderMaterial || node.material.cullingMode != Material.CullingMode.Back || node.material.wireframe)) {
             logger.debug("Using default renderpass material for ${node.name}")
+            renderpasses
+                .filter { it.value.passConfig.type == RenderConfigReader.RenderpassType.geometry || it.value.passConfig.type == RenderConfigReader.RenderpassType.lights }
+                .forEach {
+                    it.value.removePipeline(node)
+                }
+
+            lateResizeInitializers.remove(node)
             return false
         }
 
@@ -924,6 +931,12 @@ open class VulkanRenderer(hub: Hub,
                                 Material.DepthTest.GreaterEqual -> pipeline.depthStencilState.depthCompareOp(VK_COMPARE_OP_GREATER_OR_EQUAL)
                                 Material.DepthTest.Always -> pipeline.depthStencilState.depthCompareOp(VK_COMPARE_OP_ALWAYS)
                                 Material.DepthTest.Never -> pipeline.depthStencilState.depthCompareOp(VK_COMPARE_OP_NEVER)
+                            }
+
+                            if(node.material.wireframe) {
+                                pipeline.rasterizationState.polygonMode(VK_POLYGON_MODE_LINE)
+                            } else {
+                                pipeline.rasterizationState.polygonMode(VK_POLYGON_MODE_FILL)
                             }
 
                             if(node.material.blending.transparent) {
@@ -1959,11 +1972,11 @@ open class VulkanRenderer(hub: Hub,
                         }
                     }
 
-                    if (material.blending.hashCode() != metadata.blendingHashCode || (material is ShaderMaterial && material.shaders.stale)) {
+                    if (material.materialHashCode() != metadata.materialHashCode || (material is ShaderMaterial && material.shaders.stale)) {
                         logger.trace("Force command buffer re-recording, as blending options for ${it.name} have changed")
                         val reloaded = initializeCustomShadersForNode(it)
-                        logger.info("Material is stale, re-recording, reloaded=$reloaded")
-                        metadata.blendingHashCode = it.material.blending.hashCode()
+                        logger.debug("Material is stale, re-recording, reloaded=$reloaded")
+                        metadata.materialHashCode = it.material.materialHashCode()
 
                         // if we reloaded the node's shaders, we might need to recreate its texture descriptor sets
                         if(reloaded) {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -546,6 +546,13 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
     }
 
     /**
+     * Removes any preferred [VulkanPipeline] for the node given in [forNode].
+     */
+    fun removePipeline(forNode: Node): Boolean {
+        return pipelines.remove("preferred-${forNode.uuid}") != null
+    }
+
+    /**
      * Returns this renderpasses' default pipeline.
      */
     fun getDefaultPipeline(): VulkanPipeline {


### PR DESCRIPTION
This PR introduces wireframe rendering, to be activated via `Material.wireframe`. It addresses #128.