### PR TITLE
OpenGL window handling improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <dokka.version>0.9.18</dokka.version>
         <dokka.skip>true</dokka.skip>
 
-        <cleargl.version>2.2.6</cleargl.version>
+        <cleargl.version>2.2.7</cleargl.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lwjgl.version>3.2.3</lwjgl.version>
         <spirvcrossj.version>0.6.0-1.1.106.0</spirvcrossj.version>

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -240,7 +240,8 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
             settings.set("System.Runtime", runtime)
 
             if (renderer?.managesRenderLoop != false) {
-                Thread.sleep(5)
+                renderer?.render()
+                Thread.sleep(1)
             } else {
                 stats.addTimed("render") { renderer?.render() ?: 0.0f }
             }
@@ -438,6 +439,12 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
 
         if(wait) {
             latch?.await()
+        }
+    }
+
+    fun waitForSceneInitialisation() {
+        while(!sceneInitialized()) {
+            Thread.sleep(200)
         }
     }
 

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -342,7 +342,7 @@ open class OpenGLRenderer(hub: Hub,
 
         this.flow = this.renderConfig.createRenderpassFlow()
 
-        logger.info("Loaded ${renderConfig.name} (${renderConfig.description ?: "no description"}")
+        logger.info("Loaded ${renderConfig.name} (${renderConfig.description ?: "no description"})")
 
         this.scene = scene
         this.applicationName = applicationName

--- a/src/test/tests/graphics/scenery/tests/examples/advanced/MultiBoxInstancedExample.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/advanced/MultiBoxInstancedExample.kt
@@ -82,11 +82,7 @@ class MultiBoxInstancedExample : SceneryBase("MultiBoxInstancedExample") {
         scene.addChild(hullbox)
 
         thread {
-            while(!sceneInitialized()) {
-                Thread.sleep(200)
-            }
-
-            while (true) {
+            while (running) {
                 container.rotation.rotateByEuler(0.001f, 0.001f, 0.0f)
                 container.needsUpdateWorld = true
                 container.needsUpdate = true

--- a/src/test/tests/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
@@ -39,7 +39,7 @@ class TexturedCubeExample : SceneryBase("TexturedCubeExample") {
         }
 
         thread {
-            while (true) {
+            while (running) {
                 box.rotation.rotateByAngleY(0.01f)
                 box.needsUpdate = true
 

--- a/src/test/tests/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
@@ -43,7 +43,8 @@ class ExampleRunner {
             .filter { !it.canonicalName.contains("stresstests") && !it.canonicalName.contains("cluster") }
             .filter { !blacklist.contains(it.simpleName) }
 
-        val renderers = when(ExtractsNatives.getPlatform()) {
+        val rendererProperty = System.getProperty("scenery.Renderer")
+        val renderers = rendererProperty?.split(",") ?: when(ExtractsNatives.getPlatform()) {
             ExtractsNatives.Platform.WINDOWS,
             ExtractsNatives.Platform.LINUX -> listOf("VulkanRenderer", "OpenGLRenderer")
             ExtractsNatives.Platform.MACOS -> listOf("OpenGLRenderer")


### PR DESCRIPTION
This PR addresses an issue where OpenGL would throw exceptions on quit. It also bumps ClearGL to 2.2.7 and allows manual specification of the renderers to use for the ExampleRunner.