### PR TITLE
Include metadata in RaycastResult

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -257,7 +257,7 @@ open class Camera : Node("Camera") {
      */
     @JvmOverloads fun getNodesForScreenSpacePosition(x: Int, y: Int,
                                                        ignoredObjects: List<Class<*>> = emptyList(),
-                                                       debug: Boolean = false): List<Scene.RaycastResult> {
+                                                       debug: Boolean = false): Scene.RaycastResult {
         val view = (target - position).normalize()
         var h = view.cross(up).normalize()
         var v = h.cross(view)
@@ -278,7 +278,7 @@ open class Camera : Node("Camera") {
         val scene = getScene()
         if(scene == null) {
             logger.warn("No scene found for $this, returning empty list for raycast.")
-            return emptyList()
+            return Scene.RaycastResult(emptyList(), worldPos, worldDir)
         }
 
         return scene.raycast(worldPos, worldDir, ignoredObjects, debug)

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/SelectCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/SelectCommand.kt
@@ -1,7 +1,8 @@
 package graphics.scenery.controls.behaviours
 
-import cleargl.GLVector
-import graphics.scenery.*
+import graphics.scenery.BoundingGrid
+import graphics.scenery.Camera
+import graphics.scenery.Scene
 import graphics.scenery.backends.Renderer
 import graphics.scenery.utils.LazyLogger
 import org.scijava.ui.behaviour.ClickBehaviour
@@ -26,7 +27,7 @@ open class SelectCommand @JvmOverloads constructor(protected val name: String,
                                                    protected val camera: () -> Camera?,
                                                    protected var debugRaycast: Boolean = false,
                                                    var ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java),
-                                                   protected var action: ((List<Scene.RaycastResult>) -> Unit) = {}) : ClickBehaviour {
+                                                   protected var action: ((Scene.RaycastResult, Int, Int) -> Unit) = { _, _, _ -> Unit }) : ClickBehaviour {
     protected val logger by LazyLogger()
 
     protected val cam: Camera? by CameraDelegate()
@@ -52,7 +53,7 @@ open class SelectCommand @JvmOverloads constructor(protected val name: String,
     override fun click(x: Int, y: Int) {
         cam?.let { cam ->
             val matches = cam.getNodesForScreenSpacePosition(x, y, ignoredObjects, debugRaycast)
-            action.invoke(matches)
+            action.invoke(matches, x, y)
         }
     }
 }

--- a/src/test/tests/graphics/scenery/tests/examples/advanced/PickerExample.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/advanced/PickerExample.kt
@@ -48,8 +48,8 @@ class PickerExample: SceneryBase("PickerExample", wantREPL = true) {
     override fun inputSetup() {
         super.inputSetup()
 
-        val wiggle: (List<Scene.RaycastResult>) -> Unit = { result ->
-            result.firstOrNull()?.let { nearest ->
+        val wiggle: (Scene.RaycastResult, Int, Int) -> Unit = { result, _, _ ->
+            result.matches.firstOrNull()?.let { nearest ->
                 val originalPosition = nearest.node.position.clone()
                 thread {
                     for(i in 0 until 200) {

--- a/src/test/tests/graphics/scenery/tests/unit/SceneTests.kt
+++ b/src/test/tests/graphics/scenery/tests/unit/SceneTests.kt
@@ -42,7 +42,7 @@ class SceneTests {
             direction = GLVector(0.0f, 0.0f, -1.0f),
             ignoredObjects = emptyList())
 
-        assertEquals(count, results.size, "Raycast should have hit $count objects")
+        assertEquals(count, results.matches.size, "Raycast should have hit $count objects")
     }
 
     @Test


### PR DESCRIPTION
This PR includes world direction and world position of the initial ray into RaycastResult and extends SelectCommand to also hand over the click x/y to the function called on the matched object(s).