### PR TITLE
Camera transform fix

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -70,6 +70,9 @@ open class Camera : Node("Camera") {
 
                 this.viewSpaceTripod = cameraTripod()
 
+                this.needsUpdate = true
+                this.needsUpdateWorld = true
+
                 if(!targeted) {
                     this.target = this.position + this.forward
                 }
@@ -85,6 +88,9 @@ open class Camera : Node("Camera") {
                 val m = GLMatrix.fromQuaternion(q)
                 this.forward = GLVector(m.get(0, 2), m.get(1, 2), m.get(2, 2)).normalize() * -1.0f
                 this.viewSpaceTripod = cameraTripod()
+
+                this.needsUpdate = true
+                this.needsUpdateWorld = true
             }
         }
 
@@ -400,6 +406,10 @@ open class Camera : Node("Camera") {
             this.getScene()?.removeChild(tb)
             messages?.remove(tb)
         }
+    }
+
+    override fun composeModel() {
+        model = getTransformation().inverse
     }
 
     companion object {

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -384,26 +384,19 @@ open class Camera : Node("Camera") {
         tb.backgroundColor = backgroundColor
         tb.text = message
         tb.scale = GLVector(size, size, size)
-        tb.update.add {
-            tb.position = this.viewportToWorld(GLVector(0.3f, 0.7f), 1.0f) + this.forward * distance
-            if(this is DetachedHeadCamera) {
-                tb.rotation = headOrientation.conjugate().normalize()
-            } else {
-                tb.rotation = rotation.conjugate().normalize()
-            }
-        }
+        tb.position = GLVector(0.0f, 0.0f, -1.0f * distance)
 
         val messages = metadata.getOrPut("messages", { mutableListOf<Node>() }) as? MutableList<Node>
-        messages?.forEach { getScene()?.removeChild(it) }
+        messages?.forEach { this.removeChild(it) }
         messages?.clear()
 
         messages?.add(tb)
-        this.getScene()?.addChild(tb)
+        this.addChild(tb)
 
         thread {
             Thread.sleep(duration.toLong())
 
-            this.getScene()?.removeChild(tb)
+            this.removeChild(tb)
             messages?.remove(tb)
         }
     }

--- a/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
+++ b/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
@@ -1079,14 +1079,17 @@ open class OpenVRHMD(val seated: Boolean = false, val useCompositor: Boolean = t
         }
 
         logger.info("Adding child $node to $camera")
-        camera?.addChild(node)
+        camera?.getScene()?.addChild(node)
 
         node.update.add {
             this.getPose(TrackedDeviceType.Controller).firstOrNull { it.name == device.name }?.let { controller ->
 
                 node.wantsComposeModel = false
                 node.model.setIdentity()
-                node.model.mult(controller.pose.invert())
+                camera?.let {
+                    node.model.translate(it.position)
+                }
+                node.model.mult(controller.pose)
 
 //                logger.info("Updating pose of $controller, ${node.model}")
 

--- a/src/test/tests/graphics/scenery/tests/unit/CameraTests.kt
+++ b/src/test/tests/graphics/scenery/tests/unit/CameraTests.kt
@@ -29,11 +29,11 @@ class CameraTests {
         s.addChild(cam)
 
         cam.showMessage("hello camera", duration = duration)
-        assertTrue("Scene contains messages TextBoard from Camera") { (s.children.last() as? TextBoard)?.text == "hello camera" }
+        assertTrue("Scene contains messages TextBoard from Camera") { (cam.children.last() as? TextBoard)?.text == "hello camera" }
         assertTrue("Camera contains messages metadata object") { cam.metadata.containsKey("messages") }
         Thread.sleep(2L * duration)
 
-        assertTrue("TextBoard was removed from scene after showing duration") { s.children.size == 1 }
+        assertTrue("TextBoard was removed from scene after showing duration") { cam.children.size == 0 }
         assertTrue("Messages metadata object contains no more entries") { (cam.metadata.get("messages") as MutableList<Node>).isEmpty() }
     }
 


### PR DESCRIPTION
This PR makes a Camera's children adhere to the same transform properties as other nodes, such that objects can be more easily attached to cameras, and will follow it's position and rotatation.

(Somewhat related to #272)