### PR TITLE
Fix cleanup code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dokka.skip>true</dokka.skip>
 
         <bigvolumeviewer.version>0.1.6</bigvolumeviewer.version>
-        <cleargl.version>2.2.9</cleargl.version>
+        <cleargl.version>2.2.10</cleargl.version>
         <coremem.version>0.4.6</coremem.version>
         <ffmpeg.version>4.1-1.4.4</ffmpeg.version>
         <gluegen-rt.version>${gluegen-rt-main.version}</gluegen-rt.version>

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -340,6 +340,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
         renderdoc?.close()
 
         hub.get<Profiler>()?.close()
+        hub.get<Statistics>()?.close()
     }
 
     /**
@@ -390,6 +391,8 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
         shouldClose = true
         gracePeriod = 10
         renderer?.close()
+
+        renderer = null
 
         (hub.get(SceneryElement.NodePublisher) as? NodePublisher)?.close()
         (hub.get(SceneryElement.NodeSubscriber) as? NodeSubscriber)?.close()

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -336,7 +336,6 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
 
         running = false
         inputHandler?.close()
-        renderer?.close()
         renderdoc?.close()
 
         hub.get<Profiler>()?.close()
@@ -387,10 +386,15 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     /**
      * Sets the shouldClose flag on renderer, causing it to shut down and thereby ending the main loop.
      */
-    fun close() {
+    open fun close() {
         shouldClose = true
-        gracePeriod = 10
+        gracePeriod = 60
         renderer?.close()
+
+        while(gracePeriod > 0 || renderer?.initialized == true) {
+            logger.debug("Waiting for grace period to go to 0, current=$gracePeriod")
+            Thread.sleep(100)
+        }
 
         renderer = null
 

--- a/src/main/kotlin/graphics/scenery/backends/Renderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/Renderer.kt
@@ -10,10 +10,7 @@ import graphics.scenery.backends.vulkan.VulkanRenderer
 import graphics.scenery.utils.ExtractsNatives
 import graphics.scenery.utils.LazyLogger
 import graphics.scenery.utils.SceneryPanel
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /**

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -3250,6 +3250,7 @@ open class VulkanRenderer(hub: Hub,
         vkDestroyInstance(instance, null)
 
         heartbeatTimer.cancel()
+        heartbeatTimer.purge()
         logger.info("Renderer teardown complete.")
     }
 

--- a/src/main/kotlin/graphics/scenery/controls/GLFWMouseAndKeyHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/GLFWMouseAndKeyHandler.kt
@@ -468,6 +468,7 @@ open class GLFWMouseAndKeyHandler(protected var hub: Hub?) : MouseAndKeyHandlerB
     }
 
     override fun close() {
+        super.close()
         cursorCallback.close()
         keyCallback.close()
         mouseCallback.close()

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -242,5 +242,6 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
 
     override fun close() {
         logger.debug("Closing InputHandler")
+        handler?.close()
     }
 }

--- a/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
+++ b/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
@@ -44,6 +44,8 @@ open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
     private val CONTROLLER_HEARTBEAT = 5L
     private val CONTROLLER_DOWN_THRESHOLD = 0.95f
 
+    protected var shouldClose = false
+
     /**
      * Managing internal behaviour lists.
      *
@@ -155,7 +157,7 @@ open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
             var queue: EventQueue
             val event = Event()
 
-            while (true) {
+            while (!shouldClose) {
                 controller?.let { c ->
                     c.poll()
 
@@ -327,5 +329,12 @@ open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
 
     open fun attach(window: SceneryWindow, inputMap: InputTriggerMap, behaviourMap: BehaviourMap): MouseAndKeyHandlerBase {
         throw UnsupportedOperationException("MouseAndKeyHandlerBase cannot be attached to a window.")
+    }
+
+    open fun close() {
+        shouldClose = true
+        controllerThread?.join()
+        controllerThread = null
+        logger.debug("MouseAndKeyHandlerBase closed.")
     }
 }

--- a/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
+++ b/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
@@ -327,10 +327,18 @@ open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
         }
     }
 
+    /**
+     * Attaches this handler to a given [window], with input bindings and behaviours given in [inputMap] and
+     * [behaviourMap]. MouseAndKeyHandlerBase itself cannot be attached to any windows.
+     */
     open fun attach(window: SceneryWindow, inputMap: InputTriggerMap, behaviourMap: BehaviourMap): MouseAndKeyHandlerBase {
         throw UnsupportedOperationException("MouseAndKeyHandlerBase cannot be attached to a window.")
     }
 
+    /**
+     * Closes this instance of MouseAndKeyHandlerBase.
+     * This function needs to be called as super.close() by derived classes in order to clean up gamepad handling logic.
+     */
     open fun close() {
         shouldClose = true
         controllerThread?.join()

--- a/src/main/kotlin/graphics/scenery/net/NodePublisher.kt
+++ b/src/main/kotlin/graphics/scenery/net/NodePublisher.kt
@@ -92,5 +92,6 @@ class NodePublisher(override var hub: Hub?, val address: String = "tcp://127.0.0
 
     fun close() {
         context.destroySocket(publisher)
+        context.close()
     }
 }

--- a/src/main/kotlin/graphics/scenery/net/NodeSubscriber.kt
+++ b/src/main/kotlin/graphics/scenery/net/NodeSubscriber.kt
@@ -131,5 +131,6 @@ class NodeSubscriber(override var hub: Hub?, val address: String = "udp://localh
 
     fun close() {
         context.destroySocket(subscriber)
+        context.close()
     }
 }

--- a/src/test/tests/graphics/scenery/tests/examples/basic/SwingTexturedCubeExample.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/basic/SwingTexturedCubeExample.kt
@@ -15,8 +15,10 @@ import kotlin.concurrent.thread
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class SwingTexturedCubeExample : SceneryBase("SwingTexturedCubeExample", windowWidth = 512, windowHeight = 512) {
+    lateinit var mainFrame: JFrame
+
     override fun init() {
-        val mainFrame = JFrame(applicationName)
+        mainFrame = JFrame(applicationName)
         mainFrame.setSize(windowWidth, windowHeight)
         mainFrame.layout = BorderLayout()
 
@@ -72,6 +74,11 @@ class SwingTexturedCubeExample : SceneryBase("SwingTexturedCubeExample", windowW
                 Thread.sleep(200)
             }
         }
+    }
+
+    override fun close() {
+        mainFrame.dispose()
+        super.close()
     }
 
     @Test override fun main() {


### PR DESCRIPTION
This PR fixes cleanup and threads not closing in NodePublisher, NodeSubscriber, Statistics, and MouseAndKeyHandlerBase. It also replaces FPSAnimator with Animator in OpenGLRenderer for improved shutdown handling, and cleans up the shutdown code in OpenGLRenderer.