### PR TITLE
Rendering device chooser

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -7,6 +7,7 @@ import org.lwjgl.system.MemoryUtil.memUTF8
 import org.lwjgl.vulkan.*
 import org.lwjgl.vulkan.VK10.*
 import java.util.*
+import kotlin.collections.ArrayList
 
 /**
  * Describes a Vulkan device attached to an [instance] and a [physicalDevice].
@@ -335,6 +336,7 @@ open class VulkanDevice(val instance: VkInstance, val physicalDevice: VkPhysical
         @JvmStatic fun fromPhysicalDevice(instance: VkInstance, physicalDeviceFilter: (Int, DeviceData) -> Boolean,
                                           additionalExtensions: (VkPhysicalDevice) -> Array<String> = { arrayOf() },
                                           validationLayers: Array<String> = arrayOf(),
+                                          discoveredDevices: ArrayList<String>,
                                           headless: Boolean = false): VulkanDevice {
             return stackPush().use { stack ->
 
@@ -374,6 +376,7 @@ open class VulkanDevice(val instance: VkInstance, val physicalDevice: VkPhysical
                     }
 
                     deviceList.add(deviceData)
+                    discoveredDevices.add("Vulkan: "+deviceData.name)
                 }
 
                 deviceList.forEachIndexed { i, device ->

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -303,6 +303,8 @@ open class VulkanRenderer(hub: Hub,
 
     protected var instance: VkInstance
     protected var device: VulkanDevice
+    /** list of all vulkan devices discovered during VulkanDevice.fromPhysicalDevice() */
+    val discoveredDevices = ArrayList<String>(10)
 
     protected var debugCallbackHandle: Long = -1L
     protected var timestampQueryPool: Long = -1L
@@ -497,6 +499,7 @@ open class VulkanRenderer(hub: Hub,
             physicalDeviceFilter = { _, device -> "${device.vendor} ${device.name}".contains(System.getProperty("scenery.Renderer.Device", "DOES_NOT_EXIST"))},
             additionalExtensions = { physicalDevice -> hub.getWorkingHMDDisplay()?.getVulkanDeviceExtensions(physicalDevice)?.toTypedArray() ?: arrayOf() },
             validationLayers = requestedValidationLayers,
+            discoveredDevices = discoveredDevices,
             headless = headless)
 
         logger.debug("Device creation done")

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -495,6 +495,7 @@ open class VulkanRenderer(hub: Hub,
         val selectedSwapchain = swapchains.firstOrNull { (it.kotlin.companionObjectInstance as SwapchainParameters).usageCondition.invoke(embedIn) }
         val headless = (selectedSwapchain?.kotlin?.companionObjectInstance as? SwapchainParameters)?.headless ?: false
 
+        logger.debug("Will be matching device against: "+System.getProperty("scenery.Renderer.Device"))
         device = VulkanDevice.fromPhysicalDevice(instance,
             physicalDeviceFilter = { _, device -> "${device.vendor} ${device.name}".contains(System.getProperty("scenery.Renderer.Device", "DOES_NOT_EXIST"))},
             additionalExtensions = { physicalDevice -> hub.getWorkingHMDDisplay()?.getVulkanDeviceExtensions(physicalDevice)?.toTypedArray() ?: arrayOf() },


### PR DESCRIPTION
The `VulkanRenderer` backend now saves names of all vulkan devices it has iterated over when it was starting/created/initiated. The list is saved in `VulkanRenderer.discoveredDevices` array and is accessible to the outer world (and used inside sciview menu item that allows user to choose different renderer).

@skalarproduktraum please polish the code, I'm not a Kotlin guru and always forgetting language basics.