### PR TITLE
Fix maximum bounding box for Nodes with children

### DIFF
--- a/src/main/kotlin/graphics/scenery/Node.kt
+++ b/src/main/kotlin/graphics/scenery/Node.kt
@@ -522,7 +522,7 @@ open class Node(open var name: String = "Node") : Renderable, Serializable {
         }
 
         return children
-            .filter { it !is BoundingGrid  }.map { it.getMaximumBoundingBox() }
+            .filter { it !is BoundingGrid  }.map { it.getMaximumBoundingBox().translate(it.position) }
             .fold(boundingBox ?: OrientedBoundingBox(this, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f), { lhs, rhs -> lhs.expand(lhs, rhs) })
     }
 

--- a/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
+++ b/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
@@ -94,4 +94,11 @@ open class OrientedBoundingBox(val n: Node, val min: GLVector, val max: GLVector
     fun asWorld(): OrientedBoundingBox {
         return OrientedBoundingBox(n, n.worldPosition(min), n.worldPosition(max))
     }
+
+    /**
+     * Return an [OrientedBoundingBox] with min/max translated by offset vector.
+     */
+    fun translate(offset: GLVector): OrientedBoundingBox {
+        return OrientedBoundingBox(n, min + offset, max + offset)
+    }
 }

--- a/src/test/tests/graphics/scenery/tests/unit/NodeTests.kt
+++ b/src/test/tests/graphics/scenery/tests/unit/NodeTests.kt
@@ -424,4 +424,23 @@ class NodeTests {
         assertEquals(totalNodes, Node.discover(s, { it.visible == true }).size,
             "Total number of nodes seen should be $totalNodes, but is ")
     }
+
+    /**
+     * Tests bounding box for nodes with children
+     */
+    @Test
+    fun testMaximumBoundingBox() {
+        val s = Scene()
+        val parent = Group()
+        parent.position = GLVector(100f, 100f, 100f)
+        ( 0 until 2).forEach {i ->
+            val sphere = Sphere(5f, 3)
+            sphere.position = GLVector(-100f * ( i % 2 ), 0f, i.toFloat())
+            parent.addChild(sphere)
+        }
+
+        val boundingSphere = parent.getMaximumBoundingBox().getBoundingSphere()
+
+        assertEquals("Bounding sphere radius should be " + boundingSphere.radius + ", but is ", boundingSphere.radius, 53.662083f, 0.001f)
+    }
 }


### PR DESCRIPTION
The position of the children is defined w.r.t. the parent and must be used as an offset when finding the maximum bounding box.