### PR TITLE
Fix macOS JInput native loading

### DIFF
--- a/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
+++ b/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
@@ -140,8 +140,9 @@ open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
         }
 
         try {
-            logger.debug("Native JARs for JInput: ${getNativeJars("jinput-platform").joinToString(", ")}")
-            val path = extractLibrariesFromJar(getNativeJars("jinput-platform", hint = ExtractsNatives.getPlatform().getPlatformJinputLibraryName()), load = false)
+            val platformJars = getNativeJars("jinput-platform", hint = ExtractsNatives.getPlatform().getPlatformJinputLibraryName())
+            logger.debug("Native JARs for JInput: ${platformJars.joinToString(", ")}")
+            val path = extractLibrariesFromJar(platformJars, load = false)
             System.setProperty("net.java.games.input.librarypath", path)
 
             ControllerEnvironment.getDefaultEnvironment().controllers.forEach {


### PR DESCRIPTION
This PR fixes the loading of native libraries for JInput on macOS: By creating a copy of the `.jnilib` file as `.dylib` it'll make the library conform to the current JVM naming conventions.