### PR TITLE
Vulkan texture descriptor set improvements

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -130,8 +130,6 @@ open class VulkanObjectState : NodeMetadata {
 
                     val (ds, duration) = measureTimedValue { createOrUpdateTextureDescriptorSet(firstTextureName, passName, texturesForSet, dsl, device, descriptorPool) }
 
-                    logger.info("$passName: Creating DS for textures: ${texturesForSet.joinToString { it.key }}, took ${duration.inMilliseconds}")
-
                     texturesForSet.forEach { (textureName, _) ->
                         textureDescriptorSets[pass.passConfig.type.name to textureName] = ds
                     }
@@ -139,7 +137,7 @@ open class VulkanObjectState : NodeMetadata {
             }
         }
 
-        logger.info("DS update took ${updateDuration.inMilliseconds} ms")
+        logger.trace("DS update took {} ms", updateDuration.inMilliseconds)
     }
 
     fun clearTextureDescriptorSets() {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1031,6 +1031,7 @@ open class VulkanRenderer(hub: Hub,
                     if(reloaded) {
                         node.rendererMetadata()?.texturesToDescriptorSets(device,
                             renderpasses.filter { pass -> pass.value.passConfig.type != RenderConfigReader.RenderpassType.quad },
+                            node,
                             descriptorPool)
                     }
                 }
@@ -1152,6 +1153,7 @@ open class VulkanRenderer(hub: Hub,
         if(descriptorUpdated) {
             s.texturesToDescriptorSets(device,
                 renderpasses.filter { it.value.passConfig.type != RenderConfigReader.RenderpassType.quad },
+                node,
                 descriptorPool)
         }
 
@@ -2008,6 +2010,7 @@ open class VulkanRenderer(hub: Hub,
                         if(reloaded) {
                             it.rendererMetadata()?.texturesToDescriptorSets(device,
                                 renderpasses.filter { pass -> pass.value.passConfig.type != RenderConfigReader.RenderpassType.quad },
+                                it,
                                 descriptorPool)
                         }
 
@@ -2879,7 +2882,7 @@ open class VulkanRenderer(hub: Hub,
                     }
 
                     ds
-                }
+                }.distinctBy { it.id }
 
                 if(sets.any { it is DescriptorSet.DynamicSet && it.offset == BUFFER_OFFSET_UNINTIALISED }) {
                     logger.error("${node.name} has uninitialised UBO offset, skipping for rendering")

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
@@ -187,10 +187,11 @@ open class VulkanShaderModule(val device: VulkanDevice, entryPoint: String, sp: 
                     spec.binding = minOf(spec.binding, compiler.getDecoration(res.id, Decoration.DecorationBinding))
                 }
             } else {
-                logger.debug("Adding inputs UBO, ${res.name}/$name, set=$setId, type=${type.basetype}, a=$arraySize, type=$samplerType, dim=$samplerDim")
+                val bindingId = compiler.getDecoration(res.id, Decoration.DecorationBinding)
+                logger.debug("Adding inputs UBO, ${res.name}/$name, set=$setId, binding=$bindingId, type=${type.basetype}, a=$arraySize, type=$samplerType, dim=$samplerDim")
                 uboSpecs[name] = UBOSpec(name,
                     set = setId,
-                    binding = compiler.getDecoration(res.id, Decoration.DecorationBinding),
+                    binding = bindingId,
                     type = when(samplerDim) {
                         0 -> UBOSpecType.SampledImage1D
                         1 -> UBOSpecType.SampledImage2D

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeShaderFactory.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeShaderFactory.kt
@@ -170,10 +170,13 @@ open class VolumeShaderFactory : Shaders.ShaderFactory() {
             }
         }
 
-        val convertedSamplers = samplers.mapIndexed { i, sampler ->
-            "layout(set = ${descriptorSetOffset + 1 + i}, binding = 0) $sampler"
-//            "layout(set = ${descriptorSetOffset + 1}, binding = $i) $sampler"
-        }
+        val inputsAndSamplers = samplers.partition { it.contains(" Input") }
+        val convertedSamplers =
+            inputsAndSamplers.first.mapIndexed { i, sampler ->
+                "layout(set = ${descriptorSetOffset + 1 + i}, binding = 0) $sampler"
+            } + inputsAndSamplers.second.mapIndexed { i, sampler ->
+                "layout(set = ${descriptorSetOffset + 1 + inputsAndSamplers.first.size}, binding = $i) $sampler"
+            }
 
         val fullUniforms = uniforms.union(predefinedUniforms).sorted().toList()
         logger.debug("Adding ${uniforms.size} to uniforms struct (${fullUniforms.joinToString(", ")})")


### PR DESCRIPTION
This PR extends the handling of descriptor sets in such a way that multiple samplers can be contained in a single descriptor set, preventing the problem of descriptor set exhaustion on less tolerant/capable GPUs (e.g. Intel integrated ones).

It also introduces a per-test runtime limit for the ExampleRunner which can be adjusted by setting the system property `scenery.ExampleRunner.maxRuntimePerTest` to a amount of desired minutes. Default is 5 minutes.