### PR TITLE
POM: remove redundant version tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,6 @@
     <properties>
         <package-name>graphics.scenery</package-name>
 
-        <scijava.jvm.version>1.8</scijava.jvm.version>
         <javac.target>1.8</javac.target>
         <kotlin.version>1.4-M2</kotlin.version>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
@@ -125,6 +124,8 @@
         <msgpack-core.version>0.8.20</msgpack-core.version>
         <reflections.version>0.9.11</reflections.version>
         <spirvcrossj.version>0.7.0-1.1.106.0</spirvcrossj.version>
+
+        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 
         <lwjgl.natives>natives-${scijava.platform.family.long}</lwjgl.natives>
 
@@ -234,7 +235,6 @@
         <dependency>
             <groupId>org.joml</groupId>
             <artifactId>joml</artifactId>
-            <version>1.9.22</version>
         </dependency>
 
         <dependency>
@@ -406,7 +406,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
         </dependency>
 
         <dependency>
@@ -550,12 +549,10 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5</artifactId>
-            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-imglib2</artifactId>
-            <version>3.4.1</version>
         </dependency>
     </dependencies>
 
@@ -717,7 +714,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.5</version>
                 <configuration>
                     <destFile>${project.build.directory}/jacoco.exec</destFile>
                     <dataFile>${project.build.directory}/jacoco.exec</dataFile>


### PR DESCRIPTION
* remove all version tags for artifacts managed by `pom-scijava`
* remove hard-coded version pinning for `n5` artifacts
* override `jacoco-maven-plugin.version` property instead of hard-coding the version
* remove redundant `scijava.jvm.version` specified in parent POM