### PR TITLE
camera moves no longer bound to y-axis

### DIFF
--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -186,7 +186,8 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         behaviourMap.put("gamepad_camera_control", GamepadCameraControl("gamepad_camera_control", listOf(Component.Identifier.Axis.Z, Component.Identifier.Axis.RZ), { scene.findObserver() }, window.width, window.height))
         behaviourMap.put("gamepad_movement_control", GamepadMovementControl("gamepad_movement_control", listOf(Component.Identifier.Axis.X, Component.Identifier.Axis.Y), { scene.findObserver() }))
 
-        behaviourMap.put("select_command", SelectCommand("select_command", renderer, scene, { scene.findObserver() }))
+        //unused until some reasonable action (to the selection) would be provided
+        //behaviourMap.put("select_command", SelectCommand("select_command", renderer, scene, { scene.findObserver() }))
 
         behaviourMap.put("move_forward", MovementCommand("move_forward", "forward", { scene.findObserver() }, slowMovementSpeed))
         behaviourMap.put("move_back", MovementCommand("move_back", "back", { scene.findObserver() }, slowMovementSpeed))
@@ -215,7 +216,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         adder.put("gamepad_movement_control")
         adder.put("gamepad_camera_control")
 
-        adder.put("select_command", "double-click button1")
+        //adder.put("select_command", "double-click button1")
 
         adder.put("move_forward", "W")
         adder.put("move_left", "A")

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -158,7 +158,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
                     "- !mapping" + "\n" +
                     "  action: mouse_control" + "\n" +
                     "  contexts: [all]" + "\n" +
-                    "  triggers: [button1, G]" + "\n" +
+                    "  triggers: [button1, M]" + "\n" +
                     "- !mapping" + "\n" +
                     "  action: gamepad_movement_control" + "\n" +
                     "  contexts: [all]" + "\n" +
@@ -166,7 +166,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
                     "- !mapping" + "\n" +
                     "  action: gamepad_camera_control" + "\n" +
                     "  contexts: [all]" + "\n" +
-                    "  triggers: [P]" + "\n" +
+                    "  triggers: [G]" + "\n" +
                     "- !mapping" + "\n" +
                     "  action: scroll1" + "\n" +
                     "  contexts: [all]" + "\n" +

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -13,11 +13,14 @@ import org.scijava.ui.behaviour.BehaviourMap
 import org.scijava.ui.behaviour.InputTrigger
 import org.scijava.ui.behaviour.InputTriggerMap
 import org.scijava.ui.behaviour.io.InputTriggerConfig
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionBuilder
+import org.scijava.ui.behaviour.io.gui.VisualEditorPanel
 import org.scijava.ui.behaviour.io.yaml.YamlConfigIO
 import java.io.FileNotFoundException
 import java.io.FileReader
 import java.io.Reader
 import java.io.StringReader
+import javax.swing.JFrame
 
 /**
  * Input orchestrator for ClearGL windows
@@ -244,5 +247,24 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     override fun close() {
         logger.debug("Closing InputHandler")
         handler?.close()
+    }
+
+    fun openKeybindingsGuiEditor( editorTitle : String = "scenery's Key bindings editor" ): VisualEditorPanel {
+        //setup content for the Visual Editor
+        val cdb = CommandDescriptionBuilder()
+        behaviourMap.keys().forEach { b -> cdb.addCommand(b,"all","") }
+        val editorPanel = VisualEditorPanel(config, cdb.get())
+
+        //show the Editor
+        val frame = JFrame(editorTitle)
+        frame.contentPane.add(editorPanel)
+        frame.pack()
+        frame.isVisible = true
+
+        //process "Apply" button of the editor
+        editorPanel.addConfigCommittedListener { config.resetThisMapFor( inputMap, "all" ) }
+
+        //return reference on the Editor, so that users can hook own extra stuff
+        return editorPanel
     }
 }

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -103,6 +103,15 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     }
 
     /**
+     * Returns *a copy of* the behaviours currently
+     * registered with this {@link InputHandler}.
+     */
+    fun getAllBehaviours(): Set<String> {
+        return behaviourMap.keys()
+        //NB: behaviourMap.keys() returns a copy of its keys
+    }
+
+    /**
      * Adds a key binding for a given behaviour
      *
      * @param[behaviourName] The behaviour to add a key binding for
@@ -115,7 +124,17 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     }
 
     /**
-     * Returns all the currently set key bindings
+     * Returns *a copy of* all keys {@link InputTrigger}s associated
+     * with the given behaviour
+     */
+    fun getKeyBindings(behaviourName: String): Set<InputTrigger> {
+        return config.getInputs( behaviourName, "all" )
+        //NB: this assumes that 'config' and 'inputMap' are well synchronized,
+        //    otherwise we would have to read 'inputMap' and build the set ourselves
+    }
+
+    /**
+     * Returns *a copy of* all the currently set key bindings
      *
      * @return Map of all currently configured key bindings.
      */

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -119,7 +119,9 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      */
     fun addKeyBinding(behaviourName: String, vararg keys: String) {
         keys.forEach { key ->
-            config.inputTriggerAdder(inputMap, "all").put(behaviourName, key)
+            val trigger = InputTrigger.getFromString( key )
+            inputMap.put( trigger, behaviourName )
+            config.add( trigger, behaviourName, "all" )
         }
     }
 
@@ -138,7 +140,6 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      *
      * @return Map of all currently configured key bindings.
      */
-    @Suppress("unused")
     fun getAllBindings(): Map<InputTrigger, Set<String>> {
         return inputMap.allBindings
     }
@@ -148,9 +149,11 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      *
      * @param[behaviourName] The behaviour to remove the key binding for.
      */
-    @Suppress("unused")
     fun removeKeyBinding(behaviourName: String) {
-        config.inputTriggerAdder(inputMap, "all").put(behaviourName)
+        config.getInputs( behaviourName, "all" ).forEach { inputTrigger ->
+            inputMap.remove( inputTrigger, behaviourName )
+            config.remove( inputTrigger, behaviourName, "all" )
+        }
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
@@ -145,7 +145,8 @@ open class ArcballCameraControl(private val name: String, private val n: () -> C
 
             distance = (target.invoke() - node.position).length()
             node.target = target.invoke()
-            node.rotation = pitchQ.mul(node.rotation).mul(yawQ).normalize()
+            node.rotation = pitchQ.mul(node.rotation).normalize()
+            node.rotation =   yawQ.mul(node.rotation).normalize()
             node.position = target.invoke() + node.forward * distance * (-1.0f)
 
             node.lock.unlock()

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
@@ -164,10 +164,11 @@ open class ArcballCameraControl(private val name: String, private val n: () -> C
      * @param[y] unused
      */
     override fun scroll(wheelRotation: Double, isHorizontal: Boolean, x: Int, y: Int) {
-        if (isHorizontal) {
+        if (isHorizontal || node == null) {
             return
         }
 
+        distance = (target.invoke() - node!!.position).length()
         distance += wheelRotation.toFloat() * scrollSpeedMultiplier
 
         if (distance >= maximumDistance) distance = maximumDistance

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
@@ -128,15 +128,15 @@ open class ArcballCameraControl(private val name: String, private val n: () -> C
             }
 
             var xoffset: Float = (x - lastX).toFloat()
-            var yoffset: Float = (lastY - y).toFloat()
+            var yoffset: Float = (y - lastY).toFloat()
 
             lastX = x
             lastY = y
 
             xoffset *= mouseSpeedMultiplier
-            yoffset *= -mouseSpeedMultiplier
+            yoffset *= mouseSpeedMultiplier
 
-            val frameYaw = (xoffset) / 180.0f * Math.PI.toFloat()
+            val frameYaw = xoffset / 180.0f * Math.PI.toFloat()
             val framePitch = yoffset / 180.0f * Math.PI.toFloat()
 
             // first calculate the total rotation quaternion to be applied to the camera

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/FPSCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/FPSCameraControl.kt
@@ -98,7 +98,8 @@ open class FPSCameraControl(private val name: String, private val n: () -> Camer
 
         val yawQ = Quaternionf().rotateXYZ(0.0f, frameYaw/180.0f*Math.PI.toFloat(), 0.0f)
         val pitchQ = Quaternionf().rotateXYZ(framePitch/180.0f*Math.PI.toFloat(), 0.0f, 0.0f)
-        node?.rotation = pitchQ.mul(node?.rotation).mul(yawQ).normalize()
+        node?.rotation = pitchQ.mul(node?.rotation).normalize()
+        node?.rotation = yawQ.mul(node?.rotation).normalize()
 
         node?.lock?.unlock()
     }

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/FPSCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/FPSCameraControl.kt
@@ -40,6 +40,9 @@ open class FPSCameraControl(private val name: String, private val n: () -> Camer
         node?.targeted = false
     }
 
+    /** multiplier for mouse movement */
+    var mouseSpeedMultiplier = 0.1f
+
     /**
      * FPS-style camera control, supplying a Camera via a Java [Supplier] lambda.
      */
@@ -90,8 +93,8 @@ open class FPSCameraControl(private val name: String, private val n: () -> Camer
         lastX = x
         lastY = y
 
-        xoffset *= 0.1f
-        yoffset *= 0.1f
+        xoffset *= mouseSpeedMultiplier
+        yoffset *= mouseSpeedMultiplier
 
         val frameYaw = xoffset
         val framePitch = yoffset

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MovementCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MovementCommand.kt
@@ -65,10 +65,10 @@ open class MovementCommand(private val name: String, private val direction: Stri
                 when (direction) {
                     "forward" -> node.position = node.position + axisProvider.forward * speed * axisProvider.deltaT
                     "back" -> node.position = node.position - axisProvider.forward * speed * axisProvider.deltaT
-                    "left" -> node.position = node.position - axisProvider.forward.cross(axisProvider.up).normalize() * speed * axisProvider.deltaT
-                    "right" -> node.position = node.position + axisProvider.forward.cross(axisProvider.up).normalize() * speed * axisProvider.deltaT
+                    "left" -> node.position = node.position - axisProvider.right * speed * axisProvider.deltaT
+                    "right" -> node.position = node.position + axisProvider.right * speed * axisProvider.deltaT
                     "up" -> node.position = node.position + axisProvider.up * speed * axisProvider.deltaT
-                    "down" -> node.position = node.position + axisProvider.up * -1.0f * speed * axisProvider.deltaT
+                    "down" -> node.position = node.position - axisProvider.up * speed * axisProvider.deltaT
                 }
 
                 node.lock.unlock()


### PR DESCRIPTION
Hi,
the original rotation implemented in both ArcBall and FPS camera moves is a composition of two moves: vertical along view x-axis and horizontal along y-axis. Original code, however had the latter acting upon y-axis that got tilted as part of the first vertical move. The proposed code does independent x- and y- axes rotation.

The dependecy/tilting of y-axis rendered cam moves schizofrenic:
- when object is "up front" - no vertical (pitch) cam move, the horizontal mouse move showed the expected horizontal (yaw) move of the cam/object
- when object is 90deg "pitched", the horizontal mouse move rendered into *rotation* along the forward-view axis (the tilted y)

Some views were impossible to achive.. .this is perhaps the glimball lock (mispeled most likely)

(I'm now working on more UX commits on the SciView side to complement this, stay tuned :-)
Vlado