### PR TITLE
inputHandler add ons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,8 @@
         <dokka.version>0.10.1</dokka.version>
         <dokka.skip>true</dokka.skip>
 
+        <ui-behaviour.version>2.0.2</ui-behaviour.version>
+
         <bigvolumeviewer.version>0.1.8</bigvolumeviewer.version>
         <ffmpeg.version>4.2.1-1.5.2</ffmpeg.version>
         <jackson-dataformat-msgpack.version>0.8.20</jackson-dataformat-msgpack.version>

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -285,9 +285,10 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         frame.isVisible = true
 
         //process "Apply" button of the editor
-        editorPanel.addConfigCommittedListener {
-            Behaviours(inputMap,behaviourMap,config,"all").updateKeyConfig(config)
-        }
+        editorPanel.configCommittedListeners().add(
+            VisualEditorPanel.ConfigChangeListener {
+                Behaviours(inputMap,behaviourMap,config,"all").updateKeyConfig(config)
+            } )
 
         //return reference on the Editor, so that users can hook own extra stuff
         return editorPanel

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -16,6 +16,7 @@ import org.scijava.ui.behaviour.io.InputTriggerConfig
 import org.scijava.ui.behaviour.io.gui.CommandDescriptionBuilder
 import org.scijava.ui.behaviour.io.gui.VisualEditorPanel
 import org.scijava.ui.behaviour.io.yaml.YamlConfigIO
+import org.scijava.ui.behaviour.util.Behaviours
 import java.io.FileNotFoundException
 import java.io.FileReader
 import java.io.Reader
@@ -284,7 +285,9 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         frame.isVisible = true
 
         //process "Apply" button of the editor
-        editorPanel.addConfigCommittedListener { config.resetThisMapFor( inputMap, "all" ) }
+        editorPanel.addConfigCommittedListener {
+            Behaviours(inputMap,behaviourMap,config,"all").updateKeyConfig(config)
+        }
 
         //return reference on the Editor, so that users can hook own extra stuff
         return editorPanel

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -186,7 +186,8 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         behaviourMap.put("gamepad_camera_control", GamepadCameraControl("gamepad_camera_control", listOf(Component.Identifier.Axis.Z, Component.Identifier.Axis.RZ), { scene.findObserver() }, window.width, window.height))
         behaviourMap.put("gamepad_movement_control", GamepadMovementControl("gamepad_movement_control", listOf(Component.Identifier.Axis.X, Component.Identifier.Axis.Y), { scene.findObserver() }))
 
-        behaviourMap.put("select_command", SelectCommand("select_command", renderer, scene, { scene.findObserver() }))
+        //unused until some reasonable action (to the selection) would be provided
+        //behaviourMap.put("select_command", SelectCommand("select_command", renderer, scene, { scene.findObserver() }))
 
         behaviourMap.put("move_forward", MovementCommand("move_forward", "forward", { scene.findObserver() }, slowMovementSpeed))
         behaviourMap.put("move_back", MovementCommand("move_back", "back", { scene.findObserver() }, slowMovementSpeed))
@@ -215,7 +216,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
         adder.put("gamepad_movement_control")
         adder.put("gamepad_camera_control")
 
-        adder.put("select_command", "double-click button1")
+        //adder.put("select_command", "double-click button1")
 
         adder.put("move_forward", "W")
         adder.put("move_left", "A")

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -158,7 +158,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
                     "- !mapping" + "\n" +
                     "  action: mouse_control" + "\n" +
                     "  contexts: [all]" + "\n" +
-                    "  triggers: [button1, G]" + "\n" +
+                    "  triggers: [button1, M]" + "\n" +
                     "- !mapping" + "\n" +
                     "  action: gamepad_movement_control" + "\n" +
                     "  contexts: [all]" + "\n" +
@@ -166,7 +166,7 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
                     "- !mapping" + "\n" +
                     "  action: gamepad_camera_control" + "\n" +
                     "  contexts: [all]" + "\n" +
-                    "  triggers: [P]" + "\n" +
+                    "  triggers: [G]" + "\n" +
                     "- !mapping" + "\n" +
                     "  action: scroll1" + "\n" +
                     "  contexts: [all]" + "\n" +

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -13,11 +13,14 @@ import org.scijava.ui.behaviour.BehaviourMap
 import org.scijava.ui.behaviour.InputTrigger
 import org.scijava.ui.behaviour.InputTriggerMap
 import org.scijava.ui.behaviour.io.InputTriggerConfig
+import org.scijava.ui.behaviour.io.gui.CommandDescriptionBuilder
+import org.scijava.ui.behaviour.io.gui.VisualEditorPanel
 import org.scijava.ui.behaviour.io.yaml.YamlConfigIO
 import java.io.FileNotFoundException
 import java.io.FileReader
 import java.io.Reader
 import java.io.StringReader
+import javax.swing.JFrame
 
 /**
  * Input orchestrator for ClearGL windows
@@ -244,5 +247,24 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     override fun close() {
         logger.debug("Closing InputHandler")
         handler?.close()
+    }
+
+    fun openKeybindingsGuiEditor( editorTitle : String = "scenery's Key bindings editor" ): VisualEditorPanel {
+        //setup content for the Visual Editor
+        val cdb = CommandDescriptionBuilder()
+        behaviourMap.keys().forEach { b -> cdb.addCommand(b,"all","") }
+        val editorPanel = VisualEditorPanel(config, cdb.get())
+
+        //show the Editor
+        val frame = JFrame(editorTitle)
+        frame.contentPane.add(editorPanel)
+        frame.pack()
+        frame.isVisible = true
+
+        //process "Apply" button of the editor
+        editorPanel.addConfigCommittedListener { config.resetThisMapFor( inputMap, "all" ) }
+
+        //return reference on the Editor, so that users can hook own extra stuff
+        return editorPanel
     }
 }

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -103,6 +103,15 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     }
 
     /**
+     * Returns *a copy of* the behaviours currently
+     * registered with this {@link InputHandler}.
+     */
+    fun getAllBehaviours(): Set<String> {
+        return behaviourMap.keys()
+        //NB: behaviourMap.keys() returns a copy of its keys
+    }
+
+    /**
      * Adds a key binding for a given behaviour
      *
      * @param[behaviourName] The behaviour to add a key binding for
@@ -115,7 +124,17 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
     }
 
     /**
-     * Returns all the currently set key bindings
+     * Returns *a copy of* all keys {@link InputTrigger}s associated
+     * with the given behaviour
+     */
+    fun getKeyBindings(behaviourName: String): Set<InputTrigger> {
+        return config.getInputs( behaviourName, "all" )
+        //NB: this assumes that 'config' and 'inputMap' are well synchronized,
+        //    otherwise we would have to read 'inputMap' and build the set ourselves
+    }
+
+    /**
+     * Returns *a copy of* all the currently set key bindings
      *
      * @return Map of all currently configured key bindings.
      */

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -119,7 +119,9 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      */
     fun addKeyBinding(behaviourName: String, vararg keys: String) {
         keys.forEach { key ->
-            config.inputTriggerAdder(inputMap, "all").put(behaviourName, key)
+            val trigger = InputTrigger.getFromString( key )
+            inputMap.put( trigger, behaviourName )
+            config.add( trigger, behaviourName, "all" )
         }
     }
 
@@ -138,7 +140,6 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      *
      * @return Map of all currently configured key bindings.
      */
-    @Suppress("unused")
     fun getAllBindings(): Map<InputTrigger, Set<String>> {
         return inputMap.allBindings
     }
@@ -148,9 +149,11 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      *
      * @param[behaviourName] The behaviour to remove the key binding for.
      */
-    @Suppress("unused")
     fun removeKeyBinding(behaviourName: String) {
-        config.inputTriggerAdder(inputMap, "all").put(behaviourName)
+        config.getInputs( behaviourName, "all" ).forEach { inputTrigger ->
+            inputMap.remove( inputTrigger, behaviourName )
+            config.remove( inputTrigger, behaviourName, "all" )
+        }
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -106,8 +106,8 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      * Returns *a copy of* the behaviours currently
      * registered with this {@link InputHandler}.
      */
-    fun getAllBehaviours(): Set<String> {
-        return behaviourMap.keys()
+    fun getAllBehaviours(): List<String> {
+        return behaviourMap.keys().sorted()
         //NB: behaviourMap.keys() returns a copy of its keys
     }
 


### PR DESCRIPTION
here's a couple of things I would really use to have for SciView:

- the `InputHandler.openKeybindingsGuiEditor()` that opens (also in scenery, in theory) the key bindings GUI editor
- the `getAllBehaviours()` listing/overview method and `getKeyBindings()` query method
- also `removeKeyBinding()` (and any binding updating method in `INputHandler`) are maintaining the synchronization of ui-behaviours `InputTriggerMapping` and `InputTriggerConfig` explicitly and on its own (....and are now functional)
- these items need the PRs from ui-behaviour... this PR will not compile without it

Plus, I noticed overlapping key bindings:
- gamepad_cam_control was using 'P' just like screenshots, I remapped that to 'G' (for *G*amepad)
- but 'G' was used for mouse_control, so I remapped it to 'M' (for *M*ouse)

Also noticed that scenery's "select_command" gets no function to process the result of ray-tracing,
so I disabled/commented-out that behaviour.