### PR TITLE
PhantomReference cache for textures

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/GPUResourceFinalizer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/GPUResourceFinalizer.kt
@@ -1,0 +1,53 @@
+package graphics.scenery.backends
+
+import graphics.scenery.utils.LazyLogger
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
+
+/**
+ * Resource finalizer class for objects allocated on the GPU that might need
+ * additional cleanup after getting picked up by the GC.
+ *
+ * @author Ulrik Guenther <hello@ulrik.is>
+ */
+class GPUResourceFinalizer<T>(val resource: T, val type: Class<*>, val queue: ReferenceQueue<T>) : PhantomReference<T>(resource, queue) {
+    private val logger by LazyLogger()
+
+    /**
+     * Finalizes the resources of [resource] with the finalizer for the specific [type] used.
+     * The finalizer has to be registered before with [registerFinalizer].
+     */
+    fun finalizeResources() {
+        logger.debug("Finalising resources of {}", resource)
+
+        val finalizer = finalizers[type]
+        if(finalizer == null) {
+            logger.error("Could not find GPU resource finalizer for ${type.simpleName}")
+        } else {
+            finalizer.invoke(resource as Any)
+        }
+    }
+
+    /**
+     * Companion object for [GPUResourceFinalizer].
+     */
+    companion object {
+        private var finalizers = HashMap<Class<*>, (Any) -> Unit>()
+
+        /**
+         * Registers a new [finalizer] for the [type] given.
+         */
+        @Synchronized @JvmStatic
+        fun registerFinalizer(type: Class<*>, finalizer: (Any) -> Unit) {
+            finalizers[type] = finalizer
+        }
+
+        /**
+         * Removes the finalizer for [type].
+         */
+        @Synchronized @JvmStatic
+        fun removeFinalizer(type: Class<*>) {
+            finalizers.remove(type)
+        }
+    }
+}

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
@@ -314,7 +314,9 @@ open class VulkanBuffer(val device: VulkanDevice, var size: Long,
             return
         }
 
-        logger.trace("Closing buffer $this (${vulkanBuffer.toHexString()}, mem=${memory.toHexString()}...")
+        if(logger.isDebugEnabled) {
+            logger.debug("Closing buffer $this (${vulkanBuffer.toHexString()}, mem=${memory.toHexString()}) of size ${String.format("%.2f", size.toFloat() / 1024.0f / 1024.0f)}M...")
+        }
 
         if(mapped) {
             unmap()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -35,6 +35,8 @@ import org.lwjgl.vulkan.VK10.*
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferByte
 import java.io.File
+import java.lang.ref.PhantomReference
+import java.lang.ref.ReferenceQueue
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.IntBuffer
@@ -385,7 +387,7 @@ open class VulkanRenderer(hub: Hub,
                               var ShaderProperties: VulkanBuffer)
     protected var buffers: DefaultBuffers
     protected var defaultUBOs = ConcurrentHashMap<String, VulkanUBO>()
-    protected var textureCache = ConcurrentHashMap<Texture, VulkanTexture>()
+    protected var textureCache = ConcurrentHashMap<Texture, PhantomReference<VulkanTexture>>()
     protected var defaultTextures = ConcurrentHashMap<String, VulkanTexture>()
     protected var descriptorSetLayouts = ConcurrentHashMap<String, Long>()
     protected var descriptorSets = ConcurrentHashMap<String, Long>()
@@ -402,6 +404,8 @@ open class VulkanRenderer(hub: Hub,
 
     private var renderConfig: RenderConfigReader.RenderConfig
     private var flow: List<String> = listOf()
+
+    private val textureResourceQueue = ReferenceQueue<VulkanTexture>()
 
     private val vulkanProjectionFix =
         Matrix4f(
@@ -705,8 +709,26 @@ open class VulkanRenderer(hub: Hub,
 
         geometryPool = VulkanBufferPool(device, usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT or VK_BUFFER_USAGE_INDEX_BUFFER_BIT or VK_BUFFER_USAGE_TRANSFER_DST_BIT)
 
+        registerResourceFinalizers()
+
         initialized = true
         logger.info("Renderer initialisation complete.")
+    }
+
+    fun registerResourceFinalizers() {
+        GPUResourceFinalizer.registerFinalizer(VulkanTexture::class.java) { resource ->
+            (resource as? VulkanTexture)?.close()
+        }
+
+        GPUResourceFinalizer.registerFinalizer(VulkanBuffer::class.java) { resource ->
+            (resource as? VulkanBuffer)?.let {
+                if(it.suballocation != null) {
+                    it.suballocation?.free = true
+                } else {
+                    it.close()
+                }
+            }
+        }
     }
 
     // source: http://stackoverflow.com/questions/34697828/parallel-operations-on-kotlin-collections
@@ -1152,7 +1174,7 @@ open class VulkanRenderer(hub: Hub,
 
             logger.debug("${node.name} will have $type texture from $texture in slot $slot")
 
-            if (!textureCache.containsKey(texture)) {
+            if (!textureCache.containsKey(texture) || texture is UpdatableTexture) {
                 try {
                     logger.debug("Loading texture {} for {}", texture, node.name)
 
@@ -1185,14 +1207,12 @@ open class VulkanRenderer(hub: Hub,
                     // add new texture to texture list and cache, and close old texture
                     s.textures[type] = t
 
-                    if(texture !is UpdatableTexture) {
-                        textureCache[texture] = t
-                    }
+                    textureCache[texture] = GPUResourceFinalizer(t, VulkanTexture::class.java, textureResourceQueue)
                 } catch (e: Exception) {
                     logger.warn("Could not load texture for ${node.name}: $e")
                 }
             } else {
-                s.textures[type] = textureCache[texture]!!
+                s.textures[type] = (textureCache[texture] as GPUResourceFinalizer<VulkanTexture>).resource
             }
         }
 
@@ -1917,6 +1937,13 @@ open class VulkanRenderer(hub: Hub,
 
         val presentDuration = System.nanoTime() - startPresent
         stats?.add("Renderer.viewportSubmitAndPresent", presentDuration)
+
+        var reference = textureResourceQueue.poll()
+        while(reference != null) {
+            (reference as? GPUResourceFinalizer<*>)?.finalizeResources()
+            reference.clear()
+            reference = textureResourceQueue.poll()
+        }
 
         firstImageReady = true
     }
@@ -3512,7 +3539,7 @@ open class VulkanRenderer(hub: Hub,
         logger.debug("Cleaning texture cache...")
         textureCache.forEach {
             logger.debug("Cleaning ${it.key}...")
-            it.value.close()
+            (it.value as? GPUResourceFinalizer<*>)?.finalizeResources()
         }
 
         logger.debug("Closing nodes...")

--- a/src/test/tests/graphics/scenery/tests/examples/basic/SponzaExample.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/basic/SponzaExample.kt
@@ -8,6 +8,7 @@ import org.joml.Vector4f
 import org.junit.Test
 import org.scijava.ui.behaviour.ClickBehaviour
 import kotlin.concurrent.thread
+import kotlin.math.cos
 
 /**
  * Demo loading the Sponza Model, demonstrating multiple moving lights
@@ -31,8 +32,8 @@ class SponzaExample : SceneryBase("SponzaExample", windowWidth = 1280, windowHei
             scene.addChild(this)
         }
 
-        val lights = (0 until 1).map {
-            Box(Vector3f(0.1f, 0.1f, 0.1f))
+        val lights = (0 until 128).map {
+            Icosphere(0.1f, 1)
         }.map {
             it.position = Vector3f(
                 Random.randomFromRange(-6.0f, 6.0f),
@@ -42,7 +43,7 @@ class SponzaExample : SceneryBase("SponzaExample", windowWidth = 1280, windowHei
 
             it.material.diffuse = Random.random3DVectorFromRange(0.1f, 0.9f)
 
-            val light = PointLight(radius = Random.randomFromRange(5.5f, 50.0f))
+            val light = PointLight(radius = Random.randomFromRange(1.0f, 8.0f))
             light.emissionColor = it.material.diffuse
             light.intensity = Random.randomFromRange(0.1f, 0.5f)
 
@@ -54,7 +55,7 @@ class SponzaExample : SceneryBase("SponzaExample", windowWidth = 1280, windowHei
 
         val mesh = Mesh()
         with(mesh) {
-            readFromOBJ(getDemoFilesPath() + "/sponza.obj", importMaterials = false)
+            readFromOBJ(getDemoFilesPath() + "/sponza.obj", importMaterials = true)
             rotation.rotateY(Math.PI.toFloat() / 2.0f)
             scale = Vector3f(0.01f, 0.01f, 0.01f)
             name = "Sponza Mesh"
@@ -72,19 +73,19 @@ class SponzaExample : SceneryBase("SponzaExample", windowWidth = 1280, windowHei
 
         thread {
             var ticks = 0L
-            while (true) {
-                if(movingLights) {
+
+            while(running) {
+                if (movingLights) {
                     lights.mapIndexed { i, light ->
                         val phi = (Math.PI * 2.0f * ticks / 1000.0f) % (Math.PI * 2.0f)
 
                         light.position = Vector3f(
                             light.position.x(),
-                            5.0f * Math.cos(phi + (i * 0.5f)).toFloat() + 5.2f,
+                            5.0f * cos(phi + (i * 0.5f)).toFloat() + 5.2f,
                             light.position.z())
 
                         light.children.forEach { it.needsUpdateWorld = true }
                     }
-
                     ticks++
                 }
 

--- a/src/test/tests/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
+++ b/src/test/tests/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
@@ -165,6 +165,8 @@ class ExampleRunner {
                     logger.info("${example.simpleName} closed ($renderer ran ${i + 1}/${examples.size} so far).")
 
                     assertFalse(failure, "ExampleRunner aborted due to exceptions in tests or exceeding maximum per-test runtime of $maxRuntimePerTest.")
+
+                    System.gc()
                 }
             }
         }

--- a/src/test/tests/graphics/scenery/tests/unit/CylinderTests.kt
+++ b/src/test/tests/graphics/scenery/tests/unit/CylinderTests.kt
@@ -4,6 +4,7 @@ import graphics.scenery.Cylinder
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
 import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.extensions.toFloatArray
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -20,22 +21,27 @@ class CylinderTests {
     fun testCreation() {
         logger.info("Testing Cylinder creating and bounding box calculation ...")
         val s = Scene()
-        val radius = Random.randomFromRange(0.1f, 100.0f)
-        val height = Random.randomFromRange(0.1f, 100.0f)
-        val segments = kotlin.random.Random.nextInt(2, 20)
-        val epsilon = 0.0001f
+        repeat(10000) {
+            val radius = Random.randomFromRange(0.1f, 100.0f)
+            val height = Random.randomFromRange(0.1f, 100.0f)
+            val segments = kotlin.random.Random.nextInt(2, 20)
+            val epsilon = 0.0001f
 
-        val b = Cylinder(radius, height, segments)
-        s.addChild(b)
+            val b = Cylinder(radius, height, segments)
+            s.addChild(b)
 
-        val bb = b.boundingBox
-        assertNotNull(bb)
-        assertTrue(bb.min.x() >= -radius - epsilon)
-        assertTrue(bb.min.y() >= 0.0f - epsilon)
-        assertTrue(bb.min.z() >= -radius - epsilon)
+            val bb = b.boundingBox
+            assertNotNull(bb)
+            assertTrue(bb.min.x() >= -radius - epsilon)
+            assertTrue(bb.min.y() >= 0.0f - epsilon)
+            assertTrue(bb.min.z() >= -radius - epsilon)
 
-        assertTrue(bb.max.x() <= radius + epsilon)
-        assertTrue(bb.max.y() <= height + epsilon)
-        assertTrue(bb.max.z() <= radius + epsilon)
+            assertTrue(bb.max.x() <= radius + epsilon)
+            assertTrue(bb.max.y() <= height + epsilon)
+            assertTrue(bb.max.z() <= radius + epsilon)
+
+            assertTrue(bb.min.toFloatArray().all { it.isFinite() && !it.isNaN() })
+            assertTrue(bb.max.toFloatArray().all { it.isFinite() && !it.isNaN() })
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a PhantomReference-based cache for textures. The intent is to maximise texture re-use, while still being able to deallocate them on the GPU when GC catches them.