### PR TITLE
Rendering order

### DIFF
--- a/src/main/kotlin/graphics/scenery/InfinitePlane.kt
+++ b/src/main/kotlin/graphics/scenery/InfinitePlane.kt
@@ -7,7 +7,7 @@ import graphics.scenery.backends.Shaders
  *
  * @author Ulrik Guenther <hello@ulrik.is>
  */
-class InfinitePlane : Mesh("InfinitePlane"), DisableFrustumCulling {
+class InfinitePlane : Mesh("InfinitePlane"), DisableFrustumCulling, RenderingOrder {
     /**
      * Enum class to define the grid type.
      */
@@ -20,6 +20,9 @@ class InfinitePlane : Mesh("InfinitePlane"), DisableFrustumCulling {
     /** [Type] of the plane, can be a normal grid, a blueprint grid, or a checkerboard. */
     @ShaderProperty
     var type = Type.Grid
+
+    /** Infinite planes need to be rendered last */
+    override var renderingOrder = Int.MAX_VALUE
 
     init {
         vertices = BufferUtils.allocateFloatAndPut(FloatArray(6*3))

--- a/src/main/kotlin/graphics/scenery/RenderingOrder.kt
+++ b/src/main/kotlin/graphics/scenery/RenderingOrder.kt
@@ -1,0 +1,5 @@
+package graphics.scenery
+
+interface RenderingOrder {
+    var renderingOrder: Int
+}

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -1769,10 +1769,12 @@ open class OpenGLRenderer(hub: Hub,
                 }
 
                 val actualObjects = if(pass.passConfig.type == RenderConfigReader.RenderpassType.geometry) {
-                    sceneObjects.filter { it !is Light }
+                    sceneObjects.filter { it !is Light }.toMutableList()
                 } else {
-                    sceneObjects.filter { it is Light }
+                    sceneObjects.filter { it is Light }.toMutableList()
                 }
+
+                actualObjects.sortBy { (it as? RenderingOrder)?.renderingOrder }
 
                 var currentShader: OpenGLShaderProgram? = null
 

--- a/src/main/resources/graphics/scenery/backends/shaders/InfiniteGrid.frag
+++ b/src/main/resources/graphics/scenery/backends/shaders/InfiniteGrid.frag
@@ -100,7 +100,8 @@ void main() {
 //    float spotlight = 1.0;
 
     FragColor = color * spotlight;
-    if(FragColor.a == 0.0) {
+
+    if(FragColor.a < 0.01f) {
         discard;
     }
 }

--- a/src/main/resources/graphics/scenery/volumes/BDVVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/BDVVolume.frag
@@ -113,14 +113,14 @@ void main()
 	// -------------------------------------------------------
 
 
-	vec4 startNDC = Vertex.MVP * vec4(wfront.xyz + tnear * direc.xyz, 1.0);
+	vec4 startNDC = Vertex.MVP * vec4(wfront.xyz, 1.0);
 	startNDC *= 1.0/startNDC.w;
 
-	#ifndef OPENGL
+#ifndef OPENGL
 	float currentSceneDepth = texture(InputZBuffer, depthUV).r;
-	#else
+#else
 	float currentSceneDepth = texture(InputZBuffer, depthUV).r * 2.0 - 1.0;
-	#endif
+#endif
 
 //	if(startNDC.z > currentSceneDepth && tnear > 0.0f) {
 //		// for debugging, green = occluded by existing scene geometry
@@ -130,7 +130,7 @@ void main()
 //		return;
 //	}
 //
-	gl_FragDepth = startNDC.z;
+	gl_FragDepth = startNDC.w;
 
 	if ( tnear < tfar )
 	{


### PR DESCRIPTION
Introduces RenderingOrder interface in order to correctly render transparent objects and floors etc.

Fixes second part of https://github.com/scenerygraphics/sciview/issues/301