### PR TITLE
Ribbon position

### DIFF
--- a/src/main/kotlin/graphics/scenery/Axis.kt
+++ b/src/main/kotlin/graphics/scenery/Axis.kt
@@ -64,7 +64,7 @@ class Axis(positions: List<Vector3f?>) {
         /**
          * Returns the centroid of a given list of points.
          */
-        private fun getCentroid(list: List<Vector3f>): Vector3f {
+         fun getCentroid(list: List<Vector3f>): Vector3f {
             return Vector3f(list.fold(0f) { acc, next -> acc + next.x() } / list.size,
                     list.fold(0f) { acc, next -> acc + next.y() } / list.size,
                     list.fold(0f) { acc, next -> acc + next.z() } / list.size)

--- a/src/main/kotlin/graphics/scenery/RibbonDiagram.kt
+++ b/src/main/kotlin/graphics/scenery/RibbonDiagram.kt
@@ -109,7 +109,9 @@ class RibbonDiagram(val protein: Protein, private val displaySS: Boolean = false
 
         val subParent = Mesh("SubProtein")
 
-        val splinePoints = spline.splinePoints()
+        val centroid = Axis.LeastSquares.getCentroid(spline.splinePoints())
+
+        val splinePoints = spline.splinePoints().map{ it.sub(centroid) }
 
         val rectangle = ArrayList<Vector3f>(4)
         rectangle.add(Vector3f(0.9f, 0f, 0f))

--- a/src/test/kotlin/graphics/scenery/tests/examples/advanced/RibbonRainbowExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/advanced/RibbonRainbowExample.kt
@@ -24,7 +24,7 @@ class RainbowRibbonExample: SceneryBase("RainbowRibbon", windowWidth = 1280, win
 
         val rowSize = 20f
 
-        val protein = Protein.fromID("5mbn")
+        val protein = Protein.fromID("6jmd")
 
         val ribbon = RibbonDiagram(protein)
 


### PR DESCRIPTION
Positions the ribbon to the origin by default. Might be useful for the workshop as sometimes coordinates in PDBs are, for whatever reason, translated to somewhere on mars. Now our users will see the protein in front of them