### PR TITLE
VolumeManager/Volume: Fix issue with compute shaders

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -179,7 +179,15 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             hub.remove(vm)
         }
 
-        volumeManager = hub.add(VolumeManager(hub))
+        volumeManager = if(vm != null) {
+            hub.add(VolumeManager(hub, vm.useCompute, vm.customSegments, vm.customBindings))
+        } else {
+            hub.add(VolumeManager(hub))
+        }
+        vm?.customTextures?.forEach {
+            volumeManager.customTextures.add(it)
+            volumeManager.material.textures[it] = vm.material.textures[it]!!
+        }
         volumeManager.add(this)
         volumes.forEach {
             volumeManager.add(it)

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
@@ -161,11 +161,15 @@ class VolumeManager(
     // or for all VolumeManager-managed nodes?
     var renderingMethod = Volume.RenderingMethod.AlphaBlending
 
+    /** List of custom-created textures not to be cleared automatically */
+    var customTextures = arrayListOf<String>()
+
     init {
         state = State.Created
         name = "VolumeManager"
         // fake geometry
 
+        logger.info("Created new volume manager with compute=$useCompute, segments=$customSegments, bindings=$customBindings")
 
         this.geometryType = GeometryType.TRIANGLES
 
@@ -198,9 +202,16 @@ class VolumeManager(
         shaderProperties["transform"] = Matrix4f()
         shaderProperties["viewportSize"] = Vector2f()
         shaderProperties["dsp"] = Vector2f()
-        material.textures.clear()
+        val oldKeys = material.textures.filter { it.key !in customTextures }.keys
+        val texturesToKeep = material.textures.filter { it.key in customTextures }
+        oldKeys.forEach {
+            material.textures.remove(it)
+        }
 
         material = ShaderMaterial(context.factory)
+        texturesToKeep.forEach { (k, v) ->
+            material.textures[k] = v
+        }
         material.cullingMode = Material.CullingMode.None
         material.blending.transparent = true
         material.blending.sourceColorBlendFactor = Blending.BlendFactor.One
@@ -355,23 +366,6 @@ class VolumeManager(
             state = State.Ready
         } else {
             state = State.Created
-        }
-    }
-
-    private fun clearKeysAndTextures() {
-        val oldKeys = this.material.textures.keys()
-            .asSequence()
-            .filter { it.contains("_") }
-        logger.info("Removing texture keys ${oldKeys.joinToString(",")}")
-        oldKeys.map {
-            this.material.textures.remove(it)
-        }
-
-        val oldProps = this.shaderProperties.keys
-            .filter { it.contains("_x_") }
-        logger.info("Removing shader props ${oldProps.joinToString(",")}")
-        oldProps.map {
-            this.shaderProperties.remove(it)
         }
     }
 
@@ -733,9 +727,16 @@ class VolumeManager(
         nodes.remove(node)
 
         val volumes = nodes.toMutableList()
-        hub?.get<VolumeManager>()?.let { hub?.remove(it) }
+        val current = hub?.get<VolumeManager>()
+        if(current != null) {
+            hub?.remove(current)
+        }
 
-        val vm = VolumeManager(hub, useCompute)
+        val vm = VolumeManager(hub, useCompute, current?.customSegments, current?.customBindings)
+        current?.customTextures?.forEach {
+            vm.customTextures.add(it)
+            vm.material.textures[it] = current.material.textures[it]!!
+        }
         volumes.forEach {
             vm.add(it)
             it.delegate = vm

--- a/src/test/kotlin/graphics/scenery/tests/examples/compute/CustomVolumeManagerExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/compute/CustomVolumeManagerExample.kt
@@ -38,6 +38,7 @@ class CustomVolumeManagerExample : SceneryBase("CustomVolumeManagerExample") {
                     "ComputeVolume.comp",
                     "intersectBoundingBox", "vis", "SampleVolume", "Convert", "Accumulate"),
             ))
+        volumeManager.customTextures.add("OutputRender")
 
         val outputBuffer = MemoryUtil.memCalloc(1280*720*4)
         val outputTexture = Texture.fromImage(Image(outputBuffer, 1280, 720), usage = hashSetOf(Texture.UsageType.LoadStoreImage, Texture.UsageType.Texture))


### PR DESCRIPTION
@aryaman-gupta had reported an issue where compute shaders would not be used if the VolumeManager is recreated. This PR fixes that, and introduces a new `customTextures` list in VolumeManager, where the developer can specify custom textures that are not under the VolumeManager's responsibility.