### PR TITLE
Gradle: Bump spirvcrossj to 0.7.1-1.1.106.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ repositories {
 "lwjgl3-awt"("0.1.7")
 "msgpack-core"("0.8.20")
 "classgraph"("4.8.86")
-"spirvcrossj"("0.7.0-1.1.106.0")
+"spirvcrossj"("0.7.1-1.1.106.0")
 "reflections"("0.9.12")
 
 dependencies {


### PR DESCRIPTION
This PR bumps spirvcrossj to the latest version, 0.7.1-1.1.106.0, solving some classloader issues reported by @elect86 and @ljjh20.