### PR TITLE
Fix BigVolumeViewer version in Gradle build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
 
 "kotlin"("1.4.21")
 "ui-behaviour"("2.0.3")
-"bigvolumeviewer"("0.1.9")
+//"bigvolumeviewer"("0.1.9")
 "ffmpeg"("4.2.1-1.5.2")
 "jackson-dataformat-msgpack"("0.8.20")
 "jeromq"("0.4.3")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
+org.gradle.caching=true
+


### PR DESCRIPTION
This PR fixes the BigVolumeViewer version in the Gradle build to the correct jitpack one, and removes the reference to release version 0.1.8. This can be changed back after tpietzsch/jogl-minimal#14 is merged.