### PR TITLE
Gradle: Specify versions for natives explicitly 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import sciJava.get
-import sciJava.invoke
-import sciJava.sciJava
-import sciJava.testSciJava
+import sciJava.*
 import java.net.URL
 
 plugins {
@@ -53,14 +50,14 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.0-M1")
 
     listOf("windows-amd64", "linux-i586", "linux-amd64", "macosx-universal").forEach {
-        sciJava("org.jogamp.gluegen:gluegen-rt", "natives-$it") // this is crap, but will be polished eventually
-        sciJava("org.jogamp.jogl:jogl-all", "natives-$it")
+        sciJava("org.jogamp.gluegen:gluegen-rt:2.3.2", "natives-$it") // this is crap, but will be polished eventually
+        sciJava("org.jogamp.jogl:jogl-all:2.3.2", "natives-$it")
     }
     sciJava("org.slf4j:slf4j-api")
     sciJava("net.clearvolume:cleargl")
     sciJava("org.joml")
     sciJava("com.github.scenerygraphics:vector:958f2e6")
-    sciJava("net.java.jinput:jinput", native = "natives-all")
+    sciJava("net.java.jinput:jinput:2.0.9", native = "natives-all")
     sciJava("org.scijava"["scijava-common", "script-editor", "ui-behaviour", "scripting-javascript", "scripting-jython"])
     sciJava("net.sf.trove4j")
     sciJava("net.java.dev.jna")
@@ -70,32 +67,32 @@ dependencies {
     listOf("", "-glfw", "-jemalloc", "-vulkan", "-opengl", "-openvr", "-xxhash", "-remotery").forEach {
         implementation("org.lwjgl:lwjgl$it")
         if (it != "-vulkan")
-            runtimeOnlylwjglNatives("org.lwjgl", "lwjgl$it") // "
+            runtimeOnlylwjglNatives("org.lwjgl", "lwjgl$it", version = versions["lwjgl"]) // "
     }
     sciJava("com.fasterxml.jackson.core:jackson-databind")
     sciJava("com.fasterxml.jackson.module:jackson-module-kotlin:\$jackson-databind")
     sciJava("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:\$jackson-databind")
     sciJava("graphics.scenery:spirvcrossj")
-    runtimeOnlylwjglNatives("graphics.scenery", "spirvcrossj") // "
+    runtimeOnlylwjglNatives("graphics.scenery", "spirvcrossj", version = versions["spirvcrossj"]) // "
     sciJava("org.zeromq:jeromq")
     sciJava("com.esotericsoftware:kryo")
     sciJava("org.msgpack:msgpack-core")
     sciJava("org.msgpack:jackson-dataformat-msgpack")
     sciJava("graphics.scenery:jvrpn")
-    runtimeOnlylwjglNatives("graphics.scenery", "jvrpn") // "
+    runtimeOnlylwjglNatives("graphics.scenery", "jvrpn", version = versions["jvrpn"]) // "
     //    runtimeOnly("graphics.scenery", "jvrpn", classifier = "natives-linux")
     //    runtimeOnly("graphics.scenery", "jvrpn", classifier = "natives-macos")
     sciJava("io.scif:scifio")
     sciJava("org.bytedeco:ffmpeg")
     listOf("windows", "linux", "macosx").forEach {
-        runtimeOnly("org.bytedeco", "ffmpeg", classifier = "$it-x86_64") // "
+        runtimeOnly("org.bytedeco", "ffmpeg", classifier = "$it-x86_64", version = versions["ffmpeg"]) // "
     }
     sciJava("org.reflections")
     sciJava("io.github.classgraph")
     //TODO revert to official BVV
-    implementation("sc.fiji:bigdataviewer-core:10.1.1-SNAPSHOT")
-    implementation("sc.fiji:bigdataviewer-vistools:1.0.0-beta-26-SNAPSHOT")
-    implementation("com.github.skalarproduktraum:jogl-minimal:1c86442")
+    api("sc.fiji:bigdataviewer-core:10.1.1-SNAPSHOT")
+    api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-26-SNAPSHOT")
+    api("com.github.skalarproduktraum:jogl-minimal:1c86442")
     //sciJava("sc.fiji:bigvolumeviewer")
     //    sciJava("org.lwjglx:lwjgl3-awt")
     implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
@@ -121,8 +118,8 @@ dependencies {
     testSciJava("net.imglib2:imglib2-ij")
 }
 
-fun DependencyHandlerScope.runtimeOnlylwjglNatives(group: String, name: String) =
-    listOf("windows", "linux", "macos").forEach { runtimeOnly(group, name, classifier = "natives-$it") }
+fun DependencyHandlerScope.runtimeOnlylwjglNatives(group: String, name: String, version: String? = null) =
+    listOf("windows", "linux", "macos").forEach { runtimeOnly(group, name, classifier = "natives-$it", version = version) }
 
 tasks {
 

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -61,7 +61,7 @@ tasks {
 
     register<JavaExec>("run") {
         classpath = sourceSets.test.get().runtimeClasspath
-        if(project.hasProperty("example")) {
+        if (project.hasProperty("example")) {
             project.property("example")?.let { example ->
                 val file = sourceSets.test.get().allSource.files.first { "class $example" in it.readText() }
                 main = file.path.substringAfter("kotlin${File.separatorChar}").replace(File.separatorChar, '.').substringBefore(".kt")
@@ -87,8 +87,8 @@ val TaskContainer.jacocoTestReport: TaskProvider<JacocoReport>
 val TaskContainer.test: TaskProvider<Test>
     get() = named<Test>("test")
 
-val Project.sourceSets: SourceSetContainer get() =
-    (this as ExtensionAware).extensions.getByName("sourceSets") as SourceSetContainer
+val Project.sourceSets: SourceSetContainer
+    get() = (this as ExtensionAware).extensions.getByName("sourceSets") as SourceSetContainer
 
 val SourceSetContainer.test: NamedDomainObjectProvider<SourceSet>
     get() = named<SourceSet>("test")


### PR DESCRIPTION
This PR specifies native versions in Gradle explictly, to prevent creation of a broken POM, make BDV/BVV API dependencies in order to leak them to dependant projects.

Probably @elect86 will want to have a look at this, as I believe that can be fixed within his sciJava Gradle plugin 👍 