### PR TITLE
Gradle: Update ffmpeg to 4.2.2-1.5.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 "kotlin"("1.4.21")
 "ui-behaviour"("2.0.3")
 //"bigvolumeviewer"("0.1.9")
-"ffmpeg"("4.2.1-1.5.2")
+"ffmpeg"("4.2.2-1.5.3")
 "jackson-dataformat-msgpack"("0.8.20")
 "jeromq"("0.4.3")
 "jinput"("2.0.9")


### PR DESCRIPTION
This PR updates ffmpeg to 4.2.2-1.5.3 -- this is the same version nd4j uses, so this removes a version clash that should make @ljjh20 happy 👍 