### PR TITLE
OrthoView.kt: add JvmName for OrthoView

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/OrthoView.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/OrthoView.kt
@@ -1,3 +1,5 @@
+@file:JvmName("OrthoView")
+
 package graphics.scenery.volumes
 
 import graphics.scenery.BoundingGrid


### PR DESCRIPTION
This adds a JvmName to OrthoView so it can be referenced from Java and Python (via scyjava) easily.