### PR TITLE
VulkanRenderer: Fix issue where screenshots would not be overwritten

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1417,6 +1417,7 @@ open class VulkanRenderer(hub: Hub,
 
             if(screenshotRequested || request != null) {
                 val writeToFile = screenshotRequested
+                val overwrite = screenshotOverwriteExisting
                 // reorder bytes for screenshot in a separate thread
                 thread {
                     imageBuffer?.let { ib ->
@@ -1425,7 +1426,7 @@ open class VulkanRenderer(hub: Hub,
                                 File(System.getProperty("user.home"), "Desktop" + File.separator + "$applicationName - ${SystemHelpers.formatDateTime()}.png")
                             } else {
                                 File(screenshotFilename)
-                            }, screenshotOverwriteExisting)
+                            }, overwrite)
                             file.createNewFile()
                             ib.rewind()
 


### PR DESCRIPTION
This PR fixes #421, where screenshots were not overwritten as requested when using the Vulkan renderer.