### PR TITLE
Jitpack: Don't create Gradle metadata JSON file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ repositories {
 }
 
 dependencies {
-
     // we cant use a platform because of a jitpack issue, we apply the dependencies constraints via
     // the sciJava.platform plugin above in the `plugins {}` scope
 //    implementation(platform("sciJava:platform:30.0.0+6"))
@@ -150,3 +149,11 @@ jacoco {
 }
 
 java.withSourcesJar()
+
+// disable Gradle metadata file creation on Jitpack, as jitpack modifies
+// the metadata file, resulting in broken metadata with missing native dependencies.
+if(System.getenv("JITPACK") != null) {
+    tasks.withType<GenerateModuleMetadata> {
+        enabled = false
+    }
+}


### PR DESCRIPTION
This PR disable the creation of the `module.json` file when building on Jitpack, as Jitpack performs opaque postprocessing on that file which leads to missing natives dependencies, and especially issues downstream with transitive dependencies.