### PR TITLE
Orthoview improvements for volume visualisation

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -147,9 +147,26 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
      * Returns the list of objects (as [Scene.RaycastResult]) under the screen space position
      * indicated by [x] and [y], sorted by their distance to the observer.
      */
-    @JvmOverloads fun getNodesForScreenSpacePosition(x: Int, y: Int,
-                                                       ignoredObjects: List<Class<*>> = emptyList(),
-                                                       debug: Boolean = false): Scene.RaycastResult {
+    @JvmOverloads
+    fun getNodesForScreenSpacePosition(
+        x: Int, y: Int,
+        ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java),
+        debug: Boolean = false
+    ): Scene.RaycastResult {
+        return getNodesForScreenSpacePosition(x, y, { n: Node ->
+            !ignoredObjects.any { it.isAssignableFrom(n.javaClass) }
+        }, debug)
+    }
+
+    /**
+     * Returns the list of objects (as [Scene.RaycastResult]) under the screen space position
+     * indicated by [x] and [y], sorted by their distance to the observer.
+     */
+    fun getNodesForScreenSpacePosition(
+        x: Int, y: Int,
+        filter: (Node) -> Boolean,
+        debug: Boolean = false
+    ): Scene.RaycastResult {
         val (worldPos, worldDir) = screenPointToRay(x, y)
 
         val scene = getScene()
@@ -158,7 +175,7 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
             return Scene.RaycastResult(emptyList(), worldPos, worldDir)
         }
 
-        return scene.raycast(worldPos, worldDir, ignoredObjects, debug)
+        return scene.raycast(worldPos, worldDir, filter, debug)
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/Scene.kt
+++ b/src/main/kotlin/graphics/scenery/Scene.kt
@@ -212,11 +212,11 @@ open class Scene : DefaultNode("RootNode"), HasRenderable, HasMaterial, HasSpati
     /**
      * Performs a raycast to discover objects in this [Scene] that would be intersected
      * by a ray originating from [position], shot in [direction]. This method can
-     * be given a list of classes as [ignoredObjects], which will then be ignored for
-     * the raycast. If [debug] is true, a set of spheres is placed along the cast ray.
+     * be given a filter function to to ignore nodes for the raycast for nodes it retuns false for.
+     * If [debug] is true, a set of spheres is placed along the cast ray.
      */
     @JvmOverloads fun raycast(position: Vector3f, direction: Vector3f,
-                              ignoredObjects: List<Class<*>>,
+                              filter: (Node) -> Boolean = {true},
                               debug: Boolean = false): RaycastResult {
         if (debug) {
             val indicatorMaterial = DefaultMaterial()
@@ -235,7 +235,7 @@ open class Scene : DefaultNode("RootNode"), HasRenderable, HasMaterial, HasSpati
         }
 
         val matches = this.discover(this, { node ->
-            node.visible && !ignoredObjects.any{it.isAssignableFrom(node.javaClass)}
+            node.visible && filter(node)
         }).flatMap { (
             if (it is InstancedNode)
                 Stream.concat(Stream.of(it as Node), it.instances.map { instanceNode -> instanceNode as Node }.stream())

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragSphere.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragSphere.kt
@@ -20,7 +20,7 @@ open class MouseDragSphere(
     protected val name: String,
     camera: () -> Camera?,
     protected var debugRaycast: Boolean = false,
-    var ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java)
+    var filter: (Node) -> Boolean
 ) : DragBehaviour, WithCameraDelegateBase(camera) {
 
     protected val logger by LazyLogger()
@@ -29,11 +29,21 @@ open class MouseDragSphere(
     protected var currentHit: Vector3f = Vector3f()
     protected var distance: Float = 0f
 
+    constructor(
+        name: String,
+        camera: () -> Camera?,
+        debugRaycast: Boolean = false,
+        ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java)
+    ) : this(name, camera, debugRaycast, { n: Node ->
+        !ignoredObjects.any { it.isAssignableFrom(n.javaClass) }})
+
+
     override fun init(x: Int, y: Int) {
         cam?.let { cam ->
-            val matches = cam.getNodesForScreenSpacePosition(x, y, ignoredObjects, debugRaycast)
+            val matches = cam.getNodesForScreenSpacePosition(x, y, filter, debugRaycast)
             currentNode = matches.matches.firstOrNull()?.node
-            distance = matches.matches.firstOrNull()?.distance ?: 0f//currentNode?.position?.distance(cam.position) ?: 0f
+            distance =
+                matches.matches.firstOrNull()?.distance ?: 0f//currentNode?.position?.distance(cam.position) ?: 0f
 
             val (rayStart, rayDir) = cam.screenPointToRay(x, y)
             rayDir.normalize()

--- a/src/main/kotlin/graphics/scenery/volumes/OrthoView.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/OrthoView.kt
@@ -43,6 +43,11 @@ fun createOrthoView(volume: Volume) {
         planeXY.spatial().position = center
         planeYZ.spatial().position = center
 
+        planeXZ.addAttribute(OrthoPlane::class.java, OrthoPlane())
+        planeXY.addAttribute(OrthoPlane::class.java, OrthoPlane())
+        planeYZ.addAttribute(OrthoPlane::class.java, OrthoPlane())
+
+
         // make transparent
         planeXZ.material {
             blending.setOverlayBlending()
@@ -94,21 +99,19 @@ fun createOrthoView(volume: Volume) {
     }
 }
 
+class OrthoPlane
+
 /**
  * Adds a [MouseDragSphere] behavior which ignores the appropriate classes to move the ortho view slices correctly.
  */
 fun InputHandler.addOrthoViewDragBehavior(key: String) {
     addBehaviour(
-        "sphereDragObject", MouseDragSphere(
-            "sphereDragObject",
+        "dragOrthoPlane", MouseDragSphere(
+            "dragOrthoPlane",
             { this.scene.findObserver() },
             debugRaycast = false,
-            ignoredObjects = listOf<Class<*>>(
-                BoundingGrid::class.java,
-                VolumeManager::class.java,
-                Volume::class.java
-            )
+            filter = { it.getAttributeOrNull(OrthoPlane::class.java) != null }
         )
     )
-    addKeyBinding("sphereDragObject", key)
+    addKeyBinding("dragOrthoPlane", key)
 }

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/OrthoViewExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/OrthoViewExample.kt
@@ -61,14 +61,12 @@ class OrthoViewExample : SceneryBase("Ortho View example", 1280, 720) {
         bGrid.node = volume
         volume.addChild(bGrid)
 
-        createOrthoView(volume)
+        createOrthoView(volume,"1")
     }
 
     override fun inputSetup() {
         setupCameraModeSwitching()
-
-        inputHandler?.addOrthoViewDragBehavior("1")
-
+        //inputHandler?.addOrthoViewDragBehavior("2")
     }
 
     companion object {

--- a/src/test/kotlin/graphics/scenery/tests/unit/SceneTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/SceneTests.kt
@@ -40,8 +40,7 @@ class SceneTests {
 
         val results = scene.raycast(
             position = Vector3f(0.0f),
-            direction = Vector3f(0.0f, 0.0f, -1.0f),
-            ignoredObjects = emptyList())
+            direction = Vector3f(0.0f, 0.0f, -1.0f))
 
         assertEquals(count, results.matches.size, "Raycast should have hit $count objects")
     }


### PR DESCRIPTION
Depends on #406 and #411.

- Add node filter to raycast collision detection as second mode instead of ignoring classes.
- OrthoView Input behavior uses this new filtering.
- OrthoView input behavior now adds itself automatically.