### PR TITLE
Added parser for .cube files (DFT output, atomic positions + electronic density)

### DIFF
--- a/src/main/kotlin/graphics/scenery/DFTParser.kt
+++ b/src/main/kotlin/graphics/scenery/DFTParser.kt
@@ -1,45 +1,46 @@
 package graphics.scenery
+import graphics.scenery.repl.REPL
 import graphics.scenery.utils.RingBuffer
 import org.joml.Vector3f
 import org.lwjgl.system.MemoryUtil
 import java.io.File
 import java.nio.ByteBuffer
 
-class DFTParser (val fileType: String = "cube", val normalizeDensityTo: Float = -1.0f){
-    /*
-     Properties.
-     */
-    var numberOfAtoms:Int = 0
-    var gridSpacings = FloatArray(3) { 0.0f }
-    var gridDimensions = IntArray(3) { 0 }
-    var atomicPositions = Array(0){ Vector3f()}
-    var electronicDensity = Array(0, { Array(0, { FloatArray(0) } ) } )
-    lateinit var electronicDensityUInt : ByteBuffer
+/**
+Parses a density functional theory (common simulation method in solid state physics and theoretical chemistry)
+calculation. Can be used to visualize single DFT calculations or DFT-MD (=DFT molecular dynamics simulations).
 
+ * @property[normalizeDensityTo] Defines to which value the density is scaled. This is useful when visualizing more then one DFT calculation at the
+    same time, in order to keep the density visualization consistent. Negative values mean the density is scaled
+    per snapshot. Default is -1.0f.
+ */
+class DFTParser (val normalizeDensityTo: Float = -1.0f){
+    /**  Number of Atoms.*/
+    var numberOfAtoms:Int = 0
+    /** Distance between two grid points in either direction in Bohr.*/
+    var gridSpacings = FloatArray(3) { 0.0f }
+    /** Number of gridpoints in 3D grid.*/
+    var gridDimensions = IntArray(3) { 0 }
+    /** Positions of the atoms in Bohr.*/
+    var atomicPositions = Array(0){ Vector3f()}
+    private var electronicDensity = Array(0, {Array(0, { FloatArray(0) } ) } )
+    /** Electronic density as scaled bytes, in scaled(1/Bohr).*/
+    lateinit var electronicDensityUInt : ByteBuffer
+    /** Origin of the unit cell, usually 0,0,0. */
     var unitCellOrigin = FloatArray(3) { 0.0f }
+    /** Dimensions of the unit cell, in Bohr.*/
     var unitCellDimensions = FloatArray(3) { 0.0f }
 
-    /*
-     Functions.
-     */
-
-    // Parse a file containing visualize-able information about a DFT calculation.
-    fun parseFile(filename: String) {
-        if (this.fileType == "cube") {
-            this.parseCube(filename)
-        }
-    }
-
     // Parse information as .cube file.
-    private fun parseCube(filename: String){
+    fun parseCube(filename: String){
         // Read entire file content
         val cubeFile =  File(filename).bufferedReader().readLines()
         var counter = 0
         var xcounter = 0
         var ycounter = 0
         var zcounter = 0
-        var minDensity:Float = 1000.0f
-        var maxDensity:Float = 0.0f
+        var minDensity = 1000.0f
+        var maxDensity = 0.0f
 
         // Iterate through file. We know what is were with a cube file.
         // 0-1: Comments.
@@ -112,7 +113,7 @@ class DFTParser (val fileType: String = "cube", val normalizeDensityTo: Float = 
         // Converting to byte buffer.
         counter = 0
         electronicDensityUInt =  MemoryUtil.memAlloc((gridDimensions[0]*
-            gridDimensions[1]*gridDimensions[2]*1).toInt())
+            gridDimensions[1]*gridDimensions[2]*1))
         if (normalizeDensityTo > 0.0f){
             maxDensity = normalizeDensityTo
         }

--- a/src/main/kotlin/graphics/scenery/DFTParser.kt
+++ b/src/main/kotlin/graphics/scenery/DFTParser.kt
@@ -5,7 +5,7 @@ import org.lwjgl.system.MemoryUtil
 import java.io.File
 import java.nio.ByteBuffer
 
-class DFTParser (val fileType: String = "cube"){
+class DFTParser (val fileType: String = "cube", val normalizeDensityTo: Float = -1.0f){
     /*
      Properties.
      */
@@ -113,7 +113,9 @@ class DFTParser (val fileType: String = "cube"){
         counter = 0
         electronicDensityUInt =  MemoryUtil.memAlloc((gridDimensions[0]*
             gridDimensions[1]*gridDimensions[2]*1).toInt())
-
+        if (normalizeDensityTo > 0.0f){
+            maxDensity = normalizeDensityTo
+        }
         for (z in 0 until gridDimensions[2]){
             for (y in 0 until gridDimensions[1]){
                 for (x in 0 until gridDimensions[0]){

--- a/src/main/kotlin/graphics/scenery/DFTParser.kt
+++ b/src/main/kotlin/graphics/scenery/DFTParser.kt
@@ -1,0 +1,100 @@
+package graphics.scenery
+import org.joml.Vector3f
+import java.io.File
+
+class DFTParser (val fileType: String = "cube"){
+    /*
+     Properties.
+     */
+    var numberOfAtoms:Int = 0
+    var gridSpacings = FloatArray(3) { 0.0f }
+    var gridDimensions = IntArray(3) { 0 }
+    var atomicPositions = Array(0){ Vector3f()}
+    var electronicDensity = Array(0, { Array(0, { FloatArray(0) } ) } )
+    var unitCellOrigin = FloatArray(3) { 0.0f }
+    var unitCellDimensions = FloatArray(3) { 0.0f }
+
+    /*
+     Functions.
+     */
+
+    // Parse a file containing visualize-able information about a DFT calculation.
+    fun parseFile(filename: String) {
+        if (this.fileType == "cube") {
+            this.parseCube(filename)
+        }
+    }
+
+    // Parse information as .cube file.
+    private fun parseCube(filename: String){
+        // Read entire file content
+        val cubeFile =  File(filename).bufferedReader().readLines()
+        var counter = 0
+        var xcounter = 0
+        var ycounter = 0
+        var zcounter = 0
+
+        // Iterate through file. We know what is were with a cube file.
+        // 0-1: Comments.
+        // 2: Number of atoms + origin.
+        // 3,4,5: Grid spacing in x,y,z direction (in Bohr)
+        // 6 - (number_of_atoms+6): One line for each atom with position and species
+        // Everything thereafter: the volumetric data, here the density.
+
+        for (line in cubeFile){
+            when (counter){
+                0,1 ->{}
+                2 -> {
+                    numberOfAtoms = (line.trim().split("\\s+".toRegex())[0]).toInt()
+                    unitCellOrigin[0] = (line.trim().split("\\s+".toRegex())[1]).toFloat()
+                    unitCellOrigin[1] = (line.trim().split("\\s+".toRegex())[1]).toFloat()
+                    unitCellOrigin[2] = (line.trim().split("\\s+".toRegex())[1]).toFloat()
+
+                    // Now we know how many atoms we have.
+                    atomicPositions = Array(numberOfAtoms){ Vector3f()}
+                }
+                3,4,5 -> {
+                    gridDimensions[counter-3] =  (line.trim().split("\\s+".toRegex())[0]).toInt()
+                    gridSpacings[counter-3] = (line.trim().split("\\s+".toRegex())[counter-2]).toFloat()
+                }
+                else->  {
+                    if (counter == 6)
+                    {
+                        unitCellDimensions[0] = (gridSpacings[0]*gridDimensions[0])+unitCellOrigin[0]
+                        unitCellDimensions[1] = (gridSpacings[1]*gridDimensions[1])+unitCellOrigin[1]
+                        unitCellDimensions[2] = (gridSpacings[2]*gridDimensions[2])+unitCellOrigin[2]
+                        electronicDensity = Array(gridDimensions[0], { Array(gridDimensions[1],
+                            { FloatArray(gridDimensions[2]) } ) } )
+
+                    }
+                    // Parsing atomic positions.
+                    if (counter < 6+numberOfAtoms){
+                        val x = (line.trim().split("\\s+".toRegex())[2]).toFloat()
+                        atomicPositions[counter-6] = Vector3f((line.trim().split("\\s+".toRegex())[2]).toFloat(),
+                                                              (line.trim().split("\\s+".toRegex())[3]).toFloat(),
+                                                              (line.trim().split("\\s+".toRegex())[4]).toFloat())
+                    }
+
+                    // Parsing volumetric data.
+                    if (counter >= 6+numberOfAtoms){
+                        for (value in (line.trim().split("\\s+".toRegex())))
+                        {
+                            // Cube files should be in Fortran (z-fastest ordering).
+                            electronicDensity[xcounter][ycounter][zcounter] = (value).toFloat()
+                            zcounter++
+                            if (zcounter == gridDimensions[2]){
+                                zcounter = 0
+                                ycounter++
+                                if (ycounter == gridDimensions[1]){
+                                    ycounter = 0
+                                    xcounter++
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            counter++
+        }
+    }
+}

--- a/src/main/kotlin/graphics/scenery/DFTParser.kt
+++ b/src/main/kotlin/graphics/scenery/DFTParser.kt
@@ -15,7 +15,6 @@ class DFTParser (val fileType: String = "cube"){
     var atomicPositions = Array(0){ Vector3f()}
     var electronicDensity = Array(0, { Array(0, { FloatArray(0) } ) } )
     lateinit var electronicDensityUInt : ByteBuffer
-    var densityPosition = FloatArray(3) { 0.0f }
 
     var unitCellOrigin = FloatArray(3) { 0.0f }
     var unitCellDimensions = FloatArray(3) { 0.0f }
@@ -73,11 +72,6 @@ class DFTParser (val fileType: String = "cube"){
                         unitCellDimensions[2] = (gridSpacings[2]*gridDimensions[2])+unitCellOrigin[2]
                         electronicDensity = Array(gridDimensions[0], { Array(gridDimensions[1],
                             { FloatArray(gridDimensions[2]) } ) } )
-                        densityPosition[0] = unitCellDimensions[0] / 2.0f - gridSpacings[0]
-                        densityPosition[1] = unitCellDimensions[1] / 2.0f - gridSpacings[1]
-                        densityPosition[2] = unitCellDimensions[2] / 2.0f - gridSpacings[2]
-
-
                     }
                     // Parsing atomic positions.
                     if (counter < 6+numberOfAtoms){
@@ -99,6 +93,7 @@ class DFTParser (val fileType: String = "cube"){
                             if (electronicDensity[xcounter][ycounter][zcounter] < minDensity) {
                                 minDensity = electronicDensity[xcounter][ycounter][zcounter]
                             }
+
                             zcounter++
                             if (zcounter == gridDimensions[2]) {
                                 zcounter = 0
@@ -124,7 +119,6 @@ class DFTParser (val fileType: String = "cube"){
                 for (x in 0 until gridDimensions[0]){
                     val value = (((electronicDensity[x][y][z] - minDensity) / (maxDensity - minDensity)) * 255.0f).toInt()
                     electronicDensityUInt.put(value.toByte())
-
                     counter++
                 }
             }

--- a/src/main/kotlin/graphics/scenery/DFTParser.kt
+++ b/src/main/kotlin/graphics/scenery/DFTParser.kt
@@ -86,6 +86,7 @@ class DFTParser (val fileType: String = "cube"){
                         for (value in (line.trim().split("\\s+".toRegex()))) {
                             // Cube files should be in Fortran (z-fastest ordering).
                             electronicDensity[xcounter][ycounter][zcounter] = (value).toFloat()
+//                            electronicDensity[xcounter][ycounter][zcounter] = (xcounter*ycounter*zcounter).toFloat()
                             if (electronicDensity[xcounter][ycounter][zcounter] > maxDensity) {
                                 maxDensity = electronicDensity[xcounter][ycounter][zcounter]
                             }
@@ -93,13 +94,13 @@ class DFTParser (val fileType: String = "cube"){
                                 minDensity = electronicDensity[xcounter][ycounter][zcounter]
                             }
 
-                            xcounter++
-                            if (xcounter == gridDimensions[2]) {
-                                xcounter = 0
+                            zcounter++
+                            if (zcounter == gridDimensions[2]) {
+                                zcounter = 0
                                 ycounter++
                                 if (ycounter == gridDimensions[1]) {
                                     ycounter = 0
-                                    zcounter++
+                                    xcounter++
                                 }
                             }
                         }
@@ -113,18 +114,37 @@ class DFTParser (val fileType: String = "cube"){
         counter = 0
 
         electronicDensityUInt =  MemoryUtil.memAlloc((gridDimensions[0]*
-            gridDimensions[1]*gridDimensions[2]*2).toInt())
+            gridDimensions[1]*gridDimensions[2]*1).toInt())
 
-        for (x in 0 until gridDimensions[0]){
+        for (z in 0 until gridDimensions[2]){
             for (y in 0 until gridDimensions[1]){
-                for (z in 0 until gridDimensions[2]){
-                    val value = (((electronicDensity[x][y][z] - minDensity) / (maxDensity - minDensity)) * 65535.0f).toInt()
+                for (x in 0 until gridDimensions[0]){
+                    val value = (((electronicDensity[x][y][z] - minDensity) / (maxDensity - minDensity)) * 255.0f).toInt()
                     electronicDensityUInt.put(value.toByte())
 
                     counter++
                 }
             }
         }
+//        for (x in 0 until gridDimensions[0]){
+//            for (y in 0 until gridDimensions[1]){
+//                for (z in 0 until gridDimensions[2]){
+//                    val value = ((z.toFloat()/gridDimensions[0].toFloat()) * 255.0f).toInt()
+//                    electronicDensityUInt.put(value.toByte())
+//
+//                    counter++
+//                }
+//            }
+//        }
+//        for (x in 0 until gridDimensions[0]*gridDimensions[1]*gridDimensions[2]){
+//            val value = ((x.toFloat()/(gridDimensions[0]*gridDimensions[1]*gridDimensions[2]).toFloat()) * 255.0f).toInt()
+//            print(x)
+//            print(" ")
+//            print(value)
+//            print("\n")
+//            electronicDensityUInt.put(value.toByte())
+//        }
+
         electronicDensityUInt.flip()
 
     }

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -1,0 +1,67 @@
+package graphics.scenery.tests.examples.basic
+
+import org.joml.Vector3f
+import graphics.scenery.*
+import graphics.scenery.backends.Renderer
+import graphics.scenery.numerics.Random
+import graphics.scenery.textures.Texture
+import graphics.scenery.utils.Image
+import kotlin.concurrent.thread
+
+/**
+ * <Description>
+ *  Visualizes a DFT snapshot.
+ *
+ * @author Lenz Fiedler <l.fiedler@hzdr.de>
+ */
+class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scenery.master", "false").toBoolean()) {
+    override fun init() {
+        renderer = hub.add(SceneryElement.Renderer,
+            Renderer.createRenderer(hub, applicationName, scene, 512, 512))
+        val snapshot = DFTParser()
+        snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
+            "tmp.pp050Fe_snapshot0_ldos.cube")
+        for(i in 0 until snapshot.numberOfAtoms) {
+            val s = Icosphere(1.0f, 4)
+            s.position = snapshot.atomicPositions[i]
+            s.material.metallic = 0.3f
+            s.material.roughness = 0.9f
+            scene.addChild(s)
+        }
+
+        // One light in every corner.
+        val lights = (0 until 8).map {
+            PointLight(radius = 15.0f)
+        }
+        lights.mapIndexed { i, light ->
+            val permutation = String.format("%3s", Integer.toBinaryString(i)).replace(' ', '0')
+            light.position = Vector3f(6.0f * (permutation[0].code-48) ,  6.0f * (permutation[1].code-48),
+                6.0f * (permutation[2].code-48))
+            light.emissionColor = Vector3f(1.0f, 1.0f, 1.0f)
+            light.intensity = 1.0f
+            scene.addChild(light)
+        }
+
+        val cam: Camera = DetachedHeadCamera()
+        with(cam) {
+            position = Vector3f(0.0f, 0.0f, 5.0f)
+            perspectiveCamera(50.0f, 512, 512)
+
+            scene.addChild(this)
+        }
+
+        thread {
+            while (running) {
+                Thread.sleep(20)
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            DFTExample().main()
+        }
+    }
+}
+

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -24,9 +24,9 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
         renderer = hub.add(SceneryElement.Renderer,
             Renderer.createRenderer(hub, applicationName, scene, 512, 512))
         val snapshot = DFTParser()
-        snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
+        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
             "Fe_snapshot0_dens.cube")
-        snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Al36/for_fesl/cubes/" +
+        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Al36/for_fesl/cubes/" +
             "Al_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -7,6 +7,7 @@ import graphics.scenery.numerics.Random
 import graphics.scenery.textures.Texture
 import graphics.scenery.utils.Image
 import graphics.scenery.volumes.Colormap
+import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import kotlin.concurrent.thread
@@ -39,21 +40,21 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
                                         snapshot.gridDimensions[2], UnsignedByteType(), hub)
 
         volume.name = "volume"
-        volume.position = Vector3f(0.0f, 0.0f, 0.0f)
-        volume.colormap = Colormap.get("hot")
-        volume.pixelToWorldRatio = 0.03f
+        volume.position = Vector3f(2.683464f, 2.683464f, 2.683464f)
+        volume.colormap = Colormap.get("viridis")
+        volume.pixelToWorldRatio = snapshot.gridSpacings[0]
 
         // Do I need this?
 //        with(volume.transferFunction) {
-//            addControlPoint(0.0f, 0.0f)
-//            addControlPoint(0.2f, 0.0f)
-//            addControlPoint(0.4f, 0.5f)
-//            addControlPoint(0.8f, 0.5f)
-//            addControlPoint(1.0f, 0.0f)
+//            addControlPoint(0.0f, 0.01f)
+//            addControlPoint(0.2f, 0.02f)
+//            addControlPoint(0.4f, 0.03f)
+//            addControlPoint(0.8f, 0.04f)
+//            addControlPoint(1.0f, 0.05f)
 //        }
+        volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
         scene.addChild(volume)
-        val currentBuffer = snapshot.electronicDensityUInt.get()
-        volume.addTimepoint("t-0", currentBuffer)
+        volume.addTimepoint("t-0", snapshot.electronicDensityUInt)
         volume.goToLastTimepoint()
 
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -26,11 +26,12 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
         snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
             "Fe_snapshot0_dens.cube")
 
-
         // Visualize the atoms.
+        val atomicRadius = 0.5f
         for(i in 0 until snapshot.numberOfAtoms) {
-            val s = Icosphere(1.0f, 4)
-            s.position = snapshot.atomicPositions[i]
+            val s = Icosphere(atomicRadius, 4)
+            // Shift the positions since the positions from the cube file are centers.
+            s.position = snapshot.atomicPositions[i].add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
             s.material.metallic = 0.3f
             s.material.roughness = 0.9f
             scene.addChild(s)
@@ -41,18 +42,11 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
                                         snapshot.gridDimensions[2], UnsignedByteType(), hub)
 
         volume.name = "volume"
-        volume.position = Vector3f(2.683464f, 2.683464f, 2.683464f)
+        volume.position = Vector3f(snapshot.densityPosition[0], snapshot.densityPosition[1],
+                                   snapshot.densityPosition[2])
         volume.colormap = Colormap.get("viridis")
         volume.pixelToWorldRatio = snapshot.gridSpacings[0]
 
-        // Do I need this?
-//        with(volume.transferFunction) {
-//            addControlPoint(0.0f, 0.01f)
-//            addControlPoint(0.2f, 0.02f)
-//            addControlPoint(0.4f, 0.03f)
-//            addControlPoint(0.8f, 0.04f)
-//            addControlPoint(1.0f, 0.05f)
-//        }
         volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
         scene.addChild(volume)
         volume.addTimepoint("t-0", snapshot.electronicDensityUInt)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -10,6 +10,7 @@ import graphics.scenery.volumes.Colormap
 import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
 import net.imglib2.type.numeric.integer.UnsignedByteType
+import java.nio.file.Paths
 import kotlin.concurrent.thread
 import kotlin.math.pow
 
@@ -24,10 +25,8 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
         renderer = hub.add(SceneryElement.Renderer,
             Renderer.createRenderer(hub, applicationName, scene, 512, 512))
         val snapshot = DFTParser()
-        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
-            "Fe_snapshot0_dens.cube")
-        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Al36/for_fesl/cubes/" +
-            "Al_dens.cube")
+
+        snapshot.parseCube(getDemoFilesPath() + "/volumes/dft/Fe_snapshot0_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
         val scalingFactor = 0.5f

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -30,14 +30,14 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
             "Al_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
-        val scalingFactor = 1.0f
+        val scalingFactor = 0.5f
 
         // Visualize the atoms.
         val atomicRadius = 0.5f*scalingFactor
         for(i in 0 until snapshot.numberOfAtoms) {
             val s = Icosphere(atomicRadius*scalingFactor, 4)
             // Shift the positions since the positions from the cube file are centers.
-            s.position = (snapshot.atomicPositions[i].mul(scalingFactor))//.add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
+            s.position = (snapshot.atomicPositions[i].mul(scalingFactor))
             s.material.metallic = 0.3f
             s.material.roughness = 0.9f
             scene.addChild(s)
@@ -50,11 +50,12 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
         volume.name = "volume"
         // Note: Volumes centered at the origin are currently offset by -2.0 in each direction
         // (see Volume.kt, line 338), so we're adding 2.0 here.
-        volume.position = (Vector3f(0.0f,0.0f,0.0f).mul(scalingFactor)).add(
+        volume.position = (Vector3f(snapshot.unitCellOrigin[0],snapshot.unitCellOrigin[1],
+                           snapshot.unitCellOrigin[2]).mul(scalingFactor)).add(
                            Vector3f(2.0f, 2.0f, 2.0f))
 
         volume.colormap = Colormap.get("viridis")
-        volume.pixelToWorldRatio = snapshot.gridSpacings[0]//*scalingFactor
+        volume.pixelToWorldRatio = snapshot.gridSpacings[0]*scalingFactor
 
         volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
         scene.addChild(volume)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTExample.kt
@@ -26,6 +26,7 @@ class DFTExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scen
         snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
             "Fe_snapshot0_dens.cube")
 
+
         // Visualize the atoms.
         for(i in 0 until snapshot.numberOfAtoms) {
             val s = Icosphere(1.0f, 4)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
@@ -24,7 +24,7 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         renderer = hub.add(SceneryElement.Renderer,
             Renderer.createRenderer(hub, applicationName, scene, 512, 512))
         val snapshot = DFTParser()
-        snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
+        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
             "Fe_snapshot0_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
@@ -84,7 +84,7 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         thread {
             while (running) {
                 // Read new MD snapshot.
-                snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot${currentSnapshot}/" +
+                snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot${currentSnapshot}/" +
                     "Fe_snapshot${currentSnapshot}_dens.cube")
                 // Visualize the atoms.
                 for(i in 0 until snapshot.numberOfAtoms) {

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
@@ -24,8 +24,7 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         renderer = hub.add(SceneryElement.Renderer,
             Renderer.createRenderer(hub, applicationName, scene, 512, 512))
         val snapshot = DFTParser()
-        snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
-            "Fe_snapshot0_dens.cube")
+        snapshot.parseCube(getDemoFilesPath() + "/volumes/dft/Fe_snapshot0_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
         val scalingFactor = 0.5f
@@ -84,8 +83,8 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         thread {
             while (running) {
                 // Read new MD snapshot.
-                snapshot.parseCube("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot${currentSnapshot}/" +
-                    "Fe_snapshot${currentSnapshot}_dens.cube")
+                snapshot.parseCube(getDemoFilesPath() + "/volumes/dft/Fe_snapshot${currentSnapshot}_dens.cube")
+
                 // Visualize the atoms.
                 for(i in 0 until snapshot.numberOfAtoms) {
                     // Shift the positions since the positions from the cube file are centers.

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
@@ -27,12 +27,15 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
             "Fe_snapshot0_dens.cube")
 
+        // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
+        val scalingFactor = 1.0f
+
         // Visualize the atoms.
         val atomicRadius = 0.5f
         val atoms: Array<Icosphere> = Array<Icosphere>(snapshot.numberOfAtoms) {Icosphere(atomicRadius, 4)}
         for(i in 0 until snapshot.numberOfAtoms) {
             // Shift the positions since the positions from the cube file are centers.
-            atoms[i].position = snapshot.atomicPositions[i].add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
+            atoms[i].position = (snapshot.atomicPositions[i]).mul(scalingFactor)
             atoms[i].material.metallic = 0.3f
             atoms[i].material.roughness = 0.9f
             scene.addChild(atoms[i])
@@ -43,8 +46,8 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
                                         snapshot.gridDimensions[2], UnsignedByteType(), hub)
 
         volume.name = "volume"
-        volume.position = Vector3f(snapshot.densityPosition[0], snapshot.densityPosition[1],
-                                   snapshot.densityPosition[2])
+        volume.position = (Vector3f(0.0f,0.0f,0.0f).mul(scalingFactor)).add(
+            Vector3f(2.0f, 2.0f, 2.0f))
         volume.colormap = Colormap.get("viridis")
         volume.pixelToWorldRatio = snapshot.gridSpacings[0]
         volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
@@ -77,12 +80,13 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
         var count = 0
         thread {
             while (running) {
+                // Read new MD snapshot.
                 snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot${currentSnapshot}/" +
                     "Fe_snapshot${currentSnapshot}_dens.cube")
                 // Visualize the atoms.
                 for(i in 0 until snapshot.numberOfAtoms) {
                     // Shift the positions since the positions from the cube file are centers.
-                    atoms[i].position = snapshot.atomicPositions[i].add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
+                    atoms[i].position = snapshot.atomicPositions[i]
                 }
 
                 volume.addTimepoint("t-${count}", snapshot.electronicDensityUInt)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
@@ -28,10 +28,10 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
             "Fe_snapshot0_dens.cube")
 
         // Scales the DFT coordinates (which are in Bohr units) for a better VR experience.
-        val scalingFactor = 1.0f
+        val scalingFactor = 0.5f
 
         // Visualize the atoms.
-        val atomicRadius = 0.5f
+        val atomicRadius = 0.5f*scalingFactor
         val atoms: Array<Icosphere> = Array<Icosphere>(snapshot.numberOfAtoms) {Icosphere(atomicRadius, 4)}
         for(i in 0 until snapshot.numberOfAtoms) {
             // Shift the positions since the positions from the cube file are centers.
@@ -46,10 +46,13 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
                                         snapshot.gridDimensions[2], UnsignedByteType(), hub)
 
         volume.name = "volume"
-        volume.position = (Vector3f(0.0f,0.0f,0.0f).mul(scalingFactor)).add(
+        // Note: Volumes centered at the origin are currently offset by -2.0 in each direction
+        // (see Volume.kt, line 338), so we're adding 2.0 here.
+        volume.position = (Vector3f(snapshot.unitCellOrigin[0],snapshot.unitCellOrigin[1],
+            snapshot.unitCellOrigin[2]).mul(scalingFactor)).add(
             Vector3f(2.0f, 2.0f, 2.0f))
         volume.colormap = Colormap.get("viridis")
-        volume.pixelToWorldRatio = snapshot.gridSpacings[0]
+        volume.pixelToWorldRatio = snapshot.gridSpacings[0]*scalingFactor
         volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
         scene.addChild(volume)
 
@@ -86,7 +89,7 @@ class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("sc
                 // Visualize the atoms.
                 for(i in 0 until snapshot.numberOfAtoms) {
                     // Shift the positions since the positions from the cube file are centers.
-                    atoms[i].position = snapshot.atomicPositions[i]
+                    atoms[i].position = (snapshot.atomicPositions[i]).mul(scalingFactor)
                 }
 
                 volume.addTimepoint("t-${count}", snapshot.electronicDensityUInt)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/DFTMDExample.kt
@@ -1,0 +1,109 @@
+package graphics.scenery.tests.examples.basic
+
+import org.joml.Vector3f
+import graphics.scenery.*
+import graphics.scenery.backends.Renderer
+import graphics.scenery.numerics.Random
+import graphics.scenery.textures.Texture
+import graphics.scenery.utils.Image
+import graphics.scenery.utils.extensions.plus
+import graphics.scenery.volumes.Colormap
+import graphics.scenery.volumes.TransferFunction
+import graphics.scenery.volumes.Volume
+import net.imglib2.type.numeric.integer.UnsignedByteType
+import kotlin.concurrent.thread
+
+/**
+ * <Description>
+ *  Visualizes a DFT snapshot.
+ *
+ * @author Lenz Fiedler <l.fiedler@hzdr.de>
+ */
+class DFTMDExample : SceneryBase("DFTExample", wantREPL = System.getProperty("scenery.master", "false").toBoolean()) {
+    override fun init() {
+        renderer = hub.add(SceneryElement.Renderer,
+            Renderer.createRenderer(hub, applicationName, scene, 512, 512))
+        val snapshot = DFTParser()
+        snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot0/" +
+            "Fe_snapshot0_dens.cube")
+
+        // Visualize the atoms.
+        val atomicRadius = 0.5f
+        val atoms: Array<Icosphere> = Array<Icosphere>(snapshot.numberOfAtoms) {Icosphere(atomicRadius, 4)}
+        for(i in 0 until snapshot.numberOfAtoms) {
+            // Shift the positions since the positions from the cube file are centers.
+            atoms[i].position = snapshot.atomicPositions[i].add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
+            atoms[i].material.metallic = 0.3f
+            atoms[i].material.roughness = 0.9f
+            scene.addChild(atoms[i])
+        }
+
+        // Visualize the density data.
+        val volume = Volume.fromBuffer(emptyList(), snapshot.gridDimensions[0], snapshot.gridDimensions[1],
+                                        snapshot.gridDimensions[2], UnsignedByteType(), hub)
+
+        volume.name = "volume"
+        volume.position = Vector3f(snapshot.densityPosition[0], snapshot.densityPosition[1],
+                                   snapshot.densityPosition[2])
+        volume.colormap = Colormap.get("viridis")
+        volume.pixelToWorldRatio = snapshot.gridSpacings[0]
+        volume.transferFunction = TransferFunction.ramp(0.0f, 0.3f, 0.5f)
+        scene.addChild(volume)
+
+
+        // One light in every corner.
+        val lights = (0 until 8).map {
+            PointLight(radius = 15.0f)
+        }
+        lights.mapIndexed { i, light ->
+            val permutation = String.format("%3s", Integer.toBinaryString(i)).replace(' ', '0')
+            light.position = Vector3f(6.0f * (permutation[0].code-48) ,  6.0f * (permutation[1].code-48),
+                6.0f * (permutation[2].code-48))
+            light.emissionColor = Vector3f(1.0f, 1.0f, 1.0f)
+            light.intensity = 1.0f
+            scene.addChild(light)
+        }
+
+        val cam: Camera = DetachedHeadCamera()
+        with(cam) {
+            position = Vector3f(0.0f, 0.0f, 5.0f)
+            perspectiveCamera(50.0f, 512, 512)
+
+            scene.addChild(this)
+        }
+
+        var currentSnapshot = 0
+        val maxSnapshot = 10
+        var count = 0
+        thread {
+            while (running) {
+                snapshot.parseFile("/home/fiedlerl/data/qe_calcs/Fe2/dft/snapshot${currentSnapshot}/" +
+                    "Fe_snapshot${currentSnapshot}_dens.cube")
+                // Visualize the atoms.
+                for(i in 0 until snapshot.numberOfAtoms) {
+                    // Shift the positions since the positions from the cube file are centers.
+                    atoms[i].position = snapshot.atomicPositions[i].add(Vector3f(atomicRadius, atomicRadius, atomicRadius))
+                }
+
+                volume.addTimepoint("t-${count}", snapshot.electronicDensityUInt)
+                volume.goToLastTimepoint()
+                volume.purgeFirst(10, 10)
+                Thread.sleep(500)
+                currentSnapshot++
+                count++
+                if (currentSnapshot == maxSnapshot)
+                {
+                    currentSnapshot = 0
+                }
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            DFTMDExample().main()
+        }
+    }
+}
+


### PR DESCRIPTION
This PR adds functionality (+examples) to parse .cube files. These are commonly used output files from density functional theory, holding atomic positions and electronic density. The implemented parser class can be extended in the future to allow input from a wide array of DFT output data. The parsed data can be used to visualize a DFT-MD.

There are still some edges before this can be merged: 

1. I am not sure if I put the parser and examples in the correct directory. 
2. When visualizing small unit cells, one of the edges seems to be wrongly zero (or close to it). I do not see this when visualizing larger cells and I've also checked the buffer for values that never get assigned. I will investigate further, but if anyone has a suggestion, I'd be thankful. (see picture)
![Screenshot from 2021-07-29 19-37-46](https://user-images.githubusercontent.com/37868410/127545067-63948511-c841-4506-b61a-2b007fb5e5ad.png)

3. I'd like to add my demo data to the demo data .zip file. Locally, I've done so to test everything.