### PR TITLE
Gradle: Add ability to create far JAR using shadowJar task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.kotlin.dsl.api
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import scenery.*
 import java.net.URL
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     val ktVersion = "1.5.0"
@@ -14,6 +15,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.4.30"
     jacoco
     id("sciJava.platform") version "30.0.0+15" // workaround for jitpack issue
+    id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 repositories {
@@ -124,6 +126,10 @@ tasks {
             }
         }
     }
+    
+    named<ShadowJar>("shadowJar") {
+        isZip64 = true
+    }
 }
 
 val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
@@ -158,3 +164,4 @@ if(System.getenv("JITPACK") != null) {
         enabled = false
     }
 }
+


### PR DESCRIPTION
This PR adds the Gradle task `shadowJar` to package scenery and all of its dependencies in one fat JAR.