### PR TITLE
Fix RTP video streaming

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -123,7 +123,7 @@ open class OpenGLRenderer(hub: Hub,
     private var screenshotRequested = false
     private var screenshotOverwriteExisting = false
     private var screenshotFilename = ""
-    private var encoder: H264Encoder? = null
+    private var encoder: VideoEncoder? = null
     private var recordMovie = false
     private var movieFilename = ""
 
@@ -2119,7 +2119,7 @@ open class OpenGLRenderer(hub: Hub,
                 }, false)
 
                 val supersamplingFactor = getSupersamplingFactor(cglWindow)
-                encoder = H264Encoder(
+                encoder = VideoEncoder(
                     (supersamplingFactor * window.width).toInt(),
                     (supersamplingFactor * window.height).toInt(),
                     file.absolutePath,

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -2,7 +2,6 @@ package graphics.scenery.backends.vulkan
 
 import graphics.scenery.*
 import graphics.scenery.backends.*
-import graphics.scenery.backends.vulkan.VulkanDevice.VulkanObjectType.*
 import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.attribute.renderable.DelegatesRenderable
@@ -22,7 +21,6 @@ import org.lwjgl.system.Configuration
 import org.lwjgl.system.MemoryStack.stackPush
 import org.lwjgl.system.MemoryUtil.*
 import org.lwjgl.system.Platform
-import org.lwjgl.system.jemalloc.JEmalloc.*
 import org.lwjgl.vulkan.*
 import org.lwjgl.vulkan.EXTDebugReport.*
 import org.lwjgl.vulkan.EXTDebugUtils.*
@@ -326,7 +324,7 @@ open class VulkanRenderer(hub: Hub,
     private var screenshotFilename = ""
     var screenshotBuffer: VulkanBuffer? = null
     var imageBuffer: ByteBuffer? = null
-    var encoder: H264Encoder? = null
+    var encoder: VideoEncoder? = null
     private var movieFilename = ""
     private var recordMovie: Boolean = false
     private var recordMovieOverwrite: Boolean = false
@@ -1368,7 +1366,7 @@ open class VulkanRenderer(hub: Hub,
                         File(movieFilename)
                     }, recordMovieOverwrite)
 
-                    encoder = H264Encoder(
+                    encoder = VideoEncoder(
                         (window.width * settings.get<Float>("Renderer.SupersamplingFactor")).toInt(),
                         (window.height* settings.get<Float>("Renderer.SupersamplingFactor")).toInt(),
                         file.absolutePath,


### PR DESCRIPTION
This PR:
* renames H264Encoder to VideoEncoder,
* fixes RTP stream output to use the actually correct format such that it can be consumed e.g. by VLC
* reintroduces the creation of SDP files in case a network video stream via RTP is opened

![image](https://user-images.githubusercontent.com/586495/129211057-9d7fbb69-a181-4590-8ef5-40f65ab8fca9.png)
