### PR TITLE
Volume.kt and RAIVolume.kt: Flip volume scale by -1f along y

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
@@ -59,7 +59,7 @@ class RAIVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewerOpti
 
         return Vector3f(
                 size.x() * pixelToWorldRatio / 10.0f,
-                size.y() * pixelToWorldRatio / 10.0f,
+                -1.0f * size.y() * pixelToWorldRatio / 10.0f,
                 size.z() * pixelToWorldRatio / 10.0f
         )
     }

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -336,7 +336,7 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
 //            voxelSizes.dimension(1).toFloat() * pixelToWorldRatio,
 //            voxelSizes.dimension(2).toFloat() * pixelToWorldRatio
             pixelToWorldRatio,
-            pixelToWorldRatio,
+            -1.0f * pixelToWorldRatio,
             pixelToWorldRatio
         )
     }


### PR DESCRIPTION
This PR fixes flipped volumes when loaded from image data. This was presented in https://github.com/scenerygraphics/scenery/issues/445