### PR TITLE
Dependency updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.net.URL
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    val ktVersion = "1.6.0"
+    val ktVersion = "1.6.10"
     java
     kotlin("jvm") version ktVersion
     kotlin("kapt") version ktVersion
@@ -14,10 +14,10 @@ plugins {
     scenery.publish
     scenery.sign
     id("com.github.elect86.sciJava") version "0.0.4"
-    id("org.jetbrains.dokka") version "1.4.30"
-    id("org.sonarqube") version "3.1.1"
+    id("org.jetbrains.dokka") version "1.6.0"
+    id("org.sonarqube") version "3.3"
     jacoco
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "7.1.0"
 }
 
 repositories {
@@ -29,26 +29,27 @@ repositories {
 
 dependencies {
     implementation(platform("org.scijava:pom-scijava:31.1.0"))
-    annotationProcessor("org.scijava:scijava-common")
+    annotationProcessor("org.scijava:scijava-common:2.87.1")
 
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt")
 
     implementation("org.jogamp.gluegen:gluegen-rt:2.3.2", joglNatives)
     implementation("org.jogamp.jogl:jogl-all:2.3.2", joglNatives)
-    implementation("org.slf4j:slf4j-api")
+    implementation("org.slf4j:slf4j-api:1.7.32")
     implementation("net.clearvolume:cleargl")
     implementation("org.joml:joml:1.10.2")
     implementation("net.java.jinput:jinput:2.0.9", "natives-all")
-    implementation("org.jocl:jocl:2.0.2")
+    implementation("org.jocl:jocl:2.0.4")
     implementation("org.scijava:scijava-common")
     implementation("org.scijava:script-editor")
     implementation("org.scijava:ui-behaviour")
     implementation("org.scijava:scripting-javascript")
     implementation("org.scijava:scripting-jython")
     implementation("net.java.dev.jna:jna-platform:5.9.0")
-    implementation(platform("org.lwjgl:lwjgl-bom:3.3.0"))
+
+    val lwjglVersion = "3.3.0"
     listOf("",
         "-glfw",
         "-jemalloc",
@@ -60,27 +61,26 @@ dependencies {
         "-spvc",
         "-shaderc"
     ).forEach { lwjglProject ->
-        api("org.lwjgl:lwjgl$lwjglProject:3.3.0")
+        api("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion")
 
         if (lwjglProject != "-vulkan") {
             lwjglNatives.forEach { native ->
-                runtimeOnly("org.lwjgl:lwjgl$lwjglProject:3.3.0:$native")
+                runtimeOnly("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion:$native")
             }
         }
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.5")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.5")
-    implementation("org.zeromq:jeromq:0.4.3")
-    implementation("com.esotericsoftware:kryo:5.1.1")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0")
+    implementation("org.zeromq:jeromq:0.5.2")
+    implementation("com.esotericsoftware:kryo:5.2.0")
     implementation("de.javakaffee:kryo-serializers:0.45")
-    implementation("org.msgpack:msgpack-core:0.8.20")
-    implementation("org.msgpack:jackson-dataformat-msgpack:0.8.20")
+    implementation("org.msgpack:msgpack-core:0.9.0")
+    implementation("org.msgpack:jackson-dataformat-msgpack:0.9.0")
     api("graphics.scenery:jvrpn:1.2.0", lwjglNatives)
     implementation("io.scif:scifio")
-    implementation("org.bytedeco:ffmpeg:4.2.1-1.5.2", ffmpegNatives)
-    implementation("org.reflections:reflections:0.9.12")
-    implementation("io.github.classgraph:classgraph:4.8.86")
+    implementation("org.bytedeco:ffmpeg:4.3.2-1.5.5", ffmpegNatives)
+    implementation("io.github.classgraph:classgraph:4.8.137")
 
     implementation("info.picocli:picocli:4.6.2")
 
@@ -108,7 +108,7 @@ dependencies {
     //    implementation("com.github.kotlin-graphics:assimp:25c68811")
 
 //    testImplementation(misc.junit4)
-    testImplementation("org.slf4j:slf4j-simple")
+    testImplementation("org.slf4j:slf4j-simple:1.7.32")
     testImplementation("net.imagej:imagej")
     testImplementation("net.imagej:ij")
     testImplementation("net.imglib2:imglib2-ij")

--- a/src/main/kotlin/graphics/scenery/repl/REPL.kt
+++ b/src/main/kotlin/graphics/scenery/repl/REPL.kt
@@ -46,8 +46,7 @@ class REPL @JvmOverloads constructor(override var hub : Hub?, scijavaContext: Co
             interpreterWindow?.isVisible = false
             repl = interpreterWindow?.repl
         } else {
-            repl = ScriptREPL(context, System.out)
-            repl?.lang("Python")
+            repl = ScriptREPL(context, "Python", System.out)
             repl?.initialize()
         }
 


### PR DESCRIPTION
This PR
* bumps Kotlin to 1.6.10
* bumps dokka to 1.6.0
* bumps kotlinx-coroutines to 1.5.2-native-mt
* bumps slf4j-simple/slf4j to 1.7.32
* bumps JOCL to 2.0.4
* bumps scijava-common to 2.78.1
* bumps jackson to 2.13.0
* bumps jeromq to 0.5.2
* bumps kryo to 5.2.0
* bumps msgpack to 0.9.0
* bumps ffmpeg to 4.3.2-1.5.5
* bumps ClassGraph to 4.8.137
* removes Reflections
* creates the REPL directly with Python as language to improve startup time