### PR TITLE
Correct screen point to ray conversion

### DIFF
--- a/src/main/kotlin/graphics/scenery/Scene.kt
+++ b/src/main/kotlin/graphics/scenery/Scene.kt
@@ -209,11 +209,11 @@ open class Scene : DefaultNode("RootNode"), HasRenderable, HasMaterial, HasSpati
             indicatorMaterial.specular = Vector3f(1.0f, 0.2f, 0.2f)
             indicatorMaterial.ambient = Vector3f(0.0f, 0.0f, 0.0f)
 
-            for(it in 5..50) {
-                val s = Box(Vector3f(0.08f, 0.08f, 0.08f))
+            for(it in 1..20) {
+                val s = Box(Vector3f(0.03f))
                 s.setMaterial(indicatorMaterial)
                 s.spatial {
-                    this.position = position + direction * it.toFloat()
+                    this.position = position + direction * (it.toFloat() * 0.5f)
                 }
                 this.addChild(s)
             }
@@ -226,14 +226,14 @@ open class Scene : DefaultNode("RootNode"), HasRenderable, HasMaterial, HasSpati
                 Stream.concat(Stream.of(it as Node), it.instances.map { instanceNode -> instanceNode as Node }.stream())
             else
                 Stream.of(it)).asSequence()
-        }.map {
-            Pair(it, it.spatialOrNull()?.intersectAABB(position, direction))
-        }.filter {
-            it.first !is InstancedNode
-        }.filter {
-            it.second is MaybeIntersects.Intersection && (it.second as MaybeIntersects.Intersection).distance > 0.0f
-        }.map {
-            RaycastMatch(it.first, (it.second as MaybeIntersects.Intersection).distance)
+        }.mapNotNull {
+            val p = Pair(it, it.spatialOrNull()?.intersectAABB(position, direction))
+            if(p.first !is InstancedNode && p.second is MaybeIntersects.Intersection
+                && (p.second as MaybeIntersects.Intersection).distance > 0.0f) {
+                RaycastMatch(p.first, (p.second as MaybeIntersects.Intersection).distance)
+            } else {
+                null
+            }
         }.sortedBy {
             it.distance
         }
@@ -246,9 +246,7 @@ open class Scene : DefaultNode("RootNode"), HasRenderable, HasMaterial, HasSpati
             m.specular = Vector3f(0.0f, 0.0f, 0.0f)
             m.ambient = Vector3f(0.0f, 0.0f, 0.0f)
 
-            matches.firstOrNull()?.let {
-                it.node.setMaterial(m)
-            }
+            matches.firstOrNull()?.node?.setMaterial(m)
         }
 
         return RaycastResult(matches, position, direction)

--- a/src/test/kotlin/graphics/scenery/tests/examples/advanced/MouseInputExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/advanced/MouseInputExample.kt
@@ -26,9 +26,9 @@ import kotlin.concurrent.thread
  * @author Ulrik Günther <hello@ulrik.is>
  * @author Jan Tiemann
  */
-class MouseInputExample : SceneryBase("MouseInputExample", wantREPL = true) {
+class MouseInputExample : SceneryBase("MouseInputExample", 1280, 720) {
     override fun init() {
-        renderer = hub.add(Renderer.createRenderer(hub, applicationName, scene, 512, 512))
+        renderer = hub.add(Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight))
 
         for (i in 0 until 200) {
             if (i % 2 == 0) {
@@ -70,7 +70,7 @@ class MouseInputExample : SceneryBase("MouseInputExample", wantREPL = true) {
         val cam: Camera = DetachedHeadCamera()
         with(cam) {
             spatial().position = Vector3f(0.0f, 0.0f, 5.0f)
-            perspectiveCamera(50.0f, 512, 512)
+            perspectiveCamera(50.0f, windowWidth, windowHeight)
 
             scene.addChild(this)
         }

--- a/src/test/kotlin/graphics/scenery/tests/unit/CameraTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/CameraTests.kt
@@ -84,7 +84,7 @@ class CameraTests {
             val b = Box()
             b.spatial().position = Vector3f(0.0f,
                 0f,
-                Random.randomFromRange(2.0f, 10.0f))
+                Random.randomFromRange(-2.0f, -10.0f))
             s.addChild(b)
             b
         }
@@ -108,8 +108,14 @@ class CameraTests {
 
         val (pos,dir) = cam.screenPointToRay(1280/2,720/2)
 
-        assertEquals(Vector3f(0f,0f,0.01f),pos, "ray start position")
-        assertEquals(Vector3f(0f,0f,1f),dir, "ray direction")
+        val epsilon = 0.001f
+        assertEquals(0.0f, pos.x, epsilon, "Position X")
+        assertEquals(0.0f, pos.y, epsilon, "Position Y")
+        assertEquals(-1.0f, pos.z, epsilon, "Position Z")
+
+        assertEquals(0.0f, dir.x, epsilon, "Direction X")
+        assertEquals(0.0f, dir.y, epsilon, "Direction Y")
+        assertEquals(-1.0f, dir.z, epsilon, "Direction Z")
 
     }
 }


### PR DESCRIPTION
This PR fixes #381. The skewness for creating world-space rays from screen-space positions was caused by an incorrect data type for calculating the aspect ratio, with `width/height` being used, and resulting in an integer, while `width.toFloat()/height.toFloat()` would have been correct. The screenPointToRay() method was also refactored for improved readability.

Thanks to @moreApi for the bug report!