### PR TITLE
Remove performance cost of unused slicing planes

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -216,7 +216,7 @@ open class VulkanObjectState : NodeMetadata {
 
     /**
      * Returns the descriptor set named [textureSet] containing referring to the textures needed in a given [passname].
-     * If [textureSet] is not found for [passname], null is returned.
+     * If [textureSet] is not found for [passname], null is returne
      */
     fun getTextureDescriptorSet(passname: String, textureSet: String = ""): Long? {
         val texture = if(textureSet == "") {

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -690,7 +690,7 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
         }
 
         /** Amount of supported slicing planes per volume, see also sampling shader segments */
-        private const val MAX_SUPPORTED_SLICING_PLANES = 16
+        internal const val MAX_SUPPORTED_SLICING_PLANES = 16
 
     }
 

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
@@ -285,13 +285,14 @@ class VolumeManager(
             "sampleVolume",
             "convert",
             "slicingPlanes",
-            "slicingMode"
+            "slicingMode",
+            "usedSlicingPlanes"
         )
         segments[SegmentType.SampleVolume] = SegmentTemplate(
             "SampleSimpleVolume.frag",
             "im", "sourcemax", "intersectBoundingBox",
             "volume", "transferFunction", "colorMap", "sampleVolume", "convert", "slicingPlanes",
-            "slicingMode"
+            "slicingMode", "usedSlicingPlanes"
         )
         segments[SegmentType.Convert] = SegmentTemplate(
             "Converter.frag",
@@ -461,6 +462,8 @@ class VolumeManager(
                     currentProg.registerCustomSampler(i, "colorMap", state.colorMap)
                     currentProg.setCustomFloatArrayUniformForVolume(i, "slicingPlanes", 4, state.node.slicingArray())
                     currentProg.setCustomUniformForVolume(i, "slicingMode", state.node.slicingMode.id)
+                    currentProg.setCustomUniformForVolume(i,"usedSlicingPlanes",
+                        min(state.node.slicingPlaneEquations.size, Volume.MAX_SUPPORTED_SLICING_PLANES))
 
                     context.bindTexture(state.transferFunction)
                     context.bindTexture(state.colorMap)

--- a/src/main/resources/graphics/scenery/volumes/SampleBlockVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/SampleBlockVolume.frag
@@ -5,6 +5,7 @@ uniform vec3 sourcemin;
 uniform vec3 sourcemax;
 uniform vec4 slicingPlanes[16];
 uniform int slicingMode;
+uniform int usedSlicingPlanes;
 
 void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float tfar )
 {
@@ -28,7 +29,7 @@ vec4 sampleVolume( vec4 wpos, sampler3D volumeCache, vec3 cacheSize, vec3 blockS
     bool isCropped = false;
     bool isInSlice = false;
 
-    for(int i = 0; i < 16; i++){
+    for(int i = 0; i < usedSlicingPlanes; i++){
         vec4 slicingPlane = slicingPlanes[i];
         float dv = slicingPlane.x * wpos.x + slicingPlane.y * wpos.y + slicingPlane.z * wpos.z;
 

--- a/src/main/resources/graphics/scenery/volumes/SampleSimpleVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/SampleSimpleVolume.frag
@@ -2,6 +2,7 @@ uniform mat4 im;
 uniform vec3 sourcemax;
 uniform vec4 slicingPlanes[16];
 uniform int slicingMode;
+uniform int usedSlicingPlanes;
 
 void intersectBoundingBox( vec4 wfront, vec4 wback, out float tnear, out float tfar )
 {
@@ -22,7 +23,7 @@ vec4 sampleVolume( vec4 wpos )
     bool isCropped = false;
     bool isInSlice = false;
 
-    for(int i = 0; i < 16; i++){
+    for(int i = 0; i < usedSlicingPlanes; i++){
         vec4 slicingPlane = slicingPlanes[i];
         float dv = slicingPlane.x * wpos.x + slicingPlane.y * wpos.y + slicingPlane.z * wpos.z;
 


### PR DESCRIPTION
Volume/Manager, Sample*Volume.frag: only consider used slicing planes in shader -> better performance