### PR TITLE
Vulkan: macOS and Apple Silicon support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            java: 8
-          - os: ubuntu-latest
             java: 11
           - os: ubuntu-latest
             java: 16
@@ -42,8 +40,6 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            java: 8
-          - os: windows-latest
             java: 11
           - os: windows-latest
             java: 16
@@ -68,8 +64,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
-            java: 8
           - os: macos-latest
             java: 11
           - os: macos-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ unit-tests-no-gpu:
       - "hs_err_*"
 
 scenery-nvidia:
-  image: scenerygraphics/nvidia-vulkan:1.2.170.0-ubuntu20.04
+  image: scenerygraphics/nvidia-vulkan:1.3.216.0-ubuntu20.04
   <<: *base-job-gpu
   after_script:
     - nvidia-smi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -180,8 +180,15 @@ tasks {
                     "-xxhash",
                     "-remotery",
                     "-spvc",
-                    "-shaderc"
-                ).forEach { lwjglProject ->
+                    "-shaderc",
+                    "-vulkan",
+                ).forEach pkg@ { lwjglProject ->
+                    // OpenVR does not have macOS binaries, Vulkan only has macOS binaries
+                    if((lwjglProject.contains("openvr") && nativePlatform.contains("mac"))
+                            || (lwjglProject.contains("vulkan") && !nativePlatform.contains("mac"))) {
+                        return@pkg
+                    }
+
                     val dependencyNode = dependenciesNode.appendNode("dependency")
                     dependencyNode.appendNode("groupId", "org.lwjgl")
                     dependencyNode.appendNode("artifactId", "lwjgl$lwjglProject")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,7 +200,7 @@ tasks {
             dependencyNodeLWJGLVulkan.appendNode("scope", "runtime")
 
             // jvrpn natives
-            lwjglNatives.forEach {
+            lwjglNatives.filter { !it.contains("arm") }.forEach {
                 val dependencyNode = dependenciesNode.appendNode("dependency")
                 dependencyNode.appendNode("groupId", "graphics.scenery")
                 dependencyNode.appendNode("artifactId", "jvrpn")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import java.net.URL
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    val ktVersion = "1.6.10"
+    val ktVersion = "1.7.0"
     java
     kotlin("jvm") version ktVersion
     kotlin("kapt") version ktVersion
@@ -14,7 +14,7 @@ plugins {
     scenery.publish
     scenery.sign
     id("com.github.elect86.sciJava") version "0.0.4"
-    id("org.jetbrains.dokka") version "1.6.0"
+    id("org.jetbrains.dokka") version "1.6.21"
     id("org.sonarqube") version "3.3"
     jacoco
     id("com.github.johnrengelman.shadow") version "7.1.0"
@@ -30,17 +30,17 @@ repositories {
 
 dependencies {
     implementation(platform("org.scijava:pom-scijava:31.1.0"))
-    annotationProcessor("org.scijava:scijava-common:2.87.1")
+    annotationProcessor("org.scijava:scijava-common:2.88.1")
 
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2-native-mt")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
     implementation("org.jogamp.gluegen:gluegen-rt:2.3.2", joglNatives)
     implementation("org.jogamp.jogl:jogl-all:2.3.2", joglNatives)
-    implementation("org.slf4j:slf4j-api:1.7.32")
+    implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("net.clearvolume:cleargl")
-    implementation("org.joml:joml:1.10.2")
+    implementation("org.joml:joml:1.10.4")
     implementation("net.java.jinput:jinput:2.0.9", "natives-all")
     implementation("org.jocl:jocl:2.0.4")
     implementation("org.scijava:scijava-common")
@@ -48,7 +48,7 @@ dependencies {
     implementation("org.scijava:ui-behaviour")
     implementation("org.scijava:scripting-javascript")
     implementation("org.scijava:scripting-jython")
-    implementation("net.java.dev.jna:jna-platform:5.9.0")
+    implementation("net.java.dev.jna:jna-platform:5.11.0")
 
     val lwjglVersion = "3.3.1"
     listOf("",
@@ -79,20 +79,20 @@ dependencies {
             }
         }
     }
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.0")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.3")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.3")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3")
     implementation("org.zeromq:jeromq:0.5.2")
-    implementation("com.esotericsoftware:kryo:5.2.0")
+    implementation("com.esotericsoftware:kryo:5.3.0")
     implementation("de.javakaffee:kryo-serializers:0.45")
-    implementation("org.msgpack:msgpack-core:0.9.0")
-    implementation("org.msgpack:jackson-dataformat-msgpack:0.9.0")
+    implementation("org.msgpack:msgpack-core:0.9.1")
+    implementation("org.msgpack:jackson-dataformat-msgpack:0.9.1")
     api("graphics.scenery:jvrpn:1.2.0", lwjglNatives.filter { !it.contains("arm") }.toTypedArray())
     implementation("io.scif:scifio")
     implementation("org.bytedeco:ffmpeg:4.3.2-1.5.5", ffmpegNatives)
-    implementation("io.github.classgraph:classgraph:4.8.137")
+    implementation("io.github.classgraph:classgraph:4.8.147")
 
-    implementation("info.picocli:picocli:4.6.2")
+    implementation("info.picocli:picocli:4.6.3")
 
     api("sc.fiji:bigdataviewer-core:10.2.0")
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
@@ -101,7 +101,7 @@ dependencies {
     api("graphics.scenery:bigvolumeviewer:a6b021d")
 
 //    implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
-    implementation("com.github.skalarproduktraum:lwjgl3-awt:f298596")
+    implementation("com.github.skalarproduktraum:lwjgl3-awt:d7a7369")
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {
@@ -119,7 +119,7 @@ dependencies {
     //    implementation("com.github.kotlin-graphics:assimp:25c68811")
 
 //    testImplementation(misc.junit4)
-    testImplementation("org.slf4j:slf4j-simple:1.7.32")
+    testImplementation("org.slf4j:slf4j-simple:1.7.36")
     testImplementation("net.imagej:imagej")
     testImplementation("net.imagej:ij")
     testImplementation("net.imglib2:imglib2-ij")
@@ -136,8 +136,8 @@ tasks {
         kotlinOptions {
             jvmTarget = project.properties["jvmTarget"]?.toString() ?: default
             freeCompilerArgs += listOf("-Xinline-classes", "-Xopt-in=kotlin.RequiresOptIn")
+//            sourceCompatibility = project.properties["sourceCompatibility"]?.toString() ?: default
         }
-        sourceCompatibility = project.properties["sourceCompatibility"]?.toString() ?: default
     }
 
     withType<GenerateMavenPom>().configureEach {
@@ -148,25 +148,25 @@ tasks {
 
         pom.withXml {
             // Add parent to the generated pom
-            var parent = asNode().appendNode("parent")
+            val parent = asNode().appendNode("parent")
             parent.appendNode("groupId", "org.scijava")
             parent.appendNode("artifactId", "pom-scijava")
             parent.appendNode("version", "31.1.0")
             parent.appendNode("relativePath")
 
-            var repositories = asNode().appendNode("repositories")
-            var jitpackRepo = repositories.appendNode("repository")
+            val repositories = asNode().appendNode("repositories")
+            val jitpackRepo = repositories.appendNode("repository")
             jitpackRepo.appendNode("id", "jitpack.io")
             jitpackRepo.appendNode("url", "https://jitpack.io")
 
-            var scijavaRepo = repositories.appendNode("repository")
+            val scijavaRepo = repositories.appendNode("repository")
             scijavaRepo.appendNode("id", "scijava.public")
             scijavaRepo.appendNode("url", "https://maven.scijava.org/content/groups/public")
 
             
             // Update the dependencies and properties
-            var dependenciesNode = asNode().appendNode("dependencies")
-            var propertiesNode = asNode().appendNode("properties")
+            val dependenciesNode = asNode().appendNode("dependencies")
+            val propertiesNode = asNode().appendNode("properties")
             propertiesNode.appendNode("inceptionYear", 2016)
 
             // lwjgl natives
@@ -182,7 +182,7 @@ tasks {
                     "-spvc",
                     "-shaderc"
                 ).forEach { lwjglProject ->
-                    var dependencyNode = dependenciesNode.appendNode("dependency")
+                    val dependencyNode = dependenciesNode.appendNode("dependency")
                     dependencyNode.appendNode("groupId", "org.lwjgl")
                     dependencyNode.appendNode("artifactId", "lwjgl$lwjglProject")
                     dependencyNode.appendNode("version", "\${lwjgl.version}")
@@ -192,7 +192,7 @@ tasks {
             }
 
             // lwjgl-vulkan native for macos
-            var dependencyNodeLWJGLVulkan = dependenciesNode.appendNode("dependency")
+            val dependencyNodeLWJGLVulkan = dependenciesNode.appendNode("dependency")
             dependencyNodeLWJGLVulkan.appendNode("groupId", "org.lwjgl")
             dependencyNodeLWJGLVulkan.appendNode("artifactId", "lwjgl-vulkan")
             dependencyNodeLWJGLVulkan.appendNode("version", "\${lwjgl.version}")
@@ -201,7 +201,7 @@ tasks {
 
             // jvrpn natives
             lwjglNatives.forEach {
-                var dependencyNode = dependenciesNode.appendNode("dependency")
+                val dependencyNode = dependenciesNode.appendNode("dependency")
                 dependencyNode.appendNode("groupId", "graphics.scenery")
                 dependencyNode.appendNode("artifactId", "jvrpn")
                 dependencyNode.appendNode("version", "\${jvrpn.version}")
@@ -212,7 +212,7 @@ tasks {
             propertiesNode.appendNode("jvrpn.version", "1.2.0")
 
             // jinput natives
-            var dependencyNode = dependenciesNode.appendNode("dependency")
+            val dependencyNode = dependenciesNode.appendNode("dependency")
             dependencyNode.appendNode("groupId", "net.java.jinput")
             dependencyNode.appendNode("artifactId", "jinput")
             dependencyNode.appendNode("version", "2.0.9")
@@ -264,18 +264,18 @@ tasks {
             val toSkip = listOf("pom-scijava")
             
             configurations.implementation.allDependencies.forEach {
-                var artifactId = it.name
+                val artifactId = it.name
 
                 if( !toSkip.contains(artifactId) ) {
                     
-                    var propertyName = "$artifactId.version"
+                    val propertyName = "$artifactId.version"
 
                     if( versionedArtifacts.contains(artifactId) ) {
                         // add "<artifactid.version>[version]</artifactid.version>" to pom
                         propertiesNode.appendNode(propertyName, it.version)
                     }
 
-                    var dependencyNode = dependenciesNode.appendNode("dependency")
+                    val dependencyNode = dependenciesNode.appendNode("dependency")
                     dependencyNode.appendNode("groupId", it.group)
                     dependencyNode.appendNode("artifactId", artifactId)
                     dependencyNode.appendNode("version", "\${$propertyName}")
@@ -287,11 +287,11 @@ tasks {
                     }
                     // from https://github.com/scenerygraphics/sciview/pull/399#issuecomment-904732945
                     if(artifactId == "formats-gpl") {
-                        var exclusions = dependencyNode.appendNode("exclusions")
-                        var jacksonCore = exclusions.appendNode("exclusion")
+                        val exclusions = dependencyNode.appendNode("exclusions")
+                        val jacksonCore = exclusions.appendNode("exclusion")
                         jacksonCore.appendNode("groupId", "com.fasterxml.jackson.core")
                         jacksonCore.appendNode("artifactId", "jackson-core")
-                        var jacksonAnnotations = exclusions.appendNode("exclusion")
+                        val jacksonAnnotations = exclusions.appendNode("exclusion")
                         jacksonAnnotations.appendNode("groupId", "com.fasterxml.jackson.core")
                         jacksonAnnotations.appendNode("artifactId", "jackson-annotations")
                     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,10 +107,11 @@ dependencies {
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {
-        implementation("org.biojava:biojava-$it:5.4.0") {
+        implementation("org.biojava:biojava-$it:6.0.5") {
             exclude("org.slf4j", "slf4j-api")
             exclude("org.slf4j", "slf4j-simple")
             exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+            exclude("org.biojava.thirdparty", "forester")
         }
     }
     implementation("org.jetbrains.kotlin:kotlin-scripting-jsr223:1.5.31")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,11 +21,11 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://maven.scijava.org/content/groups/public")
     maven("https://jitpack.io")
+    mavenLocal()
 }
 
 dependencies {
@@ -101,7 +101,7 @@ dependencies {
     api("graphics.scenery:bigvolumeviewer:a6b021d")
 
 //    implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
-    implementation("org.lwjglx:lwjgl3-awt:0.1.9-localbuild")
+    implementation("com.github.skalarproduktraum:lwjgl3-awt:f298596")
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,8 +94,12 @@ dependencies {
 
     implementation("info.picocli:picocli:4.6.3")
 
-    api("sc.fiji:bigdataviewer-core:10.2.0")
+    api("sc.fiji:bigdataviewer-core:10.4.0")
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
+    // TODO: These are still needed for HDF5 support to work on M1
+    // api(files("sis-base-18.09.0.jar"))
+    // api(files("sis-jhdf5-1654327451.jar"))
+
 
     //TODO revert to official BVV
     api("graphics.scenery:bigvolumeviewer:a6b021d")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.1")
     api("graphics.scenery:jvrpn:1.2.0", lwjglNatives.filter { !it.contains("arm") }.toTypedArray())
     implementation("io.scif:scifio")
-    implementation("org.bytedeco:ffmpeg:4.3.2-1.5.5", ffmpegNatives)
+    implementation("org.bytedeco:ffmpeg:5.0-1.5.7", ffmpegNatives)
     implementation("io.github.classgraph:classgraph:4.8.147")
 
     implementation("info.picocli:picocli:4.6.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://maven.scijava.org/content/groups/public")
@@ -49,7 +50,7 @@ dependencies {
     implementation("org.scijava:scripting-jython")
     implementation("net.java.dev.jna:jna-platform:5.9.0")
 
-    val lwjglVersion = "3.3.0"
+    val lwjglVersion = "3.3.1"
     listOf("",
         "-glfw",
         "-jemalloc",
@@ -63,8 +64,17 @@ dependencies {
     ).forEach { lwjglProject ->
         api("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion")
 
-        if (lwjglProject != "-vulkan") {
-            lwjglNatives.forEach { native ->
+        lwjglNatives.forEach { native ->
+            if (lwjglProject.endsWith("-vulkan")) {
+                if (!native.contains("linux") && !native.contains("win")) {
+                    runtimeOnly("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion:$native")
+                }
+            }
+            else if (lwjglProject.endsWith("-openvr")) {
+                if (native.contains("linux") && native.contains("win")) {
+                    runtimeOnly("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion:$native")
+                }
+            } else {
                 runtimeOnly("org.lwjgl:lwjgl$lwjglProject:$lwjglVersion:$native")
             }
         }
@@ -77,7 +87,7 @@ dependencies {
     implementation("de.javakaffee:kryo-serializers:0.45")
     implementation("org.msgpack:msgpack-core:0.9.0")
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.0")
-    api("graphics.scenery:jvrpn:1.2.0", lwjglNatives)
+    api("graphics.scenery:jvrpn:1.2.0", lwjglNatives.filter { !it.contains("arm") }.toTypedArray())
     implementation("io.scif:scifio")
     implementation("org.bytedeco:ffmpeg:4.3.2-1.5.5", ffmpegNatives)
     implementation("io.github.classgraph:classgraph:4.8.137")
@@ -90,7 +100,8 @@ dependencies {
     //TODO revert to official BVV
     api("graphics.scenery:bigvolumeviewer:a6b021d")
 
-    implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
+//    implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
+    implementation("org.lwjglx:lwjgl3-awt:0.1.9-localbuild")
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {

--- a/buildSrc/src/main/kotlin/scenery/utils.kt
+++ b/buildSrc/src/main/kotlin/scenery/utils.kt
@@ -72,5 +72,5 @@ fun DependencyHandlerScope.api(dep: String, natives: Array<String>) {
 }
 
 val joglNatives = arrayOf("natives-windows-amd64", "natives-linux-i586", "natives-linux-amd64", "natives-macosx-universal")
-val lwjglNatives = arrayOf("natives-windows", "natives-linux", "natives-macos")
+val lwjglNatives = arrayOf("natives-windows", "natives-linux", "natives-macos", "natives-macos-arm64")
 val ffmpegNatives = arrayOf("windows-x86_64", "linux-x86_64", "macosx-x86_64")

--- a/buildSrc/src/main/kotlin/scenery/utils.kt
+++ b/buildSrc/src/main/kotlin/scenery/utils.kt
@@ -73,4 +73,4 @@ fun DependencyHandlerScope.api(dep: String, natives: Array<String>) {
 
 val joglNatives = arrayOf("natives-windows-amd64", "natives-linux-i586", "natives-linux-amd64", "natives-macosx-universal")
 val lwjglNatives = arrayOf("natives-windows", "natives-linux", "natives-macos", "natives-macos-arm64")
-val ffmpegNatives = arrayOf("windows-x86_64", "linux-x86_64", "macosx-x86_64")
+val ffmpegNatives = arrayOf("windows-x86_64", "linux-x86_64", "macosx-x86_64", "macosx-arm64")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 org.gradle.caching=true
+kotlinVersion=1.7.10
+dokkaVersion=1.7.10
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
-distributionSha256Sum=23b89f8eac363f5f4b8336e0530c7295c55b728a9caa5268fdd4a532610d5392
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,14 @@
 
 pluginManagement {
+    val kotlinVersion: String by settings
+    val dokkaVersion: String by settings
+
+    plugins {
+        kotlin("jvm") version kotlinVersion
+        kotlin("kapt") version kotlinVersion
+        id("org.jetbrains.dokka") version dokkaVersion
+    }
+
     repositories {
         gradlePluginPortal()
     }

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -447,7 +447,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
         }
 
         hub.addApplication(this)
-        logger.info("Started application as PID ${getProcessID()}")
+        logger.info("Started application as PID ${getProcessID()} on ${Platform.get()}/${Platform.getArchitecture()}")
         running = true
 
         if(parseBoolean(System.getProperty("scenery.Profiler", "false"))) {

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -106,6 +106,17 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
         AssertionCheckPoint.AfterClose to arrayListOf()
     )
 
+    val headless = parseBoolean(System.getProperty("scenery.Headless", "false"))
+    val renderdoc = if(System.getProperty("scenery.AttachRenderdoc")?.toBoolean() == true) {
+        Renderdoc()
+    } else {
+        null
+    }
+
+    val master = System.getProperty("scenery.master")?.toBoolean() ?: false
+    val masterAddress = System.getProperty("scenery.MasterNode")
+
+
     interface XLib: Library {
         fun XInitThreads()
 
@@ -146,84 +157,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
      *
      */
     open suspend fun sceneryMain() {
-        System.getProperties().forEach { prop ->
-            val name = prop.key as? String ?: return@forEach
-            val value = prop.value as? String ?: return@forEach
 
-            if(name.startsWith("scenery.LogLevel.")) {
-                val className = name.substringAfter("scenery.LogLevel.")
-                logger.info("Setting logging level of class $className to $value")
-                System.setProperty("org.slf4j.simpleLogger.log.${className}", value)
-            }
-        }
-
-        hub.addApplication(this)
-        logger.info("Started application as PID ${getProcessID()}")
-        running = true
-
-        if(parseBoolean(System.getProperty("scenery.Profiler", "false"))) {
-            hub.add(RemoteryProfiler(hub))
-        }
-
-        val headless = parseBoolean(System.getProperty("scenery.Headless", "false"))
-        val renderdoc = if(System.getProperty("scenery.AttachRenderdoc")?.toBoolean() == true) {
-            Renderdoc()
-        } else {
-            null
-        }
-
-        val master = System.getProperty("scenery.master")?.toBoolean() ?: false
-        val masterAddress = System.getProperty("scenery.MasterNode")
-
-        if (!master && masterAddress != null) {
-            thread {
-                logger.info("NodeSubscriber will connect to master at $masterAddress")
-                val subscriber = NodeSubscriber(hub, masterAddress)
-
-                hub.add(SceneryElement.NodeSubscriber, subscriber)
-                scene.discover(scene, { true }).forEachIndexed { index, node ->
-                    subscriber.nodes.put(index, node)
-                }
-
-                while (running && !shouldClose) {
-                    subscriber.process()
-                    Thread.sleep(2)
-                }
-                logger.debug("Closing subscriber")
-            }
-        } else if(master) {
-            applicationName += " [MASTER]"
-            thread {
-                val address = settings.get("NodePublisher.ListenAddress", "tcp://127.0.0.1:6666")
-                val p = NodePublisher(hub, address)
-
-                logger.info("NodePublisher listening on ${address.substringBeforeLast(":")}:${p.port}")
-                hub.add(SceneryElement.NodePublisher, p)
-
-                scene.discover(scene, { true }).forEachIndexed { index, node ->
-                        p.nodes.put(index, node)
-                }
-
-                while (running && !shouldClose) {
-                    p.publish()
-                    Thread.sleep(2)
-                }
-                logger.debug("Closing publisher")
-            }
-        }
-
-        hub.add(SceneryElement.Statistics, stats)
-        hub.add(SceneryElement.Settings, settings)
-
-        settings.set("System.PID", getProcessID())
-
-        if (wantREPL) {
-            repl = REPL(hub, scijavaContext, scene, stats, hub)
-            repl?.addAccessibleObject(settings)
-        }
-
-        // initialize renderer, etc first in init, then setup key bindings
-        init()
 
         // wait for renderer
         while(renderer?.initialized == false) {
@@ -501,6 +435,75 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     }
 
     open fun main() {
+        System.getProperties().forEach { prop ->
+            val name = prop.key as? String ?: return@forEach
+            val value = prop.value as? String ?: return@forEach
+
+            if(name.startsWith("scenery.LogLevel.")) {
+                val className = name.substringAfter("scenery.LogLevel.")
+                logger.info("Setting logging level of class $className to $value")
+                System.setProperty("org.slf4j.simpleLogger.log.${className}", value)
+            }
+        }
+
+        hub.addApplication(this)
+        logger.info("Started application as PID ${getProcessID()}")
+        running = true
+
+        if(parseBoolean(System.getProperty("scenery.Profiler", "false"))) {
+            hub.add(RemoteryProfiler(hub))
+        }
+
+
+        if (!master && masterAddress != null) {
+            thread {
+                logger.info("NodeSubscriber will connect to master at $masterAddress")
+                val subscriber = NodeSubscriber(hub, masterAddress)
+
+                hub.add(SceneryElement.NodeSubscriber, subscriber)
+                scene.discover(scene, { true }).forEachIndexed { index, node ->
+                    subscriber.nodes.put(index, node)
+                }
+
+                while (running && !shouldClose) {
+                    subscriber.process()
+                    Thread.sleep(2)
+                }
+                logger.debug("Closing subscriber")
+            }
+        } else if(master) {
+            applicationName += " [MASTER]"
+            thread {
+                val address = settings.get("NodePublisher.ListenAddress", "tcp://127.0.0.1:6666")
+                val p = NodePublisher(hub, address)
+
+                logger.info("NodePublisher listening on ${address.substringBeforeLast(":")}:${p.port}")
+                hub.add(SceneryElement.NodePublisher, p)
+
+                scene.discover(scene, { true }).forEachIndexed { index, node ->
+                    p.nodes.put(index, node)
+                }
+
+                while (running && !shouldClose) {
+                    p.publish()
+                    Thread.sleep(2)
+                }
+                logger.debug("Closing publisher")
+            }
+        }
+
+        hub.add(SceneryElement.Statistics, stats)
+        hub.add(SceneryElement.Settings, settings)
+
+        settings.set("System.PID", getProcessID())
+
+        if (wantREPL) {
+            repl = REPL(hub, scijavaContext, scene, stats, hub)
+            repl?.addAccessibleObject(settings)
+        }
+
+        // initialize renderer, etc first in init, then setup key bindings
+        init()
         runBlocking { sceneryMain() }
     }
 

--- a/src/main/kotlin/graphics/scenery/backends/Renderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/Renderer.kt
@@ -11,6 +11,7 @@ import graphics.scenery.utils.SceneryPanel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.selects.select
+import org.lwjgl.system.Platform
 import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
@@ -255,6 +256,10 @@ abstract class Renderer : Hubable {
                 preference == null &&
                     (ExtractsNatives.getPlatform() == ExtractsNatives.Platform.LINUX
                         || ExtractsNatives.getPlatform() == ExtractsNatives.Platform.WINDOWS) -> "VulkanRenderer"
+
+                preference == null &&
+                    ExtractsNatives.getPlatform() == ExtractsNatives.Platform.MACOS &&
+                    Platform.getArchitecture() == Platform.Architecture.ARM64 -> "VulkanRenderer"
 
                 preference == null &&
                     ExtractsNatives.getPlatform() == ExtractsNatives.Platform.MACOS -> "OpenGLRenderer"

--- a/src/main/kotlin/graphics/scenery/backends/SceneryWindow.kt
+++ b/src/main/kotlin/graphics/scenery/backends/SceneryWindow.kt
@@ -45,7 +45,7 @@ open class SceneryWindow {
             field = value
             when(this) {
                 is UninitializedWindow -> {}
-                is GLFWWindow -> glfwSetWindowTitle(window, value)
+                is GLFWWindow -> {}//glfwSetWindowTitle(window, value)
                 is ClearGLWindow -> window.windowTitle = value
                 is SwingWindow -> {
                     val window = SwingUtilities.getWindowAncestor(panel)

--- a/src/main/kotlin/graphics/scenery/backends/SceneryWindow.kt
+++ b/src/main/kotlin/graphics/scenery/backends/SceneryWindow.kt
@@ -45,7 +45,7 @@ open class SceneryWindow {
             field = value
             when(this) {
                 is UninitializedWindow -> {}
-                is GLFWWindow -> {}//glfwSetWindowTitle(window, value)
+                is GLFWWindow -> glfwSetWindowTitle(window, value)
                 is ClearGLWindow -> window.windowTitle = value
                 is SwingWindow -> {
                     val window = SwingUtilities.getWindowAncestor(panel)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/SwingSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/SwingSwapchain.kt
@@ -159,7 +159,7 @@ open class SwingSwapchain(override val device: VulkanDevice,
         override var usageCondition = { p: SceneryPanel? ->
             System.getProperty("scenery.Renderer.UseAWT", "false")?.toBoolean() ?: false
                     || p is SceneryJPanel
-                    || Platform.get() == Platform.MACOSX
+                    || (Platform.get() == Platform.MACOSX && System.getProperty("scenery.Headless", "false").toBoolean())
         }
     }
 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -811,6 +811,7 @@ open class VulkanDevice(
                 0x1002 -> "AMD"
                 0x10DE -> "Nvidia"
                 0x8086 -> "Intel"
+                0x106B -> "🍎"
                 else -> "(Unknown vendor)"
             }
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -167,7 +167,7 @@ open class VulkanDevice(
             vkGetPhysicalDeviceFeatures(physicalDevice, enabledFeatures)
             if(!enabledFeatures.samplerAnisotropy()
                 || !enabledFeatures.largePoints()
-                || !enabledFeatures.geometryShader()
+//                || !enabledFeatures.geometryShader()
                 || !enabledFeatures.fillModeNonSolid()) {
                 throw IllegalStateException("Device does not support required features.")
             }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPipeline.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPipeline.kt
@@ -218,7 +218,7 @@ class VulkanPipeline(val device: VulkanDevice, val renderpass: VulkanRenderpass,
         // derivative pipelines only make sense for graphics pipelines in our case
         if(onlyForTopology == null && pipelineCreateInfo is VkGraphicsPipelineCreateInfo.Buffer) {
             // create pipelines for other topologies as well
-            GeometryType.values().forEach { topology ->
+            GeometryType.values().filter { it != GeometryType.TRIANGLE_FAN }.forEach { topology ->
                 if (topology == GeometryType.TRIANGLES) {
                     return@forEach
                 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -29,7 +29,6 @@ import org.lwjgl.vulkan.KHRWin32Surface.VK_KHR_WIN32_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.KHRXlibSurface.VK_KHR_XLIB_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.MVKMacosSurface.VK_MVK_MACOS_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.VK10.*
-import org.lwjgl.vulkan.awt.AWTVK
 import java.awt.BorderLayout
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferByte

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -30,6 +30,7 @@ import org.lwjgl.vulkan.KHRXlibSurface.VK_KHR_XLIB_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.MVKMacosSurface.VK_MVK_MACOS_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.VK10.*
 import org.lwjgl.vulkan.awt.AWTVK
+import java.awt.BorderLayout
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferByte
 import java.io.File
@@ -40,6 +41,7 @@ import java.util.*
 import java.util.concurrent.*
 import java.util.concurrent.locks.ReentrantLock
 import javax.imageio.ImageIO
+import javax.swing.JFrame
 import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
 import kotlin.reflect.full.*
@@ -478,6 +480,19 @@ open class VulkanRenderer(hub: Hub,
                 }
             }
 
+            // GLFW works kinda shaky on macOS, we create a JFrame here for a nicer experience then.
+            // That is of course unless [embedIn] is already set.
+            if(Platform.get() == Platform.MACOSX && embedIn == null) {
+                val mainFrame = JFrame(applicationName)
+                mainFrame.setSize(windowWidth, windowHeight)
+                mainFrame.layout = BorderLayout()
+
+                val sceneryPanel = SceneryJPanel()
+                mainFrame.add(sceneryPanel, BorderLayout.CENTER)
+                mainFrame.isVisible = true
+
+                embedIn = sceneryPanel
+            }
 
             // Create the Vulkan instance
             val headlessRequested = System.getProperty("scenery.Headless")?.toBoolean() ?: false

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -1,11 +1,11 @@
 package graphics.scenery.backends.vulkan
 
 import graphics.scenery.*
-import graphics.scenery.backends.*
-import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.attribute.renderable.DelegatesRenderable
 import graphics.scenery.attribute.renderable.HasCustomRenderable
+import graphics.scenery.attribute.renderable.Renderable
+import graphics.scenery.backends.*
 import graphics.scenery.textures.Texture
 import graphics.scenery.utils.*
 import io.github.classgraph.ClassGraph
@@ -29,6 +29,7 @@ import org.lwjgl.vulkan.KHRWin32Surface.VK_KHR_WIN32_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.KHRXlibSurface.VK_KHR_XLIB_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.MVKMacosSurface.VK_MVK_MACOS_SURFACE_EXTENSION_NAME
 import org.lwjgl.vulkan.VK10.*
+import org.lwjgl.vulkan.awt.AWTVK
 import java.awt.image.BufferedImage
 import java.awt.image.DataBufferByte
 import java.io.File
@@ -437,260 +438,273 @@ open class VulkanRenderer(hub: Hub,
     }
 
     init {
-        this.hub = hub
+        stackPush().use { stack ->
+            this.hub = hub
 
-        val hmd = hub.getWorkingHMDDisplay()
-        if (hmd != null) {
-            logger.debug("Setting window dimensions to bounds from HMD")
-            val bounds = hmd.getRenderTargetSize()
-            window.width = bounds.x() * 2
-            window.height = bounds.y()
-        } else {
-            window.width = windowWidth
-            window.height = windowHeight
-        }
-
-        this.applicationName = applicationName
-        this.scene = scene
-
-        this.settings = loadDefaultRendererSettings((hub.get(SceneryElement.Settings) as Settings))
-
-        logger.debug("Loading rendering config from $renderConfigFile")
-        this.renderConfigFile = renderConfigFile
-        this.renderConfig = RenderConfigReader().loadFromFile(renderConfigFile)
-
-        logger.info("Loaded ${renderConfig.name} (${renderConfig.description ?: "no description"})")
-
-        if((System.getenv("ENABLE_VULKAN_RENDERDOC_CAPTURE")?.toInt() == 1  || Renderdoc.renderdocAttached)&& validation) {
-            logger.warn("Validation Layers requested, but Renderdoc capture and Validation Layers are mutually incompatible. Disabling validations layers.")
-            validation = false
-        }
-
-        // explicitly create VK, to make GLFW pick up MoltenVK on OS X
-        if(ExtractsNatives.getPlatform() == ExtractsNatives.Platform.MACOS) {
-            try {
-                Configuration.VULKAN_EXPLICIT_INIT.set(true)
-                VK.create()
-            } catch (e: IllegalStateException) {
-                logger.warn("IllegalStateException during Vulkan initialisation")
-            }
-        }
-
-
-        // Create the Vulkan instance
-        val headlessRequested = System.getProperty("scenery.Headless")?.toBoolean() ?: false
-        instance = if(embedIn != null || headlessRequested) {
-            logger.debug("Running embedded or headless, skipping GLFW initialisation.")
-            createInstance(
-                null,
-                validation,
-                headless = headlessRequested
-            )
-        } else {
-            if (!glfwInit()) {
-                val buffer = PointerBuffer.allocateDirect(255)
-                val error = glfwGetError(buffer)
-
-                val description = if(error != 0) {
-                    buffer.stringUTF8
-                } else {
-                    "no error"
-                }
-                
-                throw RendererUnavailableException("Failed to initialize GLFW: $description ($error)")
-            }
-            if (!glfwVulkanSupported()) {
-                throw RendererUnavailableException("Failed to find Vulkan loader. Is Vulkan supported by your GPU and do you have the most recent graphics drivers installed?")
-            }
-
-            /* Look for instance extensions */
-            val requiredExtensions = glfwGetRequiredInstanceExtensions() ?: throw RendererUnavailableException("Failed to find list of required Vulkan extensions")
-            createInstance(requiredExtensions, validation)
-        }
-
-        debugCallbackHandle = if(validation) {
-            setupDebuggingDebugUtils(instance,
-                VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT
-                    or VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
-                    or VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
-                    or VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT,
-                debugCallbackUtils)
-        } else {
-            -1L
-        }
-
-        val requestedValidationLayers = if(validation) {
-            if(wantsOpenGLSwapchain) {
-                logger.warn("Requested OpenGL swapchain, validation layers disabled.")
-                emptyArray()
+            val hmd = hub.getWorkingHMDDisplay()
+            if (hmd != null) {
+                logger.debug("Setting window dimensions to bounds from HMD")
+                val bounds = hmd.getRenderTargetSize()
+                window.width = bounds.x() * 2
+                window.height = bounds.y()
             } else {
-                defaultValidationLayers
+                window.width = windowWidth
+                window.height = windowHeight
             }
-        } else {
-            emptyArray()
-        }
 
-        // get available swapchains, but remove default swapchain, will always be there as fallback
-        val start = System.nanoTime()
-        val swapchains = ClassGraph()
+            this.applicationName = applicationName
+            this.scene = scene
+
+            this.settings = loadDefaultRendererSettings((hub.get(SceneryElement.Settings) as Settings))
+
+            logger.debug("Loading rendering config from $renderConfigFile")
+            this.renderConfigFile = renderConfigFile
+            this.renderConfig = RenderConfigReader().loadFromFile(renderConfigFile)
+
+            logger.info("Loaded ${renderConfig.name} (${renderConfig.description ?: "no description"})")
+
+            if((System.getenv("ENABLE_VULKAN_RENDERDOC_CAPTURE")?.toInt() == 1  || Renderdoc.renderdocAttached)&& validation) {
+                logger.warn("Validation Layers requested, but Renderdoc capture and Validation Layers are mutually incompatible. Disabling validations layers.")
+                validation = false
+            }
+
+            // explicitly create VK, to make GLFW pick up MoltenVK on OS X
+            if(ExtractsNatives.getPlatform() == ExtractsNatives.Platform.MACOS) {
+                try {
+                    Configuration.VULKAN_EXPLICIT_INIT.set(true)
+                    VK.create()
+                } catch (e: IllegalStateException) {
+                    logger.warn("IllegalStateException during Vulkan initialisation")
+                }
+            }
+
+
+            // Create the Vulkan instance
+            val headlessRequested = System.getProperty("scenery.Headless")?.toBoolean() ?: false
+            instance = if(embedIn != null || headlessRequested) {
+                logger.debug("Running embedded or headless, skipping GLFW initialisation.")
+
+                // macOS needs a Metal surface for embedding
+                val requiredExtensions = if(ExtractsNatives.getPlatform() == ExtractsNatives.Platform.MACOS && !headlessRequested) {
+                    stack.pointers(
+                        stack.UTF8(VK_KHR_SURFACE_EXTENSION_NAME),
+                        stack.UTF8(EXTMetalSurface.VK_EXT_METAL_SURFACE_EXTENSION_NAME)
+                    )
+                } else {
+                    null
+                }
+
+                createInstance(
+                    requiredExtensions,
+                    validation,
+                    headless = headlessRequested
+                )
+            } else {
+                if (!glfwInit()) {
+                    val buffer = PointerBuffer.allocateDirect(255)
+                    val error = glfwGetError(buffer)
+
+                    val description = if(error != 0) {
+                        buffer.stringUTF8
+                    } else {
+                        "no error"
+                    }
+
+                    throw RendererUnavailableException("Failed to initialize GLFW: $description ($error)")
+                }
+                if (!glfwVulkanSupported()) {
+                    throw RendererUnavailableException("Failed to find Vulkan loader. Is Vulkan supported by your GPU and do you have the most recent graphics drivers installed?")
+                }
+
+                /* Look for instance extensions */
+                val requiredExtensions = glfwGetRequiredInstanceExtensions() ?: throw RendererUnavailableException("Failed to find list of required Vulkan extensions")
+                createInstance(requiredExtensions, validation)
+            }
+
+            debugCallbackHandle = if(validation) {
+                setupDebuggingDebugUtils(instance,
+                    VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT
+                        or VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
+                        or VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
+                        or VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT,
+                    debugCallbackUtils)
+            } else {
+                -1L
+            }
+
+            val requestedValidationLayers = if(validation) {
+                if(wantsOpenGLSwapchain) {
+                    logger.warn("Requested OpenGL swapchain, validation layers disabled.")
+                    emptyArray()
+                } else {
+                    defaultValidationLayers
+                }
+            } else {
+                emptyArray()
+            }
+
+            // get available swapchains, but remove default swapchain, will always be there as fallback
+            val start = System.nanoTime()
+            val swapchains = ClassGraph()
                 .acceptPackages("graphics.scenery.backends.vulkan")
                 .enableClassInfo()
                 .scan()
                 .getClassesImplementing("graphics.scenery.backends.vulkan.Swapchain")
                 .filter { cls -> cls.simpleName != "VulkanSwapchain" }
                 .loadClasses()
-        val duration = System.nanoTime() - start
-        logger.debug("Finding swapchains took ${duration/10e6} ms")
+            val duration = System.nanoTime() - start
+            logger.debug("Finding swapchains took ${duration/10e6} ms")
 
-        logger.debug("Available special-purpose swapchains are: ${swapchains.joinToString { it.simpleName }}")
-        val selectedSwapchain = swapchains.firstOrNull { (it.kotlin.companionObjectInstance as SwapchainParameters).usageCondition.invoke(embedIn) }
-        val headless = (selectedSwapchain?.kotlin?.companionObjectInstance as? SwapchainParameters)?.headless ?: false
+            logger.debug("Available special-purpose swapchains are: ${swapchains.joinToString { it.simpleName }}")
+            val selectedSwapchain = swapchains.firstOrNull { (it.kotlin.companionObjectInstance as SwapchainParameters).usageCondition.invoke(embedIn) }
+            val headless = (selectedSwapchain?.kotlin?.companionObjectInstance as? SwapchainParameters)?.headless ?: false
 
-        device = VulkanDevice.fromPhysicalDevice(instance,
-            physicalDeviceFilter = { _, device -> "${device.vendor} ${device.name}".contains(System.getProperty("scenery.Renderer.Device", "DOES_NOT_EXIST"))},
-            additionalExtensions = { physicalDevice -> hub.getWorkingHMDDisplay()?.getVulkanDeviceExtensions(physicalDevice)?.toTypedArray() ?: arrayOf() },
-            validationLayers = requestedValidationLayers,
-            headless = headless,
-            debugEnabled = validation
-        )
+            device = VulkanDevice.fromPhysicalDevice(instance,
+                physicalDeviceFilter = { _, device -> "${device.vendor} ${device.name}".contains(System.getProperty("scenery.Renderer.Device", "DOES_NOT_EXIST"))},
+                additionalExtensions = { physicalDevice -> hub.getWorkingHMDDisplay()?.getVulkanDeviceExtensions(physicalDevice)?.toTypedArray() ?: arrayOf() },
+                validationLayers = requestedValidationLayers,
+                headless = headless,
+                debugEnabled = validation
+            )
 
-        logger.debug("Device creation done")
+            logger.debug("Device creation done")
 
-        if(device.deviceData.vendor.lowercase().contains("nvidia") && ExtractsNatives.getPlatform() == ExtractsNatives.Platform.WINDOWS) {
-            try {
-                gpuStats = NvidiaGPUStats()
-            } catch(e: NullPointerException) {
-                logger.warn("Could not initialize Nvidia GPU stats")
-                if(logger.isDebugEnabled) {
-                    logger.warn("Reason: ${e.message}, traceback follows:")
-                    e.printStackTrace()
-                }
-            }
-        }
-
-        queue = VU.createDeviceQueue(device, device.queues.graphicsQueue.first)
-        logger.debug("Creating transfer queue with ${device.queues.transferQueue.first} (vs ${device.queues.graphicsQueue})")
-        transferQueue = VU.createDeviceQueue(device, device.queues.transferQueue.first)
-
-        with(commandPools) {
-            Render = device.createCommandPool(device.queues.graphicsQueue.first)
-            Standard = device.createCommandPool(device.queues.graphicsQueue.first)
-            Compute = device.createCommandPool(device.queues.computeQueue.first)
-            Transfer = device.createCommandPool(device.queues.transferQueue.first)
-        }
-        logger.debug("Creating command pools done")
-
-        swapchainRecreator = SwapchainRecreator()
-        swapchain = when {
-            selectedSwapchain != null -> {
-                logger.info("Using swapchain ${selectedSwapchain.simpleName}")
-                val params = selectedSwapchain.kotlin.primaryConstructor!!.parameters.associate { param ->
-                    param to when(param.name) {
-                        "device" -> device
-                        "queue" -> queue
-                        "commandPools" -> commandPools
-                        "renderConfig" -> renderConfig
-                        "useSRGB" -> renderConfig.sRGB
-                        else -> null
-                    }
-                }.filter { it.value != null }
-
-                selectedSwapchain
-                    .kotlin
-                    .primaryConstructor!!
-                    .callBy(params) as Swapchain
-            }
-            else -> {
-                logger.info("Using default swapchain")
-                VulkanSwapchain(
-                    device, queue, commandPools,
-                    renderConfig = renderConfig, useSRGB = renderConfig.sRGB,
-                    vsync = !settings.get<Boolean>("Renderer.DisableVsync"),
-                    undecorated = settings.get("Renderer.ForceUndecoratedWindow"))
-            }
-        }.apply {
-            embedIn(embedIn)
-            window = createWindow(window, swapchainRecreator)
-        }
-
-        logger.debug("Created swapchain")
-        vertexDescriptors = prepareStandardVertexDescriptors()
-        logger.debug("Created vertex descriptors")
-
-        descriptorSetLayouts = prepareDefaultDescriptorSetLayouts(device)
-        logger.debug("Prepared default DSLs")
-        buffers = prepareDefaultBuffers(device)
-        logger.debug("Prepared default buffers")
-
-        prepareDescriptorSets(device)
-        logger.debug("Prepared default descriptor sets")
-        prepareDefaultTextures(device)
-        logger.debug("Prepared default textures")
-
-        heartbeatTimer.scheduleAtFixedRate(object : TimerTask() {
-            override fun run() {
-                if (window.shouldClose) {
-                    shouldClose = true
-                    return
-                }
-
-                fps = frames
-                frames = 0
-
-                if(!pushMode) {
-                    (hub.get(SceneryElement.Statistics) as? Statistics)?.add("Renderer.fps", fps, false)
-                }
-
-                gpuStats?.let {
-                    it.update(0)
-
-                    hub.get(SceneryElement.Statistics).let { s ->
-                        val stats = s as Statistics
-
-                        stats.add("GPU", it.get("GPU"), isTime = false)
-                        stats.add("GPU bus", it.get("Bus"), isTime = false)
-                        stats.add("GPU mem", it.get("AvailableDedicatedVideoMemory"), isTime = false)
-                    }
-
-                    if (settings.get("Renderer.PrintGPUStats")) {
-                        logger.info(it.utilisationToString())
-                        logger.info(it.memoryUtilisationToString())
+            if(device.deviceData.vendor.lowercase().contains("nvidia") && ExtractsNatives.getPlatform() == ExtractsNatives.Platform.WINDOWS) {
+                try {
+                    gpuStats = NvidiaGPUStats()
+                } catch(e: NullPointerException) {
+                    logger.warn("Could not initialize Nvidia GPU stats")
+                    if(logger.isDebugEnabled) {
+                        logger.warn("Reason: ${e.message}, traceback follows:")
+                        e.printStackTrace()
                     }
                 }
-
-                val validationsEnabled = if (validation) {
-                    " - VALIDATIONS ENABLED"
-                } else {
-                    ""
-                }
-
-                if(embedIn == null) {
-                    window.title = "$applicationName [${this@VulkanRenderer.javaClass.simpleName}, ${this@VulkanRenderer.renderConfig.name}] $validationsEnabled - $fps fps"
-                }
             }
-        }, 0, 1000)
 
-        lastTime = System.nanoTime()
-        time = 0.0f
+            queue = VU.createDeviceQueue(device, device.queues.graphicsQueue.first)
+            logger.debug("Creating transfer queue with ${device.queues.transferQueue.first} (vs ${device.queues.graphicsQueue})")
+            transferQueue = VU.createDeviceQueue(device, device.queues.transferQueue.first)
 
-        if(System.getProperty("scenery.RunFullscreen","false")?.toBoolean() == true) {
-            toggleFullscreen = true
+            with(commandPools) {
+                Render = device.createCommandPool(device.queues.graphicsQueue.first)
+                Standard = device.createCommandPool(device.queues.graphicsQueue.first)
+                Compute = device.createCommandPool(device.queues.computeQueue.first)
+                Transfer = device.createCommandPool(device.queues.transferQueue.first)
+            }
+            logger.debug("Creating command pools done")
+
+            swapchainRecreator = SwapchainRecreator()
+            swapchain = when {
+                selectedSwapchain != null -> {
+                    logger.info("Using swapchain ${selectedSwapchain.simpleName}")
+                    val params = selectedSwapchain.kotlin.primaryConstructor!!.parameters.associate { param ->
+                        param to when(param.name) {
+                            "device" -> device
+                            "queue" -> queue
+                            "commandPools" -> commandPools
+                            "renderConfig" -> renderConfig
+                            "useSRGB" -> renderConfig.sRGB
+                            else -> null
+                        }
+                    }.filter { it.value != null }
+
+                    selectedSwapchain
+                        .kotlin
+                        .primaryConstructor!!
+                        .callBy(params) as Swapchain
+                }
+                else -> {
+                    logger.info("Using default swapchain")
+                    VulkanSwapchain(
+                        device, queue, commandPools,
+                        renderConfig = renderConfig, useSRGB = renderConfig.sRGB,
+                        vsync = !settings.get<Boolean>("Renderer.DisableVsync"),
+                        undecorated = settings.get("Renderer.ForceUndecoratedWindow"))
+                }
+            }.apply {
+                embedIn(embedIn)
+                window = createWindow(window, swapchainRecreator)
+            }
+
+            logger.debug("Created swapchain")
+            vertexDescriptors = prepareStandardVertexDescriptors()
+            logger.debug("Created vertex descriptors")
+
+            descriptorSetLayouts = prepareDefaultDescriptorSetLayouts(device)
+            logger.debug("Prepared default DSLs")
+            buffers = prepareDefaultBuffers(device)
+            logger.debug("Prepared default buffers")
+
+            prepareDescriptorSets(device)
+            logger.debug("Prepared default descriptor sets")
+            prepareDefaultTextures(device)
+            logger.debug("Prepared default textures")
+
+            heartbeatTimer.scheduleAtFixedRate(object : TimerTask() {
+                override fun run() {
+                    if (window.shouldClose) {
+                        shouldClose = true
+                        return
+                    }
+
+                    fps = frames
+                    frames = 0
+
+                    if(!pushMode) {
+                        (hub.get(SceneryElement.Statistics) as? Statistics)?.add("Renderer.fps", fps, false)
+                    }
+
+                    gpuStats?.let {
+                        it.update(0)
+
+                        hub.get(SceneryElement.Statistics).let { s ->
+                            val stats = s as Statistics
+
+                            stats.add("GPU", it.get("GPU"), isTime = false)
+                            stats.add("GPU bus", it.get("Bus"), isTime = false)
+                            stats.add("GPU mem", it.get("AvailableDedicatedVideoMemory"), isTime = false)
+                        }
+
+                        if (settings.get("Renderer.PrintGPUStats")) {
+                            logger.info(it.utilisationToString())
+                            logger.info(it.memoryUtilisationToString())
+                        }
+                    }
+
+                    val validationsEnabled = if (validation) {
+                        " - VALIDATIONS ENABLED"
+                    } else {
+                        ""
+                    }
+
+                    if(embedIn == null) {
+                        window.title = "$applicationName [${this@VulkanRenderer.javaClass.simpleName}, ${this@VulkanRenderer.renderConfig.name}] $validationsEnabled - $fps fps"
+                    }
+                }
+            }, 0, 1000)
+
+            lastTime = System.nanoTime()
+            time = 0.0f
+
+            if(System.getProperty("scenery.RunFullscreen","false")?.toBoolean() == true) {
+                toggleFullscreen = true
+            }
+
+            geometryPool = VulkanBufferPool(
+                device,
+                usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT or VK_BUFFER_USAGE_INDEX_BUFFER_BIT or VK_BUFFER_USAGE_TRANSFER_DST_BIT
+            )
+
+            stagingPool = VulkanBufferPool(
+                device,
+                usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                properties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                bufferSize = 64*1024*1024
+            )
+
+            initialized = true
+            logger.info("Renderer initialisation complete.")
         }
-
-        geometryPool = VulkanBufferPool(
-            device,
-            usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT or VK_BUFFER_USAGE_INDEX_BUFFER_BIT or VK_BUFFER_USAGE_TRANSFER_DST_BIT
-        )
-
-        stagingPool = VulkanBufferPool(
-            device,
-            usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-            properties = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-            bufferSize = 64*1024*1024
-        )
-
-        initialized = true
-        logger.info("Renderer initialisation complete.")
     }
 
     // source: http://stackoverflow.com/questions/34697828/parallel-operations-on-kotlin-collections

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -479,9 +479,10 @@ open class VulkanRenderer(hub: Hub,
                 }
             }
 
+            val headlessRequested = System.getProperty("scenery.Headless")?.toBoolean() ?: false
             // GLFW works kinda shaky on macOS, we create a JFrame here for a nicer experience then.
             // That is of course unless [embedIn] is already set.
-            if(Platform.get() == Platform.MACOSX && embedIn == null) {
+            if(Platform.get() == Platform.MACOSX && embedIn == null && !headlessRequested) {
                 val mainFrame = JFrame(applicationName)
                 mainFrame.setSize(windowWidth, windowHeight)
                 mainFrame.layout = BorderLayout()
@@ -494,7 +495,6 @@ open class VulkanRenderer(hub: Hub,
             }
 
             // Create the Vulkan instance
-            val headlessRequested = System.getProperty("scenery.Headless")?.toBoolean() ?: false
             instance = if(embedIn != null || headlessRequested) {
                 logger.debug("Running embedded or headless, skipping GLFW initialisation.")
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -404,9 +404,8 @@ open class VulkanSwapchain(open val device: VulkanDevice,
                 throw RuntimeException("Presentation queue != graphics queue")
             }
 
-            presentQueue = VkQueue(VU.getPointer("Get present queue",
-                { VK10.vkGetDeviceQueue(device.vulkanDevice, presentQueueNodeIndex, 0, this); VK10.VK_SUCCESS }, {}),
-                device.vulkanDevice)
+            logger.info("Present queue is ${presentQueueNodeIndex}, graphics queue is ${graphicsQueueNodeIndex}")
+            presentQueue = VU.createDeviceQueue(device, device.queues.graphicsQueue.first)
 
             // Get list of supported formats
             val formatCount = VU.getInts("Getting supported surface formats", 1,

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanTexture.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanTexture.kt
@@ -428,8 +428,6 @@ open class VulkanTexture(val device: VulkanDevice,
 
                                 buffer.copyFrom(contents, keepMapped = true)
                                 image.copyFrom(this, buffer, genericTexture.getConsumableUpdates())
-
-                                genericTexture.clearConsumedUpdates()
                             } /*else {
                                 // TODO: Semantics, do we want UpdateableTextures to be only
                                 // updateable via updates, or shall they read from buffer on first init?
@@ -452,6 +450,9 @@ open class VulkanTexture(val device: VulkanDevice,
                 }
 
                 endCommandBuffer(this@VulkanTexture.device, commandPools.Standard, transferQueue, flush = true, dealloc = true, block = true)
+                // necessary to clear updates here, as the command buffer might still access the
+                // memory address of the texture update.
+                (gt as? UpdatableTexture)?.clearConsumedUpdates()
             }
         } else {
             val buffer = VulkanBuffer(device,

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -15,7 +15,6 @@ import org.scijava.ui.behaviour.InputTriggerMap
 import org.scijava.ui.behaviour.io.InputTriggerConfig
 import org.scijava.ui.behaviour.io.InputTriggerDescription
 import org.scijava.ui.behaviour.io.InputTriggerDescriptionsBuilder
-import org.scijava.ui.behaviour.io.gui.CommandDescriptionBuilder
 import org.scijava.ui.behaviour.io.gui.VisualEditorPanel
 import org.scijava.ui.behaviour.io.yaml.YamlConfigIO
 import org.scijava.ui.behaviour.util.Behaviours
@@ -322,9 +321,11 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
      */
     @JvmOverloads fun openKeybindingsGuiEditor(editorTitle: String = "scenery's Key bindings editor", filename: String, context: String = "all"): VisualEditorPanel {
         //setup content for the Visual Editor
-        val cdb = CommandDescriptionBuilder()
-        behaviourMap.keys().forEach { b -> cdb.addCommand(b, context, "") }
-        val editorPanel = VisualEditorPanel(config, cdb.get())
+        // TODO: Figure out where this class went
+        //val cdb = CommandDescriptionProvider()
+        //behaviourMap.keys().forEach { b -> cdb.addCommand(b, context, "") }
+        //val editorPanel = VisualEditorPanel(config, cdb.get())
+        val editorPanel = VisualEditorPanel(config, null)
 
         //show the Editor
         val frame = JFrame(editorTitle)

--- a/src/main/kotlin/graphics/scenery/textures/UpdatableTexture.kt
+++ b/src/main/kotlin/graphics/scenery/textures/UpdatableTexture.kt
@@ -1,5 +1,7 @@
 package graphics.scenery.textures
 
+import graphics.scenery.backends.vulkan.toHexString
+import graphics.scenery.utils.LazyLogger
 import net.imglib2.type.numeric.NumericType
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import org.joml.Vector3i
@@ -43,7 +45,11 @@ class UpdatableTexture(
 
     /** Clears all consumed updates */
     fun clearConsumedUpdates() {
-        updates.forEach { if(it.consumed && it.deallocate) { MemoryUtil.memFree(it.contents) } }
+        updates.forEach {
+            if((it.consumed && it.deallocate)) {
+                MemoryUtil.memFree(it.contents)
+            }
+        }
         updates.removeIf { it.consumed }
     }
 

--- a/src/main/kotlin/graphics/scenery/textures/UpdatableTexture.kt
+++ b/src/main/kotlin/graphics/scenery/textures/UpdatableTexture.kt
@@ -1,7 +1,5 @@
 package graphics.scenery.textures
 
-import graphics.scenery.backends.vulkan.toHexString
-import graphics.scenery.utils.LazyLogger
 import net.imglib2.type.numeric.NumericType
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import org.joml.Vector3i

--- a/src/main/kotlin/graphics/scenery/utils/VideoEncoder.kt
+++ b/src/main/kotlin/graphics/scenery/utils/VideoEncoder.kt
@@ -115,10 +115,6 @@ class VideoEncoder(
         }
 
         init {
-            @Suppress("DEPRECATION")
-            av_register_all()
-            @Suppress("DEPRECATION")
-            avcodec_register_all()
             avformat_network_init()
         }
     }

--- a/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
@@ -129,8 +129,7 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
     @OptIn(ExperimentalUnsignedTypes::class)
     override fun sample(uv: Vector3f, interpolate: Boolean): Float? {
         val texture = timepoints?.lastOrNull() ?: throw IllegalStateException("Could not find timepoint")
-        val source = (ds.sources.first().spimSource as? BufferSource) ?: throw IllegalStateException("No source found")
-        val dimensions = Vector3i(source.width, source.height, source.depth)
+        val dimensions = getDimensions()
 
         val bpp = when(ds.type) {
             is UnsignedByteType, is ByteType -> 1
@@ -218,8 +217,7 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
      * as well as the delta used along the ray, or null if the start/end coordinates are invalid.
      */
     override fun sampleRay(start: Vector3f, end: Vector3f): Pair<List<Float?>, Vector3f>? {
-        val source = (ds.sources.first().spimSource as? BufferSource) ?: throw IllegalStateException("No source found")
-        val dimensions = Vector3f(source.width.toFloat(), source.height.toFloat(), source.depth.toFloat())
+        val dimensions = Vector3f(getDimensions())
 
         if (start.x() < 0.0f || start.x() > 1.0f || start.y() < 0.0f || start.y() > 1.0f || start.z() < 0.0f || start.z() > 1.0f) {
             logger.debug("Invalid UV coords for ray start: {} -- will clamp values to [0.0, 1.0].", start)
@@ -248,5 +246,13 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
         return (0 until maxSteps).map {
             sample(startClamped + (delta * it.toFloat()))
         } to delta
+    }
+
+    /**
+     * Returns the volume's physical (voxel) dimensions.
+     */
+    override fun getDimensions(): Vector3i {
+        val source = ((ds.sources.first().spimSource as? TransformedSource)?.wrappedSource as? BufferSource) ?: throw IllegalStateException("No source found")
+        return Vector3i(source.width, source.height, source.depth)
     }
 }

--- a/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
@@ -9,6 +9,7 @@ import graphics.scenery.utils.extensions.times
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import org.joml.Matrix4f
 import org.joml.Vector3f
+import org.joml.Vector3i
 import tpietzsch.example2.VolumeViewerOptions
 
 class RAIVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewerOptions, hub: Hub): Volume(ds, options, hub) {
@@ -29,39 +30,33 @@ class RAIVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewerOpti
     }
 
     override fun generateBoundingBox(): OrientedBoundingBox {
-        val source = ds.sources.firstOrNull()
-
-        val sizes = if(source != null) {
-            val s = source.spimSource.getSource(0, 0)
-            val min = Vector3f(s.min(0).toFloat(), s.min(1).toFloat(), s.min(2).toFloat())
-            val max = Vector3f(s.max(0).toFloat(), s.max(1).toFloat(), s.max(2).toFloat())
-            max - min
-        } else {
-            Vector3f(1.0f, 1.0f, 1.0f)
-        }
-
         return OrientedBoundingBox(this,
             Vector3f(-0.0f, -0.0f, -0.0f),
-            sizes)
+            Vector3f(getDimensions()))
     }
 
     override fun localScale(): Vector3f {
-        var size = Vector3f(1.0f, 1.0f, 1.0f)
-        val source = ds.sources.firstOrNull()
-
-        if(source != null) {
-            val s = source.spimSource.getSource(0, 0)
-            val min = Vector3f(s.min(0).toFloat(), s.min(1).toFloat(), s.min(2).toFloat())
-            val max = Vector3f(s.max(0).toFloat(), s.max(1).toFloat(), s.max(2).toFloat())
-            size = max - min
-        }
-        logger.debug("Sizes are $size")
+        val size = getDimensions()
+        logger.info("Sizes are $size")
 
         return Vector3f(
                 size.x() * pixelToWorldRatio / 10.0f,
                 -1.0f * size.y() * pixelToWorldRatio / 10.0f,
                 size.z() * pixelToWorldRatio / 10.0f
         )
+    }
+
+    override fun getDimensions(): Vector3i {
+        val source = ds.sources.firstOrNull()
+
+        return if(source != null) {
+            val s = source.spimSource.getSource(0, 0)
+            val min = Vector3i(s.min(0).toInt(), s.min(1).toInt(), s.min(2).toInt())
+            val max = Vector3i(s.max(0).toInt(), s.max(1).toInt(), s.max(2).toInt())
+            max.sub(min)
+        } else {
+            Vector3i(1, 1, 1)
+        }
     }
 
     override fun createSpatial(): VolumeSpatial {

--- a/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
@@ -6,7 +6,6 @@ import graphics.scenery.textures.UpdatableTexture.TextureExtents
 import graphics.scenery.textures.Texture.RepeatMode
 import graphics.scenery.textures.UpdatableTexture.TextureUpdate
 import graphics.scenery.backends.ShaderType
-import graphics.scenery.backends.vulkan.toHexString
 import graphics.scenery.textures.UpdatableTexture
 import graphics.scenery.utils.LazyLogger
 import net.imglib2.type.numeric.NumericType
@@ -15,7 +14,6 @@ import net.imglib2.type.numeric.integer.UnsignedShortType
 import net.imglib2.type.numeric.real.FloatType
 import org.joml.*
 import org.lwjgl.system.MemoryUtil
-import org.lwjgl.util.xxhash.XXHash
 import tpietzsch.backend.*
 import tpietzsch.cache.TextureCache
 import tpietzsch.example2.LookupTextureARGB
@@ -26,8 +24,6 @@ import java.nio.ByteOrder
 import java.nio.FloatBuffer
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.ExperimentalTime
-import kotlin.time.measureTime
-import kotlin.time.measureTimedValue
 import tpietzsch.backend.Texture as BVVTexture
 
 /**

--- a/src/main/kotlin/graphics/scenery/volumes/TransformedMultiResolutionStack3D.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransformedMultiResolutionStack3D.kt
@@ -1,6 +1,5 @@
 package graphics.scenery.volumes
 
-import graphics.scenery.Node
 import net.imglib2.realtransform.AffineTransform3D
 import org.joml.Matrix4f
 import tpietzsch.multires.MultiResolutionStack3D
@@ -12,7 +11,11 @@ import tpietzsch.multires.ResolutionLevel3D
  *
  * @author Ulrik Guenther <hello@ulrik.is>
  */
-class TransformedMultiResolutionStack3D<T>(val stack: MultiResolutionStack3D<T>, val node: Node, val actualSourceTransform: AffineTransform3D) : MultiResolutionStack3D<T> {
+class TransformedMultiResolutionStack3D<T>(
+    val stack: MultiResolutionStack3D<T>,
+    val node: Volume,
+    val actualSourceTransform: AffineTransform3D
+) : MultiResolutionStack3D<T> {
     override fun getType(): T {
         return stack.type as T
     }
@@ -27,7 +30,13 @@ class TransformedMultiResolutionStack3D<T>(val stack: MultiResolutionStack3D<T>,
     }
 
     override fun resolutions(): List<ResolutionLevel3D<T>> {
-        return stack.resolutions() as List<ResolutionLevel3D<T>>
+        val resolutions = (stack.resolutions() as List<ResolutionLevel3D<T>>)
+        val limits = node.multiResolutionLevelLimits
+        return if(limits == null) {
+            resolutions
+        } else {
+            resolutions.subList(limits.first, limits.second)
+        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -364,6 +364,13 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
         return null
     }
 
+    /**
+     * Returns the volume's physical (voxel) dimensions.
+     */
+    open fun getDimensions(): Vector3i {
+        return Vector3i(0)
+    }
+
     companion object {
         val setupId = AtomicInteger(0)
         val scifio: SCIFIO = SCIFIO()

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -124,6 +124,8 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
     /** Modes how assigned slicing planes interact with the volume */
     var slicingMode = SlicingMode.None
 
+    var multiResolutionLevelLimits: Pair<Int, Int>? = null
+
     enum class SlicingMode(val id: Int){
         // Volume is rendered as it is
         None(0),
@@ -381,7 +383,7 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             hub: Hub,
             options : VolumeViewerOptions = VolumeViewerOptions()
         ): Volume {
-            val spimData = XmlIoSpimDataMinimal().load(path, 4)
+            val spimData = XmlIoSpimDataMinimal().load(path)
             val ds = SpimDataMinimalSource(spimData)
             return Volume(ds, options, hub)
         }

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -381,7 +381,7 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             hub: Hub,
             options : VolumeViewerOptions = VolumeViewerOptions()
         ): Volume {
-            val spimData = XmlIoSpimDataMinimal().load(path)
+            val spimData = XmlIoSpimDataMinimal().load(path, 4)
             val ds = SpimDataMinimalSource(spimData)
             return Volume(ds, options, hub)
         }

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
@@ -366,7 +366,7 @@ class VolumeManager(
         val settings = hub?.get<Settings>() ?: return false
 
         val hmd = hub?.getWorkingHMDDisplay()?.wantsVR(settings)
-        val mvp = if(hmd != null) {
+        val vp = if(hmd != null) {
             Matrix4f(hmd.getEyeProjection(0, cam.nearPlaneDistance, cam.farPlaneDistance))
                 .mul(cam.spatial().getTransformation())
         } else {
@@ -386,7 +386,7 @@ class VolumeManager(
                 if (state.stack is MultiResolutionStack3D) {
                     val volume = outOfCoreVolumes[i]
 
-                    volume.init(state.stack, cam.width, mvp)
+                    volume.init(state.stack, cam.width, vp)
 
                     val tasks = volume.fillTasks
                     numTasks += tasks.size
@@ -490,7 +490,7 @@ class VolumeManager(
             currentProg.setViewportWidth(cam.width)
             currentProg.setEffectiveViewportSize(cam.width, cam.height)
             currentProg.setDegrade(farPlaneDegradation)
-            currentProg.setProjectionViewMatrix(mvp, maxAllowedStepInVoxels * minWorldVoxelSize)
+            currentProg.setProjectionViewMatrix(vp, maxAllowedStepInVoxels * minWorldVoxelSize)
             currentProg.use(context)
             currentProg.setUniforms(context)
             currentProg.bindSamplers(context)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
@@ -15,7 +15,7 @@ import kotlin.concurrent.thread
 class TexturedCubeExample : SceneryBase("TexturedCubeExample") {
     override fun init() {
         renderer = hub.add(SceneryElement.Renderer,
-            Renderer.createRenderer(hub, applicationName, scene, 512, 512))
+            Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight))
 
         val box = Box(Vector3f(1.0f, 1.0f, 1.0f))
         box.name = "le box du win"

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/CroppingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/CroppingExample.kt
@@ -105,7 +105,7 @@ class CroppingExample : SceneryBase("Volume Cropping example", 1280, 720) {
             addAdditionalVolume(Vector3f(2f,2f,-2f)).slicingMode = Volume.SlicingMode.Slicing
             addAdditionalVolume(Vector3f(-2f,2f,-2f)).slicingMode = Volume.SlicingMode.Cropping
             addAdditionalVolume(Vector3f(2f,-2f,-2f)).slicingMode = Volume.SlicingMode.Both
-            addAdditionalVolume(Vector3f(-2f,-2f,-2f))
+//            addAdditionalVolume(Vector3f(-2f,-2f,-2f))
         }
 
         thread {

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/ProceduralVolumeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/ProceduralVolumeExample.kt
@@ -58,7 +58,7 @@ class ProceduralVolumeExample: SceneryBase("Procedural Volume Rendering Example"
         }
 
         volume.name = "volume"
-        volume.spatial().position = Vector3f(0.0f, 0.0f, 0.0f)
+        volume.spatial().position = Vector3f(0.0f, 5.0f, 0.0f)
         volume.colormap = Colormap.get("hot")
         volume.pixelToWorldRatio = 0.03f
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/RAIExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/RAIExample.kt
@@ -57,8 +57,6 @@ class RAIExample: SceneryBase("RAI Rendering example", 1280, 720) {
         val origin = Box(Vector3f(0.1f, 0.1f, 0.1f))
         origin.material().diffuse = Vector3f(0.8f, 0.0f, 0.0f)
         scene.addChild(origin)
-
-        scene.export("rai.scenery")
     }
 
     override fun inputSetup() {

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/VolumeSamplingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/VolumeSamplingExample.kt
@@ -118,11 +118,10 @@ class VolumeSamplingExample: SceneryBase("Volume Sampling example", 1280, 720) {
         val volume = Volume.fromBuffer(emptyList(), volumeSize, volumeSize, volumeSize, UnsignedByteType(), hub)
         volume.name = "volume"
         volume.spatial {
-            position = Vector3f(0.0f, 0.0f, 0.0f)
-            scale = Vector3f(10.0f, 10.0f, 10.0f)
+            position = Vector3f(0.0f, 5.0f, 0.0f)
+            scale = Vector3f(30.0f, 30.0f, 30.0f)
         }
         volume.colormap = Colormap.get("viridis")
-//        volume.voxelSizeZ = 0.5f
         with(volume.transferFunction) {
             addControlPoint(0.0f, 0.0f)
             addControlPoint(0.2f, 0.0f)
@@ -152,7 +151,7 @@ class VolumeSamplingExample: SceneryBase("Volume Sampling example", 1280, 720) {
             while(!scene.initialized) { Thread.sleep(200) }
 
             val volumeSize = 128L
-            val volumeBuffer = RingBuffer<ByteBuffer>(2) { memAlloc((volumeSize*volumeSize*volumeSize*bitsPerVoxel/8).toInt()) }
+            val volumeBuffer = RingBuffer(2, default = { memAlloc((volumeSize*volumeSize*volumeSize*bitsPerVoxel/8).toInt()) })
 
             val seed = Random.randomFromRange(0.0f, 133333337.0f).toLong()
             var shift = Vector3f(0.0f)
@@ -208,13 +207,10 @@ class VolumeSamplingExample: SceneryBase("Volume Sampling example", 1280, 720) {
                     val diagram = if(connector.getChildrenByName("diagram").isNotEmpty()) {
                         connector.getChildrenByName("diagram").first() as Line
                     } else {
-                        TODO("Implement volume size queries or refactor")
-//                        val sizeX = 128
-//                        val sizeY = 128
-//                        val sizeZ = 128
-//                        val l = Line(capacity = maxOf(sizeX, sizeY, sizeZ) * 2)
-//                        connector.addChild(l)
-//                        l
+                        val dims = volume.getDimensions()
+                        val l = Line(capacity = dims[dims.maxComponent()] * 2)
+                        connector.addChild(l)
+                        l
                     }
 
                     diagram.clearPoints()


### PR DESCRIPTION
This PR adds support for using Vulkan on macOS, especially on Apple Silicon chips.

Before merging the following needs to work:
- [X] Headless rendering
- [X] Rendering using the SwingSwapchain for embedding, plus REPL
- [x] Rendering using ~~GLFW windows~~ switched to Swing for macOS, plus REPL
- [X] Tested on macOS/ARM64
- [ ] Tested on macOS/AMD64
- [x] https://github.com/LWJGLX/lwjgl3-awt/issues/37 needs to be addressed and a new artifact including ARM64 support available
- [x] CI passing
- [x] All important integration tests running

![image](https://user-images.githubusercontent.com/586495/163429288-0ff20d67-d22d-4633-9907-e5c6574b81f1.png)
