### PR TITLE
Fix generated Maven POM/On-the-fly loading of M1 binaries for JHDF5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,8 +96,6 @@ dependencies {
 
     api("sc.fiji:bigdataviewer-core:10.4.1")
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
-    api(githubRelease("JaneliaSciComp", "jhdf5", "jhdf5-19.04.1_fatjar", "sis-base-18.09.0.jar"))
-    api(githubRelease("JaneliaSciComp", "jhdf5", "jhdf5-19.04.1_fatjar", "sis-jhdf5-1654327451.jar"))
 
     //TODO revert to official BVV
     api("graphics.scenery:bigvolumeviewer:a6b021d")
@@ -130,25 +128,6 @@ dependencies {
 
 val isRelease: Boolean
     get() = System.getProperty("release") == "true"
-
-/**
- * Downloads a [file] from the given GitHub release, with [organization], [repository], and [release] tag given.
- */
-fun githubRelease(organization: String, repository: String, release: String, file: String): ConfigurableFileCollection {
-    val url = "https://github.com/$organization/$repository/releases/download/$release/$file"
-    val output = File("$projectDir/external-libs/$organization-$repository-$release-$file")
-    output.parentFile.mkdirs()
-
-    if(!output.exists()) {
-        val created = output.createNewFile()
-        val stream = URL(url).openStream()
-        val out = output.outputStream()
-        stream.copyTo(out)
-        out.close()
-        stream.close()
-    }
-    return files(output.absolutePath)
-}
 
 tasks {
 
@@ -295,7 +274,7 @@ tasks {
 
             val toSkip = listOf("pom-scijava")
             
-            configurations.implementation.allDependencies.forEach {
+            configurations.implementation.get().allDependencies.forEach {
                 val artifactId = it.name
 
                 if( !toSkip.contains(artifactId) ) {

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -14,12 +14,7 @@ import graphics.scenery.controls.behaviours.FPSCameraControl
 import graphics.scenery.net.NodePublisher
 import graphics.scenery.net.NodeSubscriber
 import graphics.scenery.repl.REPL
-import graphics.scenery.utils.LazyLogger
-import graphics.scenery.utils.Profiler
-import graphics.scenery.utils.RemoteryProfiler
-import graphics.scenery.utils.Renderdoc
-import graphics.scenery.utils.SceneryPanel
-import graphics.scenery.utils.Statistics
+import graphics.scenery.utils.*
 import kotlinx.coroutines.*
 import org.lwjgl.system.Platform
 import org.scijava.Context
@@ -128,6 +123,8 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     init {
         // will only be called on Linux, and only if it hasn't been called before.
         xinitThreads()
+        // will only run on M1 macOS
+        m1supportForjHDF5()
     }
 
     /**
@@ -605,6 +602,31 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
                 logger.debug("Running XInitThreads")
                 XLib.INSTANCE.XInitThreads()
                 xinitThreadsCalled = true
+            }
+        }
+
+        @JvmStatic fun m1supportForjHDF5() {
+            if(Platform.get() == Platform.MACOSX && Platform.getArchitecture() == Platform.Architecture.ARM64) {
+                val arch = System.getProperty("os.arch")
+                val os = System.getProperty("os.name")
+
+                var basepath = ""
+                logger.info("Downloading M1 support libraries for JHDF5...")
+                listOf("hdf5", "jhdf5").forEach { lib ->
+                    basepath = ExtractsNatives.nativesFromGithubRelease(
+                        "JaneliaSciComp",
+                        "jhdf5",
+                        "jhdf5-19.04.1_fatjar",
+                        "sis-jhdf5-1654327451.jar",
+                        "$arch-$os",
+                        lib,
+                        "jnilib"
+                    )
+                }
+
+                if(System.getProperty("native.libpath") == null) {
+                    System.setProperty("native.libpath", basepath)
+                }
             }
         }
     }

--- a/src/main/kotlin/graphics/scenery/utils/ExtractsNatives.kt
+++ b/src/main/kotlin/graphics/scenery/utils/ExtractsNatives.kt
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import java.util.jar.JarFile
 import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.net.URL
 
 
 /**
@@ -20,6 +21,7 @@ interface ExtractsNatives {
     }
 
     companion object {
+        private val logger by LazyLogger()
         /**
          * Returns the platform based on the os.name system property.
          */
@@ -34,6 +36,55 @@ interface ExtractsNatives {
             }
 
         }
+
+        /**
+         * Downloads a [file] from a given GitHub [organization]'s [repository]'s [release],
+         * and puts it into ~/.scenery. This function was written for M1 support for JHDF5.
+         *
+         * Returns the base path to use for native file loading.
+         */
+        internal fun nativesFromGithubRelease(
+            organization: String,
+            repository: String,
+            release: String,
+            file: String,
+            archAndOS: String,
+            library: String,
+            ext: String
+        ): String {
+            val url = "https://github.com/$organization/$repository/releases/download/$release/$file"
+            val output = File(System.getProperty("user.home") + "/.scenery/native/$file")
+            if(!output.exists()) {
+                output.parentFile.mkdirs()
+
+                if (!output.exists()) {
+                    val created = output.createNewFile()
+                    val stream = URL(url).openStream()
+                    val out = output.outputStream()
+                    stream.copyTo(out)
+                    out.close()
+                    stream.close()
+                }
+            }
+
+            val basepath = File(System.getProperty("user.home") + "/.scenery/native/")
+            val target = File(System.getProperty("user.home") + "/.scenery/native/$library/$archAndOS/lib$library.$ext")
+            target.parentFile.mkdirs()
+            return if(target.exists()) {
+                basepath.absolutePath
+            } else {
+                val jarFile = JarFile(output)
+                val name = "native/$library/$archAndOS/lib$library.$ext"
+                logger.info("name is $name")
+                val entry = jarFile.getJarEntry("native/$library/$archAndOS/lib$library.$ext")
+                val stream = target.outputStream().buffered()
+                stream.write(jarFile.getInputStream(entry).buffered().readAllBytes())
+                stream.close()
+                jarFile.close()
+                basepath.absolutePath
+            }
+        }
+
     }
 
     /**


### PR DESCRIPTION
This PR addresses a recently-introduced issue due to a file dependency on the JHDF5 fat jars for M1 support. The dependency has been removed and replaced with on-the-fly loading and caching of those libraries.