### PR TITLE
Return Volumes created from SpimData/BDV XML as RAIVolume

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ unit-tests-no-gpu:
       - "hs_err_*"
 
 scenery-nvidia:
-  image: scenerygraphics/nvidia-vulkan:1.3.216.0-ubuntu20.04
+  image: scenerygraphics/nvidia-vulkan:1.3.216.0-ubuntu20.04-updatedmodels
   <<: *base-job-gpu
   after_script:
     - nvidia-smi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,8 @@
 cache:
+  key:
+    files:
+      - gradle/wrapper/gradle-wrapper.properties
   paths:
-    - maven.repository/
-    - models/
     - pdb-store/
     - .gradle-user-home/
 
@@ -22,7 +23,7 @@ unit-tests-no-gpu:
     - if [ ! -d "$MODEL_DIR" ]; then wget -q https://ulrik.is/scenery-demo-models.zip && unzip -q scenery-demo-models.zip; fi
     - chmod +x gradlew
   script:
-    - ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar
+    - ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --build-cache
 
 # base job for running with GPUs
 .base-job-gpu: &base-job-gpu
@@ -41,32 +42,32 @@ unit-tests-no-gpu:
     - ./gradlew --stop # stop any deamon https://stackoverflow.com/a/58397542/1047713
   script:
     - echo -e "\e[0Ksection_start:`date +%s`:build_section[collapsed=true]\r\e[0KGeneral build"
-    - ./gradlew build jacocoTestReport --info --full-stacktrace -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar
+    - ./gradlew build jacocoTestReport --build-cache --info --full-stacktrace -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar
     - echo -e "\e[0Ksection_end:`date +%s`:build_section\r\e[0K"
     # basic group
     - echo -e "\e[0Ksection_start:`date +%s`:basic_section[collapsed=true]\r\e[0KBasic Test Group"
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:basic_section\r\e[0K"
     # advanced group
     - echo -e "\e[0Ksection_start:`date +%s`:advanced_section[collapsed=true]\r\e[0KAdvanced Test Group"
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:advanced_section\r\e[0K"
     # compute group
     - echo -e "\e[0Ksection_start:`date +%s`:compute_section[collapsed=true]\r\e[0KCompute Test Group"
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:compute_section\r\e[0K"
     # volumes group
     - echo -e "\e[0Ksection_start:`date +%s`:volumes_section[collapsed=true]\r\e[0KVolumes Test Group"
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:volumes_section\r\e[0K"
     # code coverage reporting
     - echo -e "\e[0Ksection_start:`date +%s`:coverage_section[collapsed=true]\r\e[0KCode Coverage and Analysis"
     # we keep the same arguments here as in the last test run to not startle Gradle into re-running the test task
-    - ./gradlew fullCodeCoverageReport sonarqube --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew fullCodeCoverageReport sonarqube --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:coverage_section\r\e[0K"
   artifacts:
     when: always

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -371,6 +371,11 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
         return Vector3i(0)
     }
 
+    @JvmOverloads
+    open fun setTransferFunctionRange(min: Float, max: Float, forSetupId: Int = 0) {
+        converterSetups.getOrNull(forSetupId)?.setDisplayRange(min.toDouble(), max.toDouble())
+    }
+
     companion object {
         val setupId = AtomicInteger(0)
         val scifio: SCIFIO = SCIFIO()

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -155,13 +155,19 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
         }
 
     sealed class VolumeDataSource {
-        class SpimDataMinimalSource(val spimData : SpimDataMinimal) : VolumeDataSource()
+        class SpimDataMinimalSource(
+            val spimData : SpimDataMinimal,
+            val sources: List<SourceAndConverter<*>>,
+            val converterSetups: ArrayList<ConverterSetup>,
+            val numTimepoints: Int
+            ) : VolumeDataSource()
         class RAISource<T: NumericType<T>>(
             val type: NumericType<T>,
             val sources: List<SourceAndConverter<T>>,
             val converterSetups: ArrayList<ConverterSetup>,
             val numTimepoints: Int,
-            val cacheControl: CacheControl? = null) : VolumeDataSource()
+            val cacheControl: CacheControl? = null,
+            val spimData: SpimDataMinimal? = null) : VolumeDataSource()
         class NullSource(val numTimepoints: Int): VolumeDataSource()
     }
 
@@ -183,19 +189,13 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             is SpimDataMinimalSource -> {
                 val spimData = dataSource.spimData
 
-                val seq: AbstractSequenceDescription<*, *, *> = spimData.sequenceDescription
-                timepointCount = seq.timePoints.size() - 1
-                cacheControls.addCacheControl((seq.imgLoader as ViewerImgLoader).cacheControl)
+                timepointCount = dataSource.numTimepoints
+                cacheControls.addCacheControl((spimData.sequenceDescription.imgLoader as ViewerImgLoader).cacheControl)
 
                 // wraps legacy image formats (e.g., TIFF) if referenced in BDV XML
                 WrapBasicImgLoader.wrapImgLoaderIfNecessary(spimData)
-
-                val sources = ArrayList<SourceAndConverter<*>>()
-                // initialises setups and converters for all channels, and creates source.
-                // These are then stored in [converterSetups] and [sources_].
-                BigDataViewer.initSetups(spimData, converterSetups, sources)
-
-                viewerState = ViewerState(sources, timepointCount)
+                viewerState = ViewerState(dataSource.sources, timepointCount)
+                converterSetups.addAll(dataSource.converterSetups)
 
                 WrapBasicImgLoader.removeWrapperIfPresent(spimData)
             }
@@ -381,8 +381,25 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             hub : Hub,
             options : VolumeViewerOptions = VolumeViewerOptions()
         ): Volume {
-            val ds = SpimDataMinimalSource(spimData)
-            return Volume(ds, options, hub)
+            val seq: AbstractSequenceDescription<*, *, *> = spimData.sequenceDescription
+
+            val timepointCount = seq.timePoints.size()
+            // wraps legacy image formats (e.g., TIFF) if referenced in BDV XML
+            WrapBasicImgLoader.wrapImgLoaderIfNecessary(spimData)
+
+            val converterSetups = ArrayList<ConverterSetup>()
+            val sources = ArrayList<SourceAndConverter<*>>()
+            // initialises setups and converters for all channels, and creates source.
+            // These are then stored in [converterSetups] and [sources_].
+            BigDataViewer.initSetups(spimData, converterSetups, sources)
+
+            WrapBasicImgLoader.removeWrapperIfPresent(spimData)
+            val ds = SpimDataMinimalSource(spimData,
+                sources,
+                converterSetups,
+                timepointCount
+            )
+            return RAIVolume(ds, options, hub)
         }
 
         @JvmStatic @JvmOverloads fun fromXML(
@@ -391,8 +408,7 @@ open class Volume(val dataSource: VolumeDataSource, val options: VolumeViewerOpt
             options : VolumeViewerOptions = VolumeViewerOptions()
         ): Volume {
             val spimData = XmlIoSpimDataMinimal().load(path)
-            val ds = SpimDataMinimalSource(spimData)
-            return Volume(ds, options, hub)
+            return fromSpimData(spimData, hub, options)
         }
 
         @JvmStatic @JvmOverloads fun <T: NumericType<T>> fromRAI(

--- a/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
@@ -124,7 +124,6 @@ class ExampleRunner(
             // these examples require user input and/or files
             "LocalisationExample",
             "ReaderExample",
-            "BDVExample",
             "BigAndSmallVolumeExample",
             "VolumeSamplingExample",
             "VideoRecordingExample",


### PR DESCRIPTION
This PR changes the factory methods of `Volume` to return volumes created from SpimData/BDV XML as RAIVolume instead of Volume, which makes more sense. Thanks to @RuoshanLan for the idea 👍 