### PR TITLE
Raycasting fix

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -194,11 +194,12 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     fun getNodesForScreenSpacePosition(
         x: Int, y: Int,
         ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java),
+        camOrigin: Boolean = false,
         debug: Boolean = false
     ): Scene.RaycastResult {
         return getNodesForScreenSpacePosition(x, y, { n: Node ->
             !ignoredObjects.any { it.isAssignableFrom(n.javaClass) }
-        }, debug)
+        }, camOrigin, debug)
     }
 
     /**
@@ -208,9 +209,10 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     fun getNodesForScreenSpacePosition(
         x: Int, y: Int,
         filter: (Node) -> Boolean,
+        camOrigin: Boolean = false,
         debug: Boolean = false
     ): Scene.RaycastResult {
-        val (worldPos, worldDir) = screenPointToRay(x, y)
+        val (worldPos, worldDir) = screenPointToRay(x, y, camOrigin)
 
         val scene = getScene()
         if(scene == null) {
@@ -227,7 +229,7 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
      *
      * Returns (worldPos, worldDir)
      */
-    fun screenPointToRay(x: Int, y: Int): Pair<Vector3f, Vector3f> {
+    fun screenPointToRay(x: Int, y: Int, camOrigin : Boolean): Pair<Vector3f, Vector3f> {
         // calculate aspect ratio, note here that both width and height
         // are integers and need to be converted before the division, otherwise
         // we end up with an incorrect (integer) result
@@ -244,7 +246,12 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
         val origin = spatial().viewToWorld(Vector3f(0.0f)).xyz()
 
         val worldDir = (worldPos - origin).normalize()
-        return Pair(worldPos, worldDir)
+
+        return if(camOrigin) {
+            Pair(origin, worldDir)
+        } else {
+            Pair(worldPos, worldDir)
+        }
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -229,7 +229,7 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
      *
      * Returns (worldPos, worldDir)
      */
-    fun screenPointToRay(x: Int, y: Int, camOrigin : Boolean): Pair<Vector3f, Vector3f> {
+    fun screenPointToRay(x: Int, y: Int, camOrigin : Boolean = false): Pair<Vector3f, Vector3f> {
         // calculate aspect ratio, note here that both width and height
         // are integers and need to be converted before the division, otherwise
         // we end up with an incorrect (integer) result

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -194,12 +194,12 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     fun getNodesForScreenSpacePosition(
         x: Int, y: Int,
         ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java),
-        camOrigin: Boolean = false,
+        useCamOrigin: Boolean = false,
         debug: Boolean = false
     ): Scene.RaycastResult {
         return getNodesForScreenSpacePosition(x, y, { n: Node ->
             !ignoredObjects.any { it.isAssignableFrom(n.javaClass) }
-        }, camOrigin, debug)
+        }, useCamOrigin, debug)
     }
 
     /**
@@ -209,10 +209,10 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     fun getNodesForScreenSpacePosition(
         x: Int, y: Int,
         filter: (Node) -> Boolean,
-        camOrigin: Boolean = false,
+        useCamOrigin: Boolean = false,
         debug: Boolean = false
     ): Scene.RaycastResult {
-        val (worldPos, worldDir) = screenPointToRay(x, y, camOrigin)
+        val (worldPos, worldDir) = screenPointToRay(x, y, useCamOrigin)
 
         val scene = getScene()
         if(scene == null) {
@@ -229,7 +229,7 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
      *
      * Returns (worldPos, worldDir)
      */
-    fun screenPointToRay(x: Int, y: Int, camOrigin : Boolean = false): Pair<Vector3f, Vector3f> {
+    fun screenPointToRay(x: Int, y: Int, useCamOrigin : Boolean = false): Pair<Vector3f, Vector3f> {
         // calculate aspect ratio, note here that both width and height
         // are integers and need to be converted before the division, otherwise
         // we end up with an incorrect (integer) result
@@ -247,7 +247,7 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
 
         val worldDir = (worldPos - origin).normalize()
 
-        return if(camOrigin) {
+        return if(useCamOrigin) {
             Pair(origin, worldDir)
         } else {
             Pair(worldPos, worldDir)

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/RayCastExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/RayCastExample.kt
@@ -1,0 +1,111 @@
+package graphics.scenery.tests.examples.basic
+
+import org.joml.Vector3f
+import graphics.scenery.*
+import graphics.scenery.attribute.material.Material
+import graphics.scenery.backends.Renderer
+import graphics.scenery.primitives.Line
+import graphics.scenery.primitives.Plane
+import graphics.scenery.textures.Texture
+import graphics.scenery.utils.Image
+import graphics.scenery.utils.extensions.plus
+import graphics.scenery.utils.extensions.times
+import org.scijava.ui.behaviour.ClickBehaviour
+import kotlin.concurrent.thread
+
+/**
+ * <Description>
+ *
+ * @author Ulrik Günther <hello@ulrik.is>
+ */
+class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
+    val cam: Camera = DetachedHeadCamera()
+
+    override fun init() {
+        renderer = hub.add(
+            SceneryElement.Renderer,
+            Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight)
+        )
+
+        val box = Box(Vector3f(1.0f, 1.0f, 1.0f))
+        box.name = "le box du win"
+        box.material {
+            textures["diffuse"] =
+                Texture.fromImage(Image.fromResource("textures/helix.png", TexturedCubeExample::class.java))
+            metallic = 0.3f
+            roughness = 0.9f
+        }
+        //scene.addChild(box)
+
+        val plane = Plane(
+            Vector3f(-0.5f,-0.5f,0f),
+            Vector3f(-0.5f,0.5f,0f),
+            Vector3f(0.5f,-0.5f,0f),
+            Vector3f(0.5f,0.5f,0f)
+        )
+        plane.material().cullingMode = Material.CullingMode.None
+        scene.addChild(plane)
+
+
+        val light = PointLight(radius = 15.0f)
+        light.spatial().position = Vector3f(2.0f, 2.0f, 2.0f)
+        light.intensity = 5.0f
+        light.emissionColor = Vector3f(1.0f, 1.0f, 1.0f)
+        scene.addChild(light)
+
+
+        with(cam) {
+            nearPlaneDistance = 0.01f
+            spatial {
+                position = Vector3f(0.0f, 0.0f, 5.0f)
+            }
+            perspectiveCamera(50.0f, 512, 512)
+
+            scene.addChild(this)
+        }
+
+        thread {
+            while (running) {
+                box.spatial {
+                    rotation.rotateY(0.01f)
+                    needsUpdate = true
+                }
+
+                Thread.sleep(20)
+            }
+        }
+    }
+
+    override fun inputSetup() {
+        super.inputSetup()
+
+        inputHandler?.addBehaviour(
+            "sphereDragObject", object : ClickBehaviour {
+                override fun click(x: Int, y: Int) {
+                    val ray = cam.getNodesForScreenSpacePosition(x,y, listOf<Class<*>>(BoundingGrid::class.java), true)
+                    val line = scene.find("Line") as? Line
+                    if(line is Line)
+                    {
+                        line.addPoint(cam.spatial().position)
+                        line.addPoint(ray.initialPosition + ray.initialDirection.times(5.0f))
+                    }
+
+                    ray.matches.firstOrNull()?.let { hit ->
+                        val node = hit.node as? Box ?: return //backside might get hit first
+                        val hitPos = ray.initialPosition + ray.initialDirection.normalize(hit.distance)
+                        logger.info("Node: $node, HitPos: $hitPos, Distance: ${hit.distance}, Origin: ${ray.initialPosition}")
+                    }
+                }
+            }
+        )
+        inputHandler?.addKeyBinding("sphereDragObject", "1")
+    }
+
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            TexturedCubeExampleRC().main()
+        }
+    }
+}
+

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
@@ -12,7 +12,10 @@ import kotlin.concurrent.thread
 /**
  * <Description>
  *
- * @author Ulrik Günther <hello@ulrik.is>
+ * @author Konrad Michel
+ *
+ * Example to test scene mouse picking via raycasting -> Using number key 1 to cast a ray into the scene. Debug-renders a line with cubes along the ray
+ * upon hit, the console pints some information about the hit object and some spatial data concerning the hit position and distance
  */
 class SceneRayCastingExample : SceneryBase("SceneRayCastingExample") {
     val cam: Camera = DetachedHeadCamera()
@@ -62,19 +65,19 @@ class SceneRayCastingExample : SceneryBase("SceneRayCastingExample") {
         super.inputSetup()
 
         inputHandler?.addBehaviour(
-            "sphereDragObject", object : ClickBehaviour {
+            "raycastPicking", object : ClickBehaviour {
                 override fun click(x: Int, y: Int) {
                     val ray = cam.getNodesForScreenSpacePosition(x,y, listOf<Class<*>>(BoundingGrid::class.java), true, true)
 
                     ray.matches.firstOrNull()?.let { hit ->
-                        val node = hit.node as? Box ?: return //backside might get hit first
+                        val node = hit.node as? Plane ?: return //backside might get hit first
                         val hitPos = ray.initialPosition + ray.initialDirection.normalize(hit.distance)
                         logger.info("Node: $node, HitPos: $hitPos, Distance: ${hit.distance}, Origin: ${ray.initialPosition}")
                     }
                 }
             }
         )
-        inputHandler?.addKeyBinding("sphereDragObject", "1")
+        inputHandler?.addKeyBinding("raycastPicking", "1")
     }
 
     companion object {

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.thread
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
+class RayCastingExample : SceneryBase("RayCastingExample") {
     val cam: Camera = DetachedHeadCamera()
 
     override fun init() {
@@ -26,16 +26,6 @@ class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
             SceneryElement.Renderer,
             Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight)
         )
-
-        val box = Box(Vector3f(1.0f, 1.0f, 1.0f))
-        box.name = "le box du win"
-        box.material {
-            textures["diffuse"] =
-                Texture.fromImage(Image.fromResource("textures/helix.png", TexturedCubeExample::class.java))
-            metallic = 0.3f
-            roughness = 0.9f
-        }
-        //scene.addChild(box)
 
         val plane = Plane(
             Vector3f(-0.5f,-0.5f,0f),
@@ -66,10 +56,6 @@ class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
 
         thread {
             while (running) {
-                box.spatial {
-                    rotation.rotateY(0.01f)
-                    needsUpdate = true
-                }
 
                 Thread.sleep(20)
             }
@@ -82,13 +68,7 @@ class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
         inputHandler?.addBehaviour(
             "sphereDragObject", object : ClickBehaviour {
                 override fun click(x: Int, y: Int) {
-                    val ray = cam.getNodesForScreenSpacePosition(x,y, listOf<Class<*>>(BoundingGrid::class.java), true)
-                    val line = scene.find("Line") as? Line
-                    if(line is Line)
-                    {
-                        line.addPoint(cam.spatial().position)
-                        line.addPoint(ray.initialPosition + ray.initialDirection.times(5.0f))
-                    }
+                    val ray = cam.getNodesForScreenSpacePosition(x,y, listOf<Class<*>>(BoundingGrid::class.java), true, true)
 
                     ray.matches.firstOrNull()?.let { hit ->
                         val node = hit.node as? Box ?: return //backside might get hit first
@@ -104,7 +84,7 @@ class TexturedCubeExampleRC : SceneryBase("TexturedCubeExampleRC") {
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
-            TexturedCubeExampleRC().main()
+            RayCastingExample().main()
         }
     }
 }

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/SceneRayCastingExample.kt
@@ -4,12 +4,8 @@ import org.joml.Vector3f
 import graphics.scenery.*
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.backends.Renderer
-import graphics.scenery.primitives.Line
 import graphics.scenery.primitives.Plane
-import graphics.scenery.textures.Texture
-import graphics.scenery.utils.Image
 import graphics.scenery.utils.extensions.plus
-import graphics.scenery.utils.extensions.times
 import org.scijava.ui.behaviour.ClickBehaviour
 import kotlin.concurrent.thread
 
@@ -18,7 +14,7 @@ import kotlin.concurrent.thread
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-class RayCastingExample : SceneryBase("RayCastingExample") {
+class SceneRayCastingExample : SceneryBase("SceneRayCastingExample") {
     val cam: Camera = DetachedHeadCamera()
 
     override fun init() {
@@ -84,7 +80,7 @@ class RayCastingExample : SceneryBase("RayCastingExample") {
     companion object {
         @JvmStatic
         fun main(args: Array<String>) {
-            RayCastingExample().main()
+            SceneRayCastingExample().main()
         }
     }
 }


### PR DESCRIPTION
Added SceneRayCastingExample.kt, which contains a simple Scene wioth a Plane, a camera and the ability to hit key '1' to shoot a ray and debug print the hit result.

Changed Camera.kt's getNodesFromScreenSpace() to also take in an optional boolean to choose whether the ray origin should be on the worldSpace screen (starts ray at the position the screen would be when it is located in front f the camera and the ray 'shoots' through it into the scene) or the camera origin.

screenPointToRay now used the prior boolean (camOrigin) to either return a pair of worldPos and worldDir (boolean false) or origin (camera) and worldDir (boolean true)