### PR TITLE
VulkanBuffer: Circumvent too low `minUniformBufferOffsetAlignment` values

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
@@ -171,8 +171,12 @@ open class VulkanBuffer(val device: VulkanDevice, var size: Long,
      * Advances this buffer to the next possible aligned position,
      * override the buffer's default alignment by setting [align] to
      * the desired value. Returns the new position.
+     *
+     * Note: 256 seems to be the safe value here, despite devices
+     * reporting values of 16 or 64 as minUniformBufferOffsetAlignment.
+     * So we take the maximum value of buffer alignment, or 256.
      */
-    fun advance(align: Long = this.alignment): Int {
+    fun advance(align: Long = maxOf(this.alignment, 256)): Int {
         val pos = stagingBuffer.position()
         val rem = pos.rem(align)
 


### PR DESCRIPTION
This PR circumvents an issue where drivers seem to report too-low minUniformBufferOffsetAlignment values, use 256 as minimum difference between successive UBOs. This issue appeared with the 516 series Nvidia drivers and is also seen on macOS.

This should also fix the issue @RuoshanLan was seeing with wrongly-displayed instances.