### PR TITLE
Image.kt changed bufferImageToRGBABuffer imageBuffer allocation to us…

### DIFF
--- a/src/main/kotlin/graphics/scenery/utils/Image.kt
+++ b/src/main/kotlin/graphics/scenery/utils/Image.kt
@@ -2,6 +2,7 @@ package graphics.scenery.utils
 
 import cleargl.TGAReader
 import graphics.scenery.volumes.Colormap
+import org.lwjgl.system.MemoryUtil
 import java.awt.Color
 import java.awt.color.ColorSpace
 import java.awt.geom.AffineTransform
@@ -140,7 +141,7 @@ open class Image(val contents: ByteBuffer, val width: Int, val height: Int, val 
 
             val data = (texImage.raster.dataBuffer as DataBufferByte).data
 
-            imageBuffer = ByteBuffer.allocateDirect(data.size)
+            imageBuffer = MemoryUtil.memAlloc(data.size)
             imageBuffer.order(ByteOrder.nativeOrder())
             imageBuffer.put(data, 0, data.size)
             imageBuffer.rewind()


### PR DESCRIPTION
Inside Image.kt

Method: bufferedImageToRGBABuffer ->
Line 144: changed imageBuffer allocation to use MemoryUtil.memAlloc() instead of ByteBuffer.allocateDirect() -> fix memory overflow when repeatetly using the function