### PR TITLE
Fix issue where used/unused textures were cached incorrectly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,32 +44,32 @@ unit-tests-no-gpu:
     - ./gradlew --stop # stop any deamon https://stackoverflow.com/a/58397542/1047713
   script:
     - echo -e "\e[0Ksection_start:`date +%s`:build_section[collapsed=true]\r\e[0KGeneral build"
-    - ./gradlew build jacocoTestReport --build-cache --info --full-stacktrace -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar
+    - ./gradlew build jacocoTestReport --build-cache --full-stacktrace -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar
     - echo -e "\e[0Ksection_end:`date +%s`:build_section\r\e[0K"
     # basic group
     - echo -e "\e[0Ksection_start:`date +%s`:basic_section[collapsed=true]\r\e[0KBasic Test Group"
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:basic_section\r\e[0K"
     # advanced group
     - echo -e "\e[0Ksection_start:`date +%s`:advanced_section[collapsed=true]\r\e[0KAdvanced Test Group"
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=advanced -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:advanced_section\r\e[0K"
     # compute group
     - echo -e "\e[0Ksection_start:`date +%s`:compute_section[collapsed=true]\r\e[0KCompute Test Group"
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=compute -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:compute_section\r\e[0K"
     # volumes group
     - echo -e "\e[0Ksection_start:`date +%s`:volumes_section[collapsed=true]\r\e[0KVolumes Test Group"
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
-    - ./gradlew test jacocoTestReport --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShading.yml
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:volumes_section\r\e[0K"
     # code coverage reporting
     - echo -e "\e[0Ksection_start:`date +%s`:coverage_section[collapsed=true]\r\e[0KCode Coverage and Analysis"
     # we keep the same arguments here as in the last test run to not startle Gradle into re-running the test task
-    - ./gradlew fullCodeCoverageReport sonarqube --build-cache --info --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
+    - ./gradlew fullCodeCoverageReport sonarqube --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=volumes -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml
     - echo -e "\e[0Ksection_end:`date +%s`:coverage_section\r\e[0K"
   artifacts:
     when: always

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -46,8 +46,8 @@ tasks {
             filter { excludeTestsMatching("graphics.scenery.tests.unit.**") }
 
             // this should circumvent Nvidia's Vulkan cleanup issue
-            maxParallelForks = 2
-            setForkEvery(4)
+            maxParallelForks = 1
+            setForkEvery(1)
 
             testLogging {
                 exceptionFormat = TestExceptionFormat.FULL

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -44,7 +44,7 @@ tasks {
 
             // this should circumvent Nvidia's Vulkan cleanup issue
             maxParallelForks = 2
-            setForkEvery(8)
+            setForkEvery(4)
 
             // we only want the Vulkan renderer here, and all screenshot to be stored in the screenshots/ dir
             systemProperty("scenery.Renderer", "VulkanRenderer")

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -1,5 +1,8 @@
 package scenery
 
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     jacoco
 }
@@ -45,6 +48,15 @@ tasks {
             // this should circumvent Nvidia's Vulkan cleanup issue
             maxParallelForks = 2
             setForkEvery(4)
+
+            testLogging {
+                exceptionFormat = TestExceptionFormat.FULL
+                events = mutableSetOf(TestLogEvent.PASSED,
+                    TestLogEvent.FAILED,
+                    TestLogEvent.SKIPPED,
+                    TestLogEvent.STARTED)
+                showStandardStreams = true
+            }
 
             // we only want the Vulkan renderer here, and all screenshot to be stored in the screenshots/ dir
             systemProperty("scenery.Renderer", "VulkanRenderer")

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -48,6 +48,7 @@ tasks {
             // this should circumvent Nvidia's Vulkan cleanup issue
             maxParallelForks = 1
             setForkEvery(1)
+            systemProperty("scenery.Workarounds.DontCloseVulkanInstances", "true")
 
             testLogging {
                 exceptionFormat = TestExceptionFormat.FULL

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
@@ -277,7 +277,8 @@ object VulkanNodeHelpers {
 
             logger.debug("${node.name} will have $type texture from $texture in slot $slot")
 
-            if (!textureCache.containsKey(texture)) {
+            val existing = textureCache[texture]
+            if (existing == null) {
                 try {
                     logger.debug("Loading texture {} for {}", texture, node.name)
 
@@ -317,7 +318,10 @@ object VulkanNodeHelpers {
                     logger.warn("Could not load texture for ${node.name}: $e")
                 }
             } else {
-                s.textures[type] = textureCache[texture]!!
+                if(s.textures[type] != existing) {
+                    descriptorUpdated = true
+                }
+                s.textures[type] = existing
             }
         }
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
@@ -330,6 +330,7 @@ object VulkanNodeHelpers {
         val isCompute = material is ShaderMaterial && ((material as? ShaderMaterial)?.isCompute() ?: false)
         if(!isCompute) {
             Texture.objectTextures.forEach {
+                s.defaultTexturesFor.clear()
                 if (!s.textures.containsKey(it)) {
                     s.textures.putIfAbsent(it, defaultTexture)
                     s.defaultTexturesFor.add(it)

--- a/src/main/kotlin/graphics/scenery/utils/TimestampedConcurrentHashMap.kt
+++ b/src/main/kotlin/graphics/scenery/utils/TimestampedConcurrentHashMap.kt
@@ -2,7 +2,7 @@ package graphics.scenery.utils
 
 import java.util.concurrent.ConcurrentHashMap
 
-class TimestampedConcurrentHashMap<K, V: Timestamped>(initialCapacity: Int = 10) : ConcurrentHashMap<K, V>(initialCapacity) {
+class TimestampedConcurrentHashMap<K : Any, V: Timestamped>(initialCapacity: Int = 10) : ConcurrentHashMap<K, V>(initialCapacity) {
     private var added = ConcurrentHashMap<K, Long>()
 
     override fun put(key: K, value: V): V? {


### PR DESCRIPTION
This PR addresses an issue where reassigned textures would not correctly clear the used/unused texture state. 

Thanks to @PowerOfNames for pointing out this issue 👍