### PR TITLE
Fix BigVolumeViewer resolution level loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,18 @@ jobs:
             java: 17
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '${{ matrix.java }}'
           distribution: 'temurin'
-      #- name: Fix assistive technologies on Linux/JDK11
-      #  run: sudo sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - uses: burrunan/gradle-cache-action@v1
-        name: Build scenery
-        with:
-          arguments: build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info
+      - name: Build scenery
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon
 
   windows-unittests:
     name: 'Windows'
@@ -45,17 +42,16 @@ jobs:
             java: 17
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '${{ matrix.java }}'
           distribution: 'temurin'
-      - uses: burrunan/gradle-cache-action@v1
-        name: Build scenery
-        with:
-          arguments: build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info
+          cache: 'gradle'
+      - name: Build scenery
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon
 
   mac-unittests:
     name: 'macOS'
@@ -70,16 +66,15 @@ jobs:
             java: 17
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '${{ matrix.java }}'
           distribution: 'temurin'
+          cache: 'gradle'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - uses: burrunan/gradle-cache-action@v1
-        name: Build scenery
-        with:
-          arguments: build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info
+      - name: Build scenery
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.jogamp.jogl:jogl-all:2.3.2", joglNatives)
     implementation("org.slf4j:slf4j-api:1.7.36")
     implementation("net.clearvolume:cleargl")
-    implementation("org.joml:joml:1.10.4")
+    implementation("org.joml:joml:1.10.5")
     implementation("net.java.jinput:jinput:2.0.9", "natives-all")
     implementation("org.jocl:jocl:2.0.4")
     implementation("org.scijava:scijava-common")
@@ -109,10 +109,9 @@ dependencies {
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
 
     //TODO revert to official BVV
-    api("graphics.scenery:bigvolumeviewer:a6b021d")
+    api("graphics.scenery:bigvolumeviewer:7698a01")
 
-//    implementation("com.github.LWJGLX:lwjgl3-awt:cfd741a6")
-    implementation("com.github.skalarproduktraum:lwjgl3-awt:d7a7369")
+    implementation("com.github.LWJGLX:lwjgl3-awt:d8ffc63")
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     //TODO revert to official BVV
     api("graphics.scenery:bigvolumeviewer:7698a01")
 
-    implementation("com.github.LWJGLX:lwjgl3-awt:d8ffc63")
+    implementation("com.github.skalarproduktraum:lwjgl3-awt:d7a7369")
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
@@ -29,6 +29,7 @@ import tpietzsch.backend.Texture
 import tpietzsch.backend.Texture3D
 import tpietzsch.cache.*
 import tpietzsch.example2.MultiVolumeShaderMip
+import tpietzsch.example2.TriConsumer
 import tpietzsch.example2.VolumeBlocks
 import tpietzsch.example2.VolumeShaderSignature
 import tpietzsch.multires.MultiResolutionStack3D
@@ -59,7 +60,7 @@ class VolumeManager(
     override var hub: Hub?,
     val useCompute: Boolean = false,
     val customSegments: Map<SegmentType, SegmentTemplate>? = null,
-    val customBindings: BiConsumer<Map<SegmentType, SegmentTemplate>, Map<SegmentType, Segment>>? = null
+    val customBindings: TriConsumer<Map<SegmentType, SegmentTemplate>, Map<SegmentType, Segment>, Int>? = null
 ) : DefaultNode("VolumeManager"), HasGeometry, HasRenderable, HasMaterial, Hubable, RequestRepaint {
 
     /**
@@ -310,7 +311,7 @@ class VolumeManager(
         customSegments?.forEach { type, segment -> segments[type] = segment }
 
         val additionalBindings = customBindings
-            ?: BiConsumer { _: Map<SegmentType, SegmentTemplate>, instances: Map<SegmentType, Segment> ->
+        ?: TriConsumer { _: Map<SegmentType, SegmentTemplate>, instances: Map<SegmentType, Segment>, _: Int ->
                 logger.debug("Connecting additional bindings")
                 instances[SegmentType.SampleMultiresolutionVolume]?.bind("convert", instances[SegmentType.Convert])
                 instances[SegmentType.SampleVolume]?.bind("convert", instances[SegmentType.Convert])


### PR DESCRIPTION
This PR bumps BVV to the latest repository version, which includes a fix for #493. 


From #493:

Thanks to a nice Heisenbug hunting session with @tpietzsch, the culprits turned out to be the use of Matrix4f.unprojectInvRay() in combination with MipmapSizes.init(). The latter contains the assumption that the ray returned from unprojectInvRay() reaches from the near to the far plane. This was the case until JOML 1.9.17. In JOML 1.9.18, this changed, due to the support for far plane at infinity. This effectively removes a far/near division from the ray length, leading to a ray that doesn't touch the far plane.

In scenery, there are order-of-magnitude differences between near and far plane, while in BVV, they are of the same order. The issue did therefore not appear in BVV. As Matrix4f.unprojectInvRay() never promised to actually return a ray that reaches the far plane, we will handle this internally, either by using the old implementation of unprojectInvRay(), or by scaling the resulting ray correctly.

Thanks to @tpietzsch for helping to resolve this!

The PR also bumps JOML to the latest version, 1.10.5, and lwjgl3-awt to the latest repository version.