### PR TITLE
Volume: Unify composeModel() routines, remove RAIVolumeSpatial

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
@@ -75,35 +75,4 @@ class RAIVolume(@Transient val ds: VolumeDataSource, options: VolumeViewerOption
             Vector3i(1, 1, 1)
         }
     }
-
-    override fun createSpatial(): VolumeSpatial {
-        return RAIVolumeSpatial(this)
-    }
-
-    class RAIVolumeSpatial(volume: RAIVolume): VolumeSpatial(volume) {
-        override fun composeModel() {
-            @Suppress("SENSELESS_COMPARISON")
-            if (position != null && rotation != null && scale != null ) {
-                val volume = (node as? RAIVolume) ?: return
-                val source = volume.firstSource()
-
-                val shift = if (source != null) {
-                    val s = source.spimSource.getSource(0, 0)
-                    val min = Vector3f(s.min(0).toFloat(), s.min(1).toFloat(), s.min(2).toFloat())
-                    val max = Vector3f(s.max(0).toFloat(), s.max(1).toFloat(), s.max(2).toFloat())
-                    (max - min) * (-0.5f)
-                } else {
-                    Vector3f(0.0f, 0.0f, 0.0f)
-                }
-
-                model.translation(position)
-                model.mul(Matrix4f().set(this.rotation))
-                model.scale(scale)
-                model.scale(volume.localScale())
-                if (volume.origin == Origin.Center) {
-                    model.translate(shift)
-                }
-            }
-        }
-    }
 }

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -33,6 +33,7 @@ import graphics.scenery.net.Networkable
 import graphics.scenery.numerics.OpenSimplexNoise
 import graphics.scenery.numerics.Random
 import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.extensions.times
 import graphics.scenery.volumes.Volume.VolumeDataSource.SpimDataMinimalSource
 import io.scif.SCIFIO
 import io.scif.util.FormatTools
@@ -857,15 +858,14 @@ open class Volume(
          * into account.
          */
         override fun composeModel() {
-            @Suppress("SENSELESS_COMPARISON")
-            if(position != null && rotation != null && scale != null) {
-                model.translation(position)
-                model.mul(Matrix4f().set(this.rotation))
-                if(volume.origin == Origin.Center) {
-                    model.translate(-2.0f, -2.0f, -2.0f)
-                }
-                model.scale(scale)
-                model.scale(volume.localScale())
+            val shift = Vector3f(volume.getDimensions()) * (-0.5f)
+
+            model.translation(position)
+            model.mul(Matrix4f().set(this.rotation))
+            model.scale(scale)
+            model.scale(volume.localScale())
+            if (volume.origin == Origin.Center) {
+                model.translate(shift)
             }
         }
     }

--- a/src/main/resources/graphics/scenery/repl/startup.py
+++ b/src/main/resources/graphics/scenery/repl/startup.py
@@ -1,6 +1,6 @@
 # scenery REPL python init file
 from graphics.scenery.volumes import TransferFunction, Colormap, Volume
-from org.joml import *
+from org.joml import Vector2f, Vector3f, Vector4f, Vector2i, Vector3i, Vector4i, Matrix3f, Matrix4f, Matrix4x3f
 from graphics.scenery import *
 from graphics.scenery.utils import *
 from graphics.scenery.net import *

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/ProceduralVolumeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/ProceduralVolumeExample.kt
@@ -7,68 +7,65 @@ import graphics.scenery.numerics.Random
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.utils.RingBuffer
 import graphics.scenery.utils.extensions.plus
+import graphics.scenery.volumes.BufferedVolume
 import graphics.scenery.volumes.Colormap
+import graphics.scenery.volumes.TransferFunction
 import graphics.scenery.volumes.Volume
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.lwjgl.system.MemoryUtil.memAlloc
 import org.scijava.ui.behaviour.ClickBehaviour
-import java.nio.ByteBuffer
 import kotlin.concurrent.thread
+import kotlin.math.PI
 
 /**
  * Example that renders procedurally generated volumes.
  * [bitsPerVoxel] can be set to 8 or 16, to generate Byte or UnsignedShort volumes.
  *
+ * Press T when running to toggle the animation.
+ *
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class ProceduralVolumeExample: SceneryBase("Procedural Volume Rendering Example", 1280, 720) {
-    val bitsPerVoxel = 8
-    val volumeSize = 128L
+    private val bitsPerVoxel = 8
+    private val volumeSize = 128
+    private lateinit var volume: BufferedVolume
 
+    /**
+     * Example initialiser, creates renderer, sets up the scene and procedural
+     * volume buffer. Starts a thread for animation.
+     */
     override fun init() {
         renderer = hub.add(Renderer.createRenderer(hub, applicationName, scene, windowWidth, windowHeight))
 
         val cam: Camera = DetachedHeadCamera()
         with(cam) {
-            spatial {
-                position = Vector3f(0.0f, 0.5f, 5.0f)
-            }
+            spatial().position = Vector3f(0.0f, 0.0f, 5.0f)
             perspectiveCamera(50.0f, windowWidth, windowHeight)
 
             scene.addChild(this)
         }
 
-        val shell = Box(Vector3f(10.0f, 10.0f, 10.0f), insideNormals = true)
+        val shell = Box(Vector3f(15.0f), insideNormals = true)
         shell.material {
             cullingMode = Material.CullingMode.None
             diffuse = Vector3f(0.1f, 0.1f, 0.1f)
             specular = Vector3f(0.0f)
             ambient = Vector3f(0.0f)
         }
-        shell.spatial {
-            position = Vector3f(0.0f, 4.0f, 0.0f)
-        }
         scene.addChild(shell)
 
-        val volume = if(bitsPerVoxel == 8) {
-            Volume.fromBuffer(emptyList(), volumeSize.toInt(), volumeSize.toInt(), volumeSize.toInt(), UnsignedByteType(), hub)
+        volume = if(bitsPerVoxel == 8) {
+            Volume.fromBuffer(emptyList(), volumeSize, volumeSize, volumeSize, UnsignedByteType(), hub)
         } else {
-            Volume.fromBuffer(emptyList(), volumeSize.toInt(), volumeSize.toInt(), volumeSize.toInt(), UnsignedShortType(), hub)
+            Volume.fromBuffer(emptyList(), volumeSize, volumeSize, volumeSize, UnsignedShortType(), hub)
         }
 
         volume.name = "volume"
-        volume.spatial().position = Vector3f(0.0f, 5.0f, 0.0f)
-        volume.colormap = Colormap.get("hot")
-        volume.pixelToWorldRatio = 0.03f
-
-        with(volume.transferFunction) {
-            addControlPoint(0.0f, 0.0f)
-            addControlPoint(0.2f, 0.0f)
-            addControlPoint(0.4f, 0.5f)
-            addControlPoint(0.8f, 0.5f)
-            addControlPoint(1.0f, 0.0f)
-        }
+        volume.colormap = Colormap.get("jet")
+        volume.pixelToWorldRatio = 0.02f
+        volume.transferFunction = TransferFunction.ramp(0.01f, 0.04f, 0.1f)
+        volume.spatial().rotation.rotateY(PI.toFloat()/4.0f)
 
         volume.metadata["animating"] = true
         scene.addChild(volume)
@@ -85,54 +82,67 @@ class ProceduralVolumeExample: SceneryBase("Procedural Volume Rendering Example"
         }
 
         thread {
-            val volumeBuffer = RingBuffer<ByteBuffer>(2, default = { memAlloc((volumeSize*volumeSize*volumeSize*bitsPerVoxel/8).toInt()) })
+            val volumeBuffer = RingBuffer(2, default = { memAlloc((volumeSize*volumeSize*volumeSize*bitsPerVoxel/8)) })
 
             val seed = Random.randomFromRange(0.0f, 133333337.0f).toLong()
             var shift = Vector3f(0.0f)
-            val shiftDelta = Random.random3DVectorFromRange(-1.5f, 1.5f)
+            var shiftDelta = Random.random3DVectorFromRange(-0.5f, 0.5f)
 
             var count = 0
             while(running && !shouldClose) {
                 if(volume.metadata["animating"] == true) {
                     val currentBuffer = volumeBuffer.get()
 
-                    Volume.generateProceduralVolume(volumeSize, 0.35f, seed = seed,
-                        intoBuffer = currentBuffer, shift = shift, use16bit = bitsPerVoxel > 8)
+                    Volume.generateProceduralVolume(
+                        volumeSize.toLong(),
+                        0.35f,
+                        seed = seed,
+                        intoBuffer = currentBuffer,
+                        shift = shift,
+                        use16bit = bitsPerVoxel > 8
+                    )
 
-                        volume.addTimepoint("t-${count}", currentBuffer)
-                        volume.goToLastTimepoint()
+                    volume.addTimepoint("t-${count}", currentBuffer)
+                    volume.goToLastTimepoint()
 
-                        volume.purgeFirst(10, 10)
+                    volume.purgeFirst(10, 10)
 
                     shift += shiftDelta
                     count++
+
+                    // 5% chance of changing direction
+                    if(kotlin.random.Random.nextFloat() > 0.95f) {
+                        shiftDelta += Random.random3DVectorFromRange(-0.5f, 0.5f)
+                    }
                 }
 
-                Thread.sleep(kotlin.random.Random.nextLong(10L, 200L))
+                Thread.sleep(kotlin.random.Random.nextLong(5L, 25L))
             }
         }
     }
 
+    /**
+     * Input setup override, sets up camera mode switching, where pressing C
+     * can toggle between FPS and Arcball camera control. Also adds animation
+     * toggling when pressing T.
+     */
     override fun inputSetup() {
         setupCameraModeSwitching()
 
-        val toggleRenderingMode = object : ClickBehaviour {
-            var modes = Volume.RenderingMethod.values()
-            var currentMode = (scene.find("volume") as? Volume)?.renderingMethod?.ordinal ?: 0
-
-            override fun click(x: Int, y: Int) {
-                currentMode = (currentMode + 1) % modes.size
-
-                (scene.find("volume") as? Volume)?.renderingMethod = Volume.RenderingMethod.values().get(currentMode)
-                logger.info("Switched volume rendering mode to ${modes[currentMode]} (${(scene.find("volume") as? Volume)?.renderingMethod})")
-            }
-        }
-
-        inputHandler?.addBehaviour("toggle_rendering_mode", toggleRenderingMode)
-        inputHandler?.addKeyBinding("toggle_rendering_mode", "M")
+        inputHandler?.addBehaviour("toggle_animation",
+                                   ClickBehaviour { _, _ ->
+                                       volume.metadata["animating"] = !(volume.metadata["animating"] as Boolean)
+                                   })
+        inputHandler?.addKeyBinding("toggle_animation", "T")
     }
 
+    /**
+     * Companion object for providing a main method.
+     */
     companion object {
+        /**
+         * Main method, instantiates the example.
+         */
         @JvmStatic
         fun main(args: Array<String>) {
             ProceduralVolumeExample().main()


### PR DESCRIPTION
This PR unifies the composeModel() routines for all Volume subtypes. This should correct centering issues, as well as issues with bounding boxes.

cc @RuoshanLan @moreApi 