### PR TITLE
Volume: Let currentTimepoint return the correct value

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
@@ -68,6 +68,8 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
         timepoints?.removeIf { it.name == name }
         timepoints?.add(Timepoint(name, buffer))
         timepointCount = timepoints?.size ?: 0
+        viewerState.numTimepoints = timepointCount
+
         volumeManager.notifyUpdate(this)
     }
 
@@ -81,6 +83,8 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
             tp?.contents?.let { MemoryUtil.memFree(it) }
         }
         timepointCount = timepoints?.size ?: 0
+        viewerState.numTimepoints = timepointCount
+
         volumeManager.notifyUpdate(this)
         return result != null
     }
@@ -102,6 +106,9 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
                 MemoryUtil.memFree(tp.contents)
             }
         }
+
+        timepointCount = timepoints?.size ?: 0
+        viewerState.numTimepoints = timepointCount
     }
 
     /**
@@ -122,6 +129,9 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
                 MemoryUtil.memFree(tp.contents)
             }
         }
+
+        timepointCount = timepoints?.size ?: 0
+        viewerState.numTimepoints = timepointCount
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -183,7 +183,6 @@ open class Volume(
             }
         }
         set(value) {
-            viewerState.numTimepoints = timepointCount
             viewerState.currentTimepoint = value
             modifiedAt = System.nanoTime()
             field = value

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -173,7 +173,7 @@ open class Volume(
     var cacheControls = CacheControl.CacheControls()
 
     /** Current timepoint. */
-    var currentTimepoint: Int
+    var currentTimepoint: Int = 0
         get() {
             // despite IDEAs warning this might be not be false if kryo uses its de/serialization magic
             return if (dataSource == null || dataSource is VolumeDataSource.NullSource) {
@@ -183,8 +183,10 @@ open class Volume(
             }
         }
         set(value) {
+            viewerState.numTimepoints = timepointCount
             viewerState.currentTimepoint = value
             modifiedAt = System.nanoTime()
+            field = value
         }
 
     sealed class VolumeDataSource {


### PR DESCRIPTION
This PR fixes an issue where `Volume.currentTimepoint` always returned 0. It now returns the correct value, and sets the BVV state variable `numTimepoints` correctly as well.

cc @moreApi 