### PR TITLE
TransferFunction.serialize() fix endianess for stale return

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/TransferFunction.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransferFunction.kt
@@ -113,7 +113,7 @@ open class TransferFunction(val name: String = "") {
      */
     fun serialise(): ByteBuffer {
         if(!stale) {
-            return buffer.duplicate()
+            return buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN)
         }
 
         val points = controlPoints.sortedBy { it.value }


### PR DESCRIPTION
Fixes a bug where the !stale return of TransferFunction.serialize() returns the buffer with the wrong Endianess.