### PR TITLE
DefaultSpatial: worldPosition with a null argument and a non scene parent now does not apply the position twice to the return value.

### DIFF
--- a/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
@@ -209,14 +209,12 @@ open class DefaultSpatial(@Transient protected var node: Node = DefaultNode()) :
         return false
     }
 
-    override fun worldPosition(v: Vector3f?): Vector3f {
-        val target = v ?: position
-        return if(node.parent is Scene && v == null) {
-            Vector3f(target)
+    override fun worldPosition(v: Vector3f?): Vector3f =
+        if(node.parent is Scene && v == null) {
+            Vector3f(position)
         } else {
-            world.transform(Vector4f().set(target, 1.0f)).xyz()
+            world.transform(Vector4f().set(v ?: Vector3f(), 1.0f)).xyz()
         }
-    }
 
     /**
      * Performs a intersection test with an axis-aligned bounding box of this [Node], where


### PR DESCRIPTION
This happens because in scenery's spatial.world also the model is included.