### PR TITLE
Fixed covers for curves and computed normals within the curve class

### DIFF
--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -255,7 +255,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 return Pair(verticesVectors, normalVectors)
             }
             if (addCoverOrTop == 0) {
-                val newVerticesAndNormals = getCoverVertices(curveGeometry.last(), false)
+                val newVerticesAndNormals = getCoverVertices(curveGeometry.first(), true)
                 verticesVectors.addAll(newVerticesAndNormals.first)
                 normalVectors.addAll(newVerticesAndNormals.second)
             }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -386,6 +386,10 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             return Pair(verticesList, normalVectors)
         }
 
+        /**
+         * Computes the normals for each vertex then gives this list to the function [orderNormals] to give each of
+         * triangle vertices it's normal.
+         */
         private fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>, shapeSize: Int): ArrayList<Vector3f> {
             //TODO allocate the size
             val normalsOfvertices = ArrayList<ArrayList<Vector3f>>()
@@ -422,28 +426,21 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     val vertexNormal = Vector3f()
                     when(shapeIndex) {
                         0-> {
-                            vertexNormal.add(section[1][sectionIndex+1])
-                            vertexNormal.add(section[1][sectionIndex])
-                            vertexNormal.add(section[1].last())
-                            vertexNormal.add(section[0].last())
-                            vertexNormal.add(section[0].drop(1).last())
-                            vertexNormal.add(section[0][sectionIndex])
-                        }
-                        shapeSize-1 -> {
                             vertexNormal.add(section[1].first())
-                            vertexNormal.add(section[1][sectionIndex])
-                            vertexNormal.add(section[1][sectionIndex-1])
-                            vertexNormal.add(section[0][sectionIndex-1])
-                            vertexNormal.add(section[0][sectionIndex-2])
-                            vertexNormal.add(section[0][sectionIndex])
+                            vertexNormal.add(section[1].last())
+                            vertexNormal.add(section[1].drop(1).last())
+                            vertexNormal.add(section[0].last())
+                            vertexNormal.add(section[0].first())
+                            vertexNormal.add(section[0][sectionIndex+1])
                         }
                         else -> {
-                            vertexNormal.add(section[1][sectionIndex+1])
                             vertexNormal.add(section[1][sectionIndex])
                             vertexNormal.add(section[1][sectionIndex-1])
+                            vertexNormal.add(section[1][sectionIndex-2])
                             vertexNormal.add(section[0][sectionIndex-1])
-                            vertexNormal.add(section[0][sectionIndex-2])
                             vertexNormal.add(section[0][sectionIndex])
+                            vertexNormal.add(section[0][sectionIndex+1])
+
                         }
                     }
                     allSectionNormals.add(vertexNormal.normalize())
@@ -478,6 +475,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             return orderNormals(normalsOfvertices)
         }
 
+        /**
+         * Orders the normals in the same structure as the triangle vertices.
+         */
         private fun orderNormals(verticesNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
             //TODO allocate size
             val finalNormals = ArrayList<Vector3f>()

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -325,17 +325,14 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
         private fun getCoverVertices(list: List<Vector3f>, ccw: Boolean): ArrayList<Vector3f> {
             val size = list.size
             val verticesList = ArrayList<Vector3f>(size + (size / 2))
-            val workList = ArrayList<Vector3f>(size)
-            workList.addAll(list)
+
             if (size >= 3) {
-                /* The algorithm must not stop before the last triangle. The next five lines ensure, therefore,
-                   that the last triangle, which contains the last point as well as the first point, is included.
-             */
-                when (size) {
-                    0 -> {  workList.add(list[0])
-                        workList.add(list[1]) }
-                    1 -> { workList.add(list[0]) }
-                }
+                val workList = ArrayList<Vector3f>(size)
+                workList.addAll(list)
+
+                //Ensures that the algorithm does not stop before the last triangle.
+                if(size%2 == 0) { workList.add(list[0]) }
+
                 val newList = ArrayList<Vector3f>((size + (size / 2)) / 2)
                 workList.windowed(3, 2) { triangle ->
                     if (ccw) {
@@ -349,6 +346,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     }
                     newList.add(triangle[0])
                 }
+                //to avoid gaps when the vertex number is odd
+                if(size%2==1) { newList.add(list.last()) }
+
                 verticesList.addAll(getCoverVertices(newList, ccw))
             }
             return verticesList

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -387,61 +387,25 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
         }
 
         fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
-            //calculate normals for every section seperately TODO compute right list size
-            val curveNormals = ArrayList<Vector3f>(intermediateNormals.size*intermediateNormals[0].size)
-            intermediateNormals.forEachIndexed { index, intermediateNormalSection ->
-                when(index) {
-                    0 -> { //TODO
-                     }
-                    intermediateNormals.lastIndex -> {
-                        //TODO
-                    }
-                    else -> {
-                        for(i in 0 .. intermediateNormalSection.lastIndex) {
-
-                        }
-                    }
-                }
-            }
-            intermediateNormals.windowed(3, 1) { sectionNormals ->
-                //first triangle normals
-                val firstVertexNormal = Vector3f()
-                firstVertexNormal.add(sectionNormals[1][1])
-                firstVertexNormal.add(sectionNormals[0][0])
-                firstVertexNormal.add(sectionNormals[0][sectionNormals[0].lastIndex])
-                firstVertexNormal.add(sectionNormals[0][sectionNormals[0].lastIndex-1])
-                firstVertexNormal.add(sectionNormals[1][sectionNormals[1].lastIndex)
-                firstVertexNormal.add(sectionNormals[1][0])
-                curveNormals.add(firstVertexNormal.normalize())
-
-                for(i in 0 .. shapeSize) {
-                    var sectionIndex = 0
-                    var triangleIndex = 0
-                    for(vertexNumber in 1 .. 6) {
-                        when(vertexNumber) {
-                            1 -> {}
-                            2 -> {
-                                triangleIndex = 1
-                            }
-                            3 -> {
-                                sectionIndex = 1
-                                triangleIndex = 1
-                            }
-                            4 -> {
-                                sectionIndex = 0
-                                triangleIndex = 0
-                            }
-
-                        }
-                    }
-
-                }
-
+            //TODO allocate the size
+            val normalsOfvertices = ArrayList<ArrayList<Vector3f>>()
+            //calculate normals for every vertex
+            intermediateNormals.windowed(size = 2, 1) { section ->
+                //TODO allocate size
+                val allSectionNormals = ArrayList<Vector3f>()
 
             }
-            return curveNormals
-
+            //TODO order normals in the right structure
+            return orderNormals(normalsOfvertices)
         }
+
+        fun orderNormals(verticesNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
+            //TODO allocate size
+            val finalNormals = ArrayList<Vector3f>()
+            //TODO algorithm
+            return finalNormals
+        }
+
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -430,7 +430,6 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     val vertexNormal = Vector3f()
                     when(shapeIndex) {
                         0-> {
-                            //ToDO the bug seems to be here
                             vertexNormal.add(section[1].first())
                             vertexNormal.add(section[1].last())
                             vertexNormal.add(section[1].drop(1).last())
@@ -496,27 +495,6 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex + 1])
                     finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex])
                 }
-
-                /*
-                val triangle1Point1 = curveGeometry[shapeIndex][shape.lastIndex]
-                    val triangle1Point2 = curveGeometry[shapeIndex][0]
-                    val triangle1Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
-                    verticesVectors.add(triangle1Point1)
-                    verticesVectors.add(triangle1Point2)
-                    verticesVectors.add(triangle1Point3)
-
-                    //normal calculation triangle 1
-                    val normal1 = ((Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))
-                        .cross(Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1))))
-                    intermediateNormalSection.add(normal1)
-
-                    val triangle2Point1 = curveGeometry[shapeIndex][0]
-                    val triangle2Point2 = curveGeometry[shapeIndex + 1][0]
-                    val triangle2Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
-                    verticesVectors.add(triangle2Point1)
-                    verticesVectors.add(triangle2Point2)
-                    verticesVectors.add(triangle2Point3)
-                 */
                 finalNormals.add(verticesNormals[shapeIndex][shape.lastIndex])
                 finalNormals.add(verticesNormals[shapeIndex][0])
                 finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -319,7 +319,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     //add all triangle normals from this section
                     intermediateNormals.add(intermediateNormalSection)
                 }
-                normalVectors.addAll(computeNormals(intermediateNormals, curveGeometry[0].size))
+                normalVectors.addAll(computeNormals(intermediateNormals))
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
             }
@@ -386,16 +386,95 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             return Pair(verticesList, normalVectors)
         }
 
-        fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
+        fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>, shapeSize: Int): ArrayList<Vector3f> {
             //TODO allocate the size
             val normalsOfvertices = ArrayList<ArrayList<Vector3f>>()
             //calculate normals for every vertex
+            val firstSectionNormals = ArrayList<Vector3f>(shapeSize)
+            for(shapeIndex in 0 until shapeSize) {
+                val sectionIndex = shapeIndex*2
+                val vertexNormal = Vector3f()
+                when(shapeIndex) {
+                    0 -> {
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex+1])
+                        vertexNormal.add(intermediateNormals.first().last())
+                    }
+                    shapeSize-1 -> {
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.first().first())
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex-1])
+                    }
+                    else -> {
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex+1])
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex-1])
+                    }
+                }
+                firstSectionNormals.add(vertexNormal.normalize())
+            }
+            normalsOfvertices.add(firstSectionNormals)
             intermediateNormals.windowed(size = 2, 1) { section ->
                 //TODO allocate size
                 val allSectionNormals = ArrayList<Vector3f>()
-
+                for(shapeIndex in 0 until shapeSize) {
+                    val sectionIndex = shapeIndex*2
+                    val vertexNormal = Vector3f()
+                    when(shapeIndex) {
+                        0-> {
+                            vertexNormal.add(section[1][sectionIndex+1])
+                            vertexNormal.add(section[1][sectionIndex])
+                            vertexNormal.add(section[1].last())
+                            vertexNormal.add(section[0].last())
+                            vertexNormal.add(section[0].drop(1).last())
+                            vertexNormal.add(section[0][sectionIndex])
+                        }
+                        shapeSize-1 -> {
+                            vertexNormal.add(section[1].first())
+                            vertexNormal.add(section[1][sectionIndex])
+                            vertexNormal.add(section[1][sectionIndex-1])
+                            vertexNormal.add(section[0][sectionIndex-1])
+                            vertexNormal.add(section[0][sectionIndex-2])
+                            vertexNormal.add(section[0][sectionIndex])
+                        }
+                        else -> {
+                            vertexNormal.add(section[1][sectionIndex+1])
+                            vertexNormal.add(section[1][sectionIndex])
+                            vertexNormal.add(section[1][sectionIndex-1])
+                            vertexNormal.add(section[0][sectionIndex-1])
+                            vertexNormal.add(section[0][sectionIndex-2])
+                            vertexNormal.add(section[0][sectionIndex])
+                        }
+                    }
+                    allSectionNormals.add(vertexNormal.normalize())
+                }
+                normalsOfvertices.add(allSectionNormals)
             }
-            //TODO order normals in the right structure
+            //TODO add normals for the last section
+            val lastSectionNormals = ArrayList<Vector3f>(shapeSize)
+            for(shapeIndex in 0 until shapeSize) {
+                val sectionIndex = shapeIndex*2
+                val vertexNormal = Vector3f()
+                when(shapeIndex) {
+                    0 -> {
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex+1])
+                        vertexNormal.add(intermediateNormals.last().last())
+                    }
+                    shapeSize-1 -> {
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.last().first())
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex-1])
+                    }
+                    else -> {
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex])
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex+1])
+                        vertexNormal.add(intermediateNormals.last()[sectionIndex-1])
+                    }
+                }
+                lastSectionNormals.add(vertexNormal.normalize())
+            }
+            normalsOfvertices.add(lastSectionNormals)
             return orderNormals(normalsOfvertices)
         }
 

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -530,27 +530,6 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 boundingBox = generateBoundingBox()
             }
             boundingBox = generateBoundingBox()
-
-            //TODO delete
-
-            val matBright = DefaultMaterial()
-            matBright.diffuse  = Vector3f(0.0f, 1.0f, 0.0f)
-            matBright.ambient  = Vector3f(1.0f, 1.0f, 1.0f)
-            matBright.specular = Vector3f(1.0f, 1.0f, 1.0f)
-            matBright.cullingMode = Material.CullingMode.None
-            verticesVectors.forEachIndexed { index, vertex ->
-                if(index%10 == 0) {
-                    val normal = normalVectors[index]
-                    val a = Arrow(Vector3f() - normal)  //shape of the vector itself
-                    a.spatial {
-                        position = vertex                 //position/base of the vector
-                    }
-                    a.addAttribute(Material::class.java, matBright)                  //usual stuff follows...
-                    a.edgeWidth = 0.5f
-                    this.addChild(a)
-                }
-            }
-
         }
     }
 }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -82,14 +82,14 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     0 -> {
                         0
                     }
-                    subShapes.size - 1 -> {
+                    subShapes.lastIndex -> {
                         2
                     }
                     else -> {
                         1
                     }
                 }
-                val trianglesAndNormals = calculateTriangles(arrayList, i)
+                val trianglesAndNormals = calculateTriangles(arrayList, addCoverOrTop = i)
                 val partialCurve = PartialCurve(trianglesAndNormals.first, trianglesAndNormals.second)
                 this.addChild(partialCurve)
             }
@@ -255,7 +255,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 return Pair(verticesVectors, normalVectors)
             }
             if (addCoverOrTop == 0) {
-                val newVerticesAndNormals = getCoverVertices(curveGeometry.last(), true)
+                val newVerticesAndNormals = getCoverVertices(curveGeometry.last(), false)
                 verticesVectors.addAll(newVerticesAndNormals.first)
                 normalVectors.addAll(newVerticesAndNormals.second)
             }
@@ -324,8 +324,6 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 verticesVectors.addAll(newVerticesAndNormals.first)
                 normalVectors.addAll(newVerticesAndNormals.second)
             }
-            println(normalVectors.size)
-            println(verticesVectors.size)
             return Pair(verticesVectors, normalVectors)
         }
 
@@ -391,7 +389,6 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
      */
     class PartialCurve(verticesVectors: ArrayList<Vector3f>, normalVectors: ArrayList<Vector3f>) : Mesh("PartialCurve") {
         init {
-            if(verticesVectors.size != verticesVectors.size) { println(" NOT right size for vertices/normals") }
             geometry {
                 vertices = BufferUtils.allocateFloat(verticesVectors.size * 3)
                 verticesVectors.forEach {

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -386,7 +386,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             return Pair(verticesList, normalVectors)
         }
 
-        fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>, shapeSize: Int): ArrayList<Vector3f> {
+        private fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>, shapeSize: Int): ArrayList<Vector3f> {
             //TODO allocate the size
             val normalsOfvertices = ArrayList<ArrayList<Vector3f>>()
             //calculate normals for every vertex
@@ -478,7 +478,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             return orderNormals(normalsOfvertices)
         }
 
-        fun orderNormals(verticesNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
+        private fun orderNormals(verticesNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
             //TODO allocate size
             val finalNormals = ArrayList<Vector3f>()
             verticesNormals.dropLast(1).forEachIndexed { shapeIndex, shape ->

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -353,10 +353,10 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     } else {
                         for (i in 0..2) {
                             verticesList.add(triangle[i])
-                            //compute normal
-                            normalVectors.add(((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
-                                .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize())
                         }
+                        //compute normal
+                        normalVectors.add(((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
+                            .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize())
                     }
                     newList.add(triangle[0])
                 }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -279,8 +279,8 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesVectors.add(triangle1Point3)
 
                         //normal calculation triangle 1
-                        val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
-                            .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
+                        val normal1 = ((Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))
+                            .cross(Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1))))
                         intermediateNormalSection.add(normal1)
 
                         val triangle2Point1 = curveGeometry[shapeIndex][vertexIndex + 1]
@@ -291,8 +291,8 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesVectors.add(triangle2Point3)
 
                         //normal calculation triangle 2
-                        val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
-                            .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
+                        val normal2 = ((Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))
+                            .cross(Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1))))
                         intermediateNormalSection.add(normal2)
                     }
 
@@ -304,20 +304,20 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     verticesVectors.add(triangle1Point3)
 
                     //normal calculation triangle 1
-                    val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
-                        .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
+                    val normal1 = ((Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))
+                        .cross(Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1))))
                     intermediateNormalSection.add(normal1)
 
-                    val triangle2Point1 = curveGeometry[shapeIndex][0]
-                    val triangle2Point2 = curveGeometry[shapeIndex + 1][0]
+                    val triangle2Point1 = curveGeometry[shapeIndex + 1][0]
+                    val triangle2Point2 = curveGeometry[shapeIndex][0]
                     val triangle2Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
                     verticesVectors.add(triangle2Point1)
                     verticesVectors.add(triangle2Point2)
                     verticesVectors.add(triangle2Point3)
 
                     //normal calculation triangle 2
-                    val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
-                        .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
+                    val normal2 = ((Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))
+                        .cross(Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1))))
                     intermediateNormalSection.add(normal2)
 
                     //add all triangle normals from this section
@@ -396,7 +396,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
          */
         private fun computeNormals(intermediateNormals: ArrayList<ArrayList<Vector3f>>, shapeSize: Int): ArrayList<Vector3f> {
             //TODO allocate the size
-            val normalsOfvertices = ArrayList<ArrayList<Vector3f>>()
+            val normalsOfVertices = ArrayList<ArrayList<Vector3f>>()
             //calculate normals for every vertex
             val firstSectionNormals = ArrayList<Vector3f>(shapeSize)
             for(shapeIndex in 0 until shapeSize) {
@@ -414,14 +414,14 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         vertexNormal.add(intermediateNormals.first()[sectionIndex-1])
                     }
                     else -> {
-                        vertexNormal.add(intermediateNormals.first()[sectionIndex])
-                        vertexNormal.add(intermediateNormals.first()[sectionIndex+1])
                         vertexNormal.add(intermediateNormals.first()[sectionIndex-1])
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex+1])
+                        vertexNormal.add(intermediateNormals.first()[sectionIndex])
                     }
                 }
                 firstSectionNormals.add(vertexNormal.normalize())
             }
-            normalsOfvertices.add(firstSectionNormals)
+            normalsOfVertices.add(firstSectionNormals)
             intermediateNormals.windowed(size = 2, 1) { section ->
                 //TODO allocate size
                 val allSectionNormals = ArrayList<Vector3f>()
@@ -444,12 +444,11 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                             vertexNormal.add(section[0][sectionIndex-1])
                             vertexNormal.add(section[0][sectionIndex])
                             vertexNormal.add(section[0][sectionIndex+1])
-
                         }
                     }
                     allSectionNormals.add(vertexNormal.normalize())
                 }
-                normalsOfvertices.add(allSectionNormals)
+                normalsOfVertices.add(allSectionNormals)
             }
 
             val lastSectionNormals = ArrayList<Vector3f>(shapeSize)
@@ -475,8 +474,8 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 }
                 lastSectionNormals.add(vertexNormal.normalize())
             }
-            normalsOfvertices.add(lastSectionNormals)
-            return orderNormals(normalsOfvertices)
+            normalsOfVertices.add(lastSectionNormals)
+            return orderNormals(normalsOfVertices)
         }
 
         /**
@@ -533,21 +532,25 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
             boundingBox = generateBoundingBox()
 
             //TODO delete
+
             val matBright = DefaultMaterial()
             matBright.diffuse  = Vector3f(0.0f, 1.0f, 0.0f)
             matBright.ambient  = Vector3f(1.0f, 1.0f, 1.0f)
             matBright.specular = Vector3f(1.0f, 1.0f, 1.0f)
             matBright.cullingMode = Material.CullingMode.None
             verticesVectors.forEachIndexed { index, vertex ->
-                val normal = normalVectors[index]
-                val a = Arrow(Vector3f() - vertex)  //shape of the vector itself
-                a.spatial {
-                    position = vertex                 //position/base of the vector
+                if(index%10 == 0) {
+                    val normal = normalVectors[index]
+                    val a = Arrow(Vector3f() - normal)  //shape of the vector itself
+                    a.spatial {
+                        position = vertex                 //position/base of the vector
+                    }
+                    a.addAttribute(Material::class.java, matBright)                  //usual stuff follows...
+                    a.edgeWidth = 0.5f
+                    this.addChild(a)
                 }
-                a.addAttribute(Material::class.java, matBright)                  //usual stuff follows...
-                a.edgeWidth = 0.5f
-                this.addChild(a)
             }
+
         }
     }
 }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -2,6 +2,10 @@ package graphics.scenery.geometry
 
 import graphics.scenery.BufferUtils
 import graphics.scenery.Mesh
+import graphics.scenery.attribute.material.DefaultMaterial
+import graphics.scenery.attribute.material.Material
+import graphics.scenery.primitives.Arrow
+import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.toFloatArray
 import org.joml.*
 import kotlin.Float.Companion.MIN_VALUE
@@ -527,6 +531,23 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 boundingBox = generateBoundingBox()
             }
             boundingBox = generateBoundingBox()
+
+            //TODO delete
+            val matBright = DefaultMaterial()
+            matBright.diffuse  = Vector3f(0.0f, 1.0f, 0.0f)
+            matBright.ambient  = Vector3f(1.0f, 1.0f, 1.0f)
+            matBright.specular = Vector3f(1.0f, 1.0f, 1.0f)
+            matBright.cullingMode = Material.CullingMode.None
+            verticesVectors.forEachIndexed { index, vertex ->
+                val normal = normalVectors[index]
+                val a = Arrow(Vector3f() - vertex)  //shape of the vector itself
+                a.spatial {
+                    position = vertex                 //position/base of the vector
+                }
+                a.addAttribute(Material::class.java, matBright)                  //usual stuff follows...
+                a.edgeWidth = 0.5f
+                this.addChild(a)
+            }
         }
     }
 }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -271,9 +271,24 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     verticesVectors.add(curveGeometry[shapeIndex + 1][0])
                     verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
 
+
+                    /*
+                    Testing, delete following three lines afterwards
+                     */
+                    verticesVectors.add(curveGeometry[shapeIndex][0])
+                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
+                    verticesVectors.add(curveGeometry[shapeIndex + 1][0])
+
                     verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
                     verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
                     verticesVectors.add(curveGeometry[shapeIndex][0])
+
+                    /*
+                    Testing, delete following three lines afterwards
+                     */
+                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
+                    verticesVectors.add(curveGeometry[shapeIndex][0])
+                    verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
@@ -323,7 +338,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
     }
 
     /**
-     * Each children of the curve must be, per definition, another Mesh. Therefore this class turns a List of
+     * Each child of the curve must be, per definition, another Mesh. Therefore, this class turns a List of
      * vertices into a Mesh.
      */
     class PartialCurve(verticesVectors: ArrayList<Vector3f>) : Mesh("PartialCurve") {

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -319,7 +319,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     //add all triangle normals from this section
                     intermediateNormals.add(intermediateNormalSection)
                 }
-                normalVectors.addAll(computeNormals(intermediateNormals))
+                normalVectors.addAll(computeNormals(intermediateNormals, curveGeometry.first().size))
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
             }
@@ -450,7 +450,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 }
                 normalsOfvertices.add(allSectionNormals)
             }
-            //TODO add normals for the last section
+
             val lastSectionNormals = ArrayList<Vector3f>(shapeSize)
             for(shapeIndex in 0 until shapeSize) {
                 val sectionIndex = shapeIndex*2
@@ -481,7 +481,25 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
         fun orderNormals(verticesNormals: ArrayList<ArrayList<Vector3f>>): ArrayList<Vector3f> {
             //TODO allocate size
             val finalNormals = ArrayList<Vector3f>()
-            //TODO algorithm
+            verticesNormals.dropLast(1).forEachIndexed { shapeIndex, shape ->
+                shape.dropLast(1).forEachIndexed { vertexIndex, _ ->
+
+                    finalNormals.add(verticesNormals[shapeIndex][vertexIndex])
+                    finalNormals.add(verticesNormals[shapeIndex][vertexIndex + 1])
+                    finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex])
+
+                    finalNormals.add(verticesNormals[shapeIndex][vertexIndex + 1])
+                    finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex + 1])
+                    finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex])
+                }
+                finalNormals.add(verticesNormals[shapeIndex][0])
+                finalNormals.add(verticesNormals[shapeIndex + 1][0])
+                finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])
+
+                finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])
+                finalNormals.add(verticesNormals[shapeIndex][shape.lastIndex])
+                finalNormals.add(verticesNormals[shapeIndex][0])
+            }
             return finalNormals
         }
 

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -250,7 +250,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
          */
         fun calculateTriangles(curveGeometry: List<List<Vector3f>>, addCoverOrTop: Int = 2): Pair<ArrayList<Vector3f>, ArrayList<Vector3f>> {
             val verticesVectors = ArrayList<Vector3f>(curveGeometry.flatten().size * 6 + curveGeometry[0].size + 1)
-            val normalVectors = ArrayList<Vector3f>(verticesVectors.size)
+            val normalVectors = ArrayList<Vector3f>(verticesVectors.size/3)
             if (curveGeometry.isEmpty()) {
                 return Pair(verticesVectors, normalVectors)
             }
@@ -275,7 +275,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         //normal calculation triangle 1
                         val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
                             .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
-                        for(i in 1..3) { normalVectors.add(normal1) }
+                        normalVectors.add(normal1)
 
 
                         val triangle2Point1 = curveGeometry[shapeIndex][vertexIndex + 1]
@@ -288,7 +288,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         //normal calculation triangle 2
                         val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
                             .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
-                        for(i in 1..3) { normalVectors.add(normal2) }
+                        normalVectors.add(normal2)
                     }
 
                     val triangle1Point1 = curveGeometry[shapeIndex][shape.lastIndex]
@@ -301,7 +301,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     //normal calculation triangle 1
                     val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
                         .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
-                    for(i in 1..3) {  normalVectors.add(normal1) }
+                    normalVectors.add(normal1)
 
 
                     val triangle2Point1 = curveGeometry[shapeIndex][0]
@@ -314,7 +314,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     //normal calculation triangle 2
                     val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
                         .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
-                    for(i in 1..3) { normalVectors.add(normal2) }
+                    normalVectors.add(normal2)
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
@@ -335,7 +335,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
         private fun getCoverVertices(list: List<Vector3f>, ccw: Boolean): Pair<ArrayList<Vector3f>, ArrayList<Vector3f>> {
             val size = list.size
             val verticesList = ArrayList<Vector3f>(size + (size / 2))
-            val normalVectors = ArrayList<Vector3f>(verticesList.size)
+            val normalVectors = ArrayList<Vector3f>(verticesList.size/3)
 
             if (size >= 3) {
                 val workList = ArrayList<Vector3f>(size)
@@ -354,7 +354,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         //compute normal
                         val normal = ((Vector3f(triangle[2]).sub(Vector3f(triangle[0])))
                             .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize()
-                        for(i in 1..3) { normalVectors.add(normal) }
+                        normalVectors.add(normal)
                     } else {
                         for (i in 0..2) {
                             verticesList.add(triangle[i])
@@ -362,7 +362,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         //compute normal
                         val normal = ((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
                             .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize()
-                        for(i in 1..3) { normalVectors.add(normal) }
+                        normalVectors.add(normal)
                     }
                     newList.add(triangle[0])
                 }
@@ -396,9 +396,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 }
                 vertices.flip()
                 texcoords = BufferUtils.allocateFloat(verticesVectors.size * 2)
-                normals = BufferUtils.allocateFloat(normalVectors.size*3)
+                normals = BufferUtils.allocateFloat(normalVectors.size*3*3)
                 normalVectors.forEach {
-                    normals.put(it.toFloatArray())
+                    for(i in 1..3) { normals.put(it.toFloatArray()) }
                 }
                 normals.flip()
 

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -248,6 +248,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
          */
         fun calculateTriangles(curveGeometry: List<List<Vector3f>>, addCoverOrTop: Int = 2): ArrayList<Vector3f> {
             val verticesVectors = ArrayList<Vector3f>(curveGeometry.flatten().size * 6 + curveGeometry[0].size + 1)
+            val normalVectors = ArrayList<Vector3f>(verticesVectors.size/3)
             if (curveGeometry.isEmpty()) {
                 return verticesVectors
             }
@@ -259,22 +260,53 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 curveGeometry.dropLast(1).forEachIndexed { shapeIndex, shape ->
                     shape.dropLast(1).forEachIndexed { vertexIndex, _ ->
 
-                        verticesVectors.add(curveGeometry[shapeIndex][vertexIndex])
-                        verticesVectors.add(curveGeometry[shapeIndex][vertexIndex + 1])
-                        verticesVectors.add(curveGeometry[shapeIndex + 1][vertexIndex])
 
-                        verticesVectors.add(curveGeometry[shapeIndex][vertexIndex + 1])
-                        verticesVectors.add(curveGeometry[shapeIndex + 1][vertexIndex + 1])
-                        verticesVectors.add(curveGeometry[shapeIndex + 1][vertexIndex])
+                        val triangle1Point1 = curveGeometry[shapeIndex][vertexIndex]
+                        val triangle1Point2 = curveGeometry[shapeIndex][vertexIndex + 1]
+                        val triangle1Point3 = curveGeometry[shapeIndex + 1][vertexIndex]
+                        verticesVectors.add(triangle1Point1)
+                        verticesVectors.add(triangle1Point2)
+                        verticesVectors.add(triangle1Point3)
+
+                        //normal calculation triangle 1
+                        normalVectors.add(((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
+                            .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize())
+
+
+                        val triangle2Point1 = curveGeometry[shapeIndex][vertexIndex + 1]
+                        val triangle2Point2 = curveGeometry[shapeIndex + 1][vertexIndex + 1]
+                        val triangle2Point3 = curveGeometry[shapeIndex + 1][vertexIndex]
+                        verticesVectors.add(triangle2Point1)
+                        verticesVectors.add(triangle2Point2)
+                        verticesVectors.add(triangle2Point3)
+
+                        //normal calculation triangle 2
+                        normalVectors.add(((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
+                            .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize())
                     }
 
-                    verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
-                    verticesVectors.add(curveGeometry[shapeIndex][0])
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
+                    val triangle1Point1 = curveGeometry[shapeIndex][shape.lastIndex]
+                    val triangle1Point2 = curveGeometry[shapeIndex][0]
+                    val triangle1Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
+                    verticesVectors.add(triangle1Point1)
+                    verticesVectors.add(triangle1Point2)
+                    verticesVectors.add(triangle1Point3)
 
-                    verticesVectors.add(curveGeometry[shapeIndex][0])
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][0])
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
+                    //normal calculation triangle 1
+                    normalVectors.add(((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
+                        .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize())
+
+
+                    val triangle2Point1 = curveGeometry[shapeIndex][0]
+                    val triangle2Point2 = curveGeometry[shapeIndex + 1][0]
+                    val triangle2Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
+                    verticesVectors.add(triangle2Point1)
+                    verticesVectors.add(triangle2Point2)
+                    verticesVectors.add(triangle2Point3)
+
+                    //normal calculation triangle 2
+                    normalVectors.add(((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
+                        .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize())
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
@@ -299,7 +331,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 /* The algorithm must not stop before the last triangle. The next five lines ensure, therefore,
                    that the last triangle, which contains the last point as well as the first point, is included.
              */
-                when (size % 1) {
+                when (size) {
                     0 -> {  workList.add(list[0])
                         workList.add(list[1]) }
                     1 -> { workList.add(list[0]) }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -250,7 +250,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
          */
         fun calculateTriangles(curveGeometry: List<List<Vector3f>>, addCoverOrTop: Int = 2): Pair<ArrayList<Vector3f>, ArrayList<Vector3f>> {
             val verticesVectors = ArrayList<Vector3f>(curveGeometry.flatten().size * 6 + curveGeometry[0].size + 1)
-            val normalVectors = ArrayList<Vector3f>(verticesVectors.size/3)
+            val normalVectors = ArrayList<Vector3f>(verticesVectors.size)
             if (curveGeometry.isEmpty()) {
                 return Pair(verticesVectors, normalVectors)
             }
@@ -273,8 +273,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesVectors.add(triangle1Point3)
 
                         //normal calculation triangle 1
-                        normalVectors.add(((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
-                            .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize())
+                        val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
+                            .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
+                        for(i in 1..3) { normalVectors.add(normal1) }
 
 
                         val triangle2Point1 = curveGeometry[shapeIndex][vertexIndex + 1]
@@ -285,8 +286,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesVectors.add(triangle2Point3)
 
                         //normal calculation triangle 2
-                        normalVectors.add(((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
-                            .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize())
+                        val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
+                            .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
+                        for(i in 1..3) { normalVectors.add(normal2) }
                     }
 
                     val triangle1Point1 = curveGeometry[shapeIndex][shape.lastIndex]
@@ -297,8 +299,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     verticesVectors.add(triangle1Point3)
 
                     //normal calculation triangle 1
-                    normalVectors.add(((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
-                        .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize())
+                    val normal1 = ((Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1)))
+                        .cross(Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))).normalize()
+                    for(i in 1..3) {  normalVectors.add(normal1) }
 
 
                     val triangle2Point1 = curveGeometry[shapeIndex][0]
@@ -309,8 +312,9 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     verticesVectors.add(triangle2Point3)
 
                     //normal calculation triangle 2
-                    normalVectors.add(((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
-                        .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize())
+                    val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
+                        .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
+                    normalVectors.add(normal2)
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
@@ -331,7 +335,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
         private fun getCoverVertices(list: List<Vector3f>, ccw: Boolean): Pair<ArrayList<Vector3f>, ArrayList<Vector3f>> {
             val size = list.size
             val verticesList = ArrayList<Vector3f>(size + (size / 2))
-            val normalVectors = ArrayList<Vector3f>(verticesList.size/3)
+            val normalVectors = ArrayList<Vector3f>(verticesList.size)
 
             if (size >= 3) {
                 val workList = ArrayList<Vector3f>(size)
@@ -348,15 +352,17 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesList.add(triangle[1])
 
                         //compute normal
-                        normalVectors.add(((Vector3f(triangle[2]).sub(Vector3f(triangle[0])))
-                            .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize())
+                        val normal = ((Vector3f(triangle[2]).sub(Vector3f(triangle[0])))
+                            .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize()
+                        for(i in 1..3) { normalVectors.add(normal) }
                     } else {
                         for (i in 0..2) {
                             verticesList.add(triangle[i])
                         }
                         //compute normal
-                        normalVectors.add(((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
-                            .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize())
+                        val normal = ((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
+                            .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize()
+                        normalVectors.add(normal)
                     }
                     newList.add(triangle[0])
                 }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -496,13 +496,34 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex + 1])
                     finalNormals.add(verticesNormals[shapeIndex + 1][vertexIndex])
                 }
+
+                /*
+                val triangle1Point1 = curveGeometry[shapeIndex][shape.lastIndex]
+                    val triangle1Point2 = curveGeometry[shapeIndex][0]
+                    val triangle1Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
+                    verticesVectors.add(triangle1Point1)
+                    verticesVectors.add(triangle1Point2)
+                    verticesVectors.add(triangle1Point3)
+
+                    //normal calculation triangle 1
+                    val normal1 = ((Vector3f(triangle1Point3).sub(Vector3f(triangle1Point1)))
+                        .cross(Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1))))
+                    intermediateNormalSection.add(normal1)
+
+                    val triangle2Point1 = curveGeometry[shapeIndex][0]
+                    val triangle2Point2 = curveGeometry[shapeIndex + 1][0]
+                    val triangle2Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
+                    verticesVectors.add(triangle2Point1)
+                    verticesVectors.add(triangle2Point2)
+                    verticesVectors.add(triangle2Point3)
+                 */
+                finalNormals.add(verticesNormals[shapeIndex][shape.lastIndex])
+                finalNormals.add(verticesNormals[shapeIndex][0])
+                finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])
+
                 finalNormals.add(verticesNormals[shapeIndex][0])
                 finalNormals.add(verticesNormals[shapeIndex + 1][0])
                 finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])
-
-                finalNormals.add(verticesNormals[shapeIndex + 1][shape.lastIndex])
-                finalNormals.add(verticesNormals[shapeIndex][shape.lastIndex])
-                finalNormals.add(verticesNormals[shapeIndex][0])
             }
             return finalNormals
         }

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -267,28 +267,14 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         verticesVectors.add(curveGeometry[shapeIndex + 1][vertexIndex + 1])
                         verticesVectors.add(curveGeometry[shapeIndex + 1][vertexIndex])
                     }
+
+                    verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
+                    verticesVectors.add(curveGeometry[shapeIndex][0])
+                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
+
                     verticesVectors.add(curveGeometry[shapeIndex][0])
                     verticesVectors.add(curveGeometry[shapeIndex + 1][0])
                     verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
-
-
-                    /*
-                    Testing, delete following three lines afterwards
-                     */
-                    verticesVectors.add(curveGeometry[shapeIndex][0])
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][0])
-
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
-                    verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
-                    verticesVectors.add(curveGeometry[shapeIndex][0])
-
-                    /*
-                    Testing, delete following three lines afterwards
-                     */
-                    verticesVectors.add(curveGeometry[shapeIndex + 1][shape.lastIndex])
-                    verticesVectors.add(curveGeometry[shapeIndex][0])
-                    verticesVectors.add(curveGeometry[shapeIndex][shape.lastIndex])
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -308,8 +308,8 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         .cross(Vector3f(triangle1Point2).sub(Vector3f(triangle1Point1))))
                     intermediateNormalSection.add(normal1)
 
-                    val triangle2Point1 = curveGeometry[shapeIndex + 1][0]
-                    val triangle2Point2 = curveGeometry[shapeIndex][0]
+                    val triangle2Point1 = curveGeometry[shapeIndex][0]
+                    val triangle2Point2 = curveGeometry[shapeIndex + 1][0]
                     val triangle2Point3 = curveGeometry[shapeIndex + 1][shape.lastIndex]
                     verticesVectors.add(triangle2Point1)
                     verticesVectors.add(triangle2Point2)
@@ -430,6 +430,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     val vertexNormal = Vector3f()
                     when(shapeIndex) {
                         0-> {
+                            //ToDO the bug seems to be here
                             vertexNormal.add(section[1].first())
                             vertexNormal.add(section[1].last())
                             vertexNormal.add(section[1].drop(1).last())

--- a/src/main/kotlin/graphics/scenery/geometry/Curve.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/Curve.kt
@@ -314,7 +314,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                     //normal calculation triangle 2
                     val normal2 = ((Vector3f(triangle2Point2).sub(Vector3f(triangle2Point1)))
                         .cross(Vector3f(triangle2Point3).sub(Vector3f(triangle2Point1)))).normalize()
-                    normalVectors.add(normal2)
+                    for(i in 1..3) { normalVectors.add(normal2) }
                 }
             } else {
                 throw IllegalArgumentException("The baseShapes must not differ in size!")
@@ -324,6 +324,8 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                 verticesVectors.addAll(newVerticesAndNormals.first)
                 normalVectors.addAll(newVerticesAndNormals.second)
             }
+            println(normalVectors.size)
+            println(verticesVectors.size)
             return Pair(verticesVectors, normalVectors)
         }
 
@@ -362,17 +364,22 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
                         //compute normal
                         val normal = ((Vector3f(triangle[0]).sub(Vector3f(triangle[2])))
                             .cross(Vector3f(triangle[1]).sub(Vector3f(triangle[0])))).normalize()
-                        normalVectors.add(normal)
+                        for(i in 1..3) { normalVectors.add(normal) }
                     }
                     newList.add(triangle[0])
                 }
-                //to avoid gaps when the vertex number is odd
-                if(size%2==1) { newList.add(list.last()) }
 
-                val newVerticesAndNormals = getCoverVertices(newList, ccw)
-                verticesList.addAll(newVerticesAndNormals.first)
-                normalVectors.addAll(newVerticesAndNormals.second)
+                //check if the recursion has come to an end
+                if(newList.size >= 3) {
+                    //to avoid gaps when the vertex number is odd
+                    if (size % 2 == 1) {
+                        newList.add(list.last())
+                    }
 
+                    val newVerticesAndNormals = getCoverVertices(newList, ccw)
+                    verticesList.addAll(newVerticesAndNormals.first)
+                    normalVectors.addAll(newVerticesAndNormals.second)
+                }
             }
             return Pair(verticesList, normalVectors)
         }
@@ -384,6 +391,7 @@ class Curve(spline: Spline, partitionAlongControlpoints: Boolean = true, private
      */
     class PartialCurve(verticesVectors: ArrayList<Vector3f>, normalVectors: ArrayList<Vector3f>) : Mesh("PartialCurve") {
         init {
+            if(verticesVectors.size != verticesVectors.size) { println(" NOT right size for vertices/normals") }
             geometry {
                 vertices = BufferUtils.allocateFloat(verticesVectors.size * 3)
                 verticesVectors.forEach {

--- a/src/main/kotlin/graphics/scenery/proteins/Helix.kt
+++ b/src/main/kotlin/graphics/scenery/proteins/Helix.kt
@@ -105,6 +105,6 @@ class Helix (private val axis: MathLine, val spline: Spline, baseShape: () -> Li
     private fun calcMesh(section: List<List<Vector3f>>, i: Int): Mesh {
         //algorithms from the curve class, see Curve (line 219-322)
         val helixSectionVertices = Curve.calculateTriangles(section, i)
-        return Curve.PartialCurve(helixSectionVertices)
+        return Curve.PartialCurve(helixSectionVertices.first, helixSectionVertices.second)
     }
 }


### PR DESCRIPTION
The cover calculation for the curve class was erroneous, leaving the empty tubes open for the user to see. The error was tracked down to a confusion of `last()` with `first()` and will be fixed by this pull request.
Moreover, the calculation of the Curves was delegated to `recalculateNormals()`. From this pull request onwards, the calculation will happen in the `Curve` class itself.