### PR TITLE
Disable OpenCL-related examples and tests on Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,8 +48,8 @@ unit-tests-no-gpu:
     - echo -e "\e[0Ksection_end:`date +%s`:build_section\r\e[0K"
     # basic group
     - echo -e "\e[0Ksection_start:`date +%s`:basic_section[collapsed=true]\r\e[0KBasic Test Group"
-    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml -Dscenery.RandomSeed=13371842
-    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml -Dscenery.RandomSeed=13371842
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShading.yml -Dscenery.RandomSeed=13371842 -Dscenery.ExampleRunner.Blocklist=EdgeBundlerExample
+    - ./gradlew test jacocoTestReport --build-cache --full-stacktrace -Pgpu=true -Dscenery.ExampleRunner.TestGroup=basic -Dscenery.ExampleRunner.Configurations=DeferredShadingStereo.yml -Dscenery.RandomSeed=13371842 -Dscenery.ExampleRunner.Blocklist=EdgeBundlerExample
     - echo -e "\e[0Ksection_end:`date +%s`:basic_section\r\e[0K"
     # advanced group
     - echo -e "\e[0Ksection_start:`date +%s`:advanced_section[collapsed=true]\r\e[0KAdvanced Test Group"

--- a/src/main/kotlin/graphics/scenery/compute/OpenCLContext.kt
+++ b/src/main/kotlin/graphics/scenery/compute/OpenCLContext.kt
@@ -30,6 +30,10 @@ class OpenCLContext(override var hub: Hub?, devicePreference: String = System.ge
     var queue: cl_command_queue
 
     init {
+        if(System.getenv("GITLAB_CI").toBoolean()) {
+            throw UnsupportedOperationException("OpenCL disabled on Gitlab CI due to Nvidia Docker issue.")
+        }
+
         hub?.add(SceneryElement.OpenCLContext, this)
 
         val platformPref = devicePreference.substringBefore(",").toInt()

--- a/src/main/kotlin/graphics/scenery/fonts/SDFFontAtlas.kt
+++ b/src/main/kotlin/graphics/scenery/fonts/SDFFontAtlas.kt
@@ -73,8 +73,7 @@ open class SDFFontAtlas(var hub: Hub, val fontName: String, val distanceFieldSiz
         } catch (e: Exception) {
             logger.debug("Cached atlas not found or not readable (because $e), creating anew, could take a little moment ...")
 
-            var ocl: OpenCLContext?
-            ocl = try {
+            val ocl: OpenCLContext? = try {
                 OpenCLContext(hub)
             } catch (e: UnsatisfiedLinkError) {
                 logger.warn("Failed to initialised OpenCL libraries: $e")

--- a/src/test/kotlin/graphics/scenery/tests/unit/fonts/SDFFontAtlasTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/fonts/SDFFontAtlasTests.kt
@@ -23,8 +23,10 @@ class SDFFontAtlasTests {
         val logger by LazyLogger()
         @JvmStatic @BeforeClass
         fun checkOpenCLAvailability() {
-            val hasOpenCL: Boolean = if (System.getenv("GITHUB_ACTIONS").toBoolean() && Platform.get() == Platform.MACOSX) {
-                logger.warn("Disabled OpenCL because Github Actions on macOS does not support accelerated OpenCL contexts.")
+            val openCLunavailable = ((System.getenv("GITHUB_ACTIONS").toBoolean() && Platform.get() == Platform.MACOSX)
+                    || System.getenv("GITLAB_CI").toBoolean())
+            val hasOpenCL: Boolean = if (openCLunavailable) {
+                logger.warn("Disabled OpenCL because Github Actions on macOS does not support accelerated OpenCL contexts, or because running on Gitlab CI Docker.")
                 false
             } else {
                 try {


### PR DESCRIPTION
This PR skips OpenCL-related examples and tests on Docker due to a bug in Nvidia's Docker engine.