### PR TITLE
Improvement of startup times and memory optimisation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     scenery.publish
     scenery.sign
     id("com.github.elect86.sciJava") version "0.0.4"
-    id("org.sonarqube") version "3.3"
     jacoco
     id("com.github.johnrengelman.shadow") version "7.1.0"
 }
@@ -69,7 +68,7 @@ dependencies {
                 // Vulkan binaries are only necessary on macOS
                 p.endsWith("vulkan") -> {
                     if(native.contains("macos")) {
-                        println("vulkan: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
+                        // println("vulkan: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                         runtimeOnly("org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                     }
                 }
@@ -78,13 +77,13 @@ dependencies {
                 // apart from macOS/ARM64
                 p.endsWith("openvr") -> {
                     if(!(native.contains("macos") && native.contains("arm64"))) {
-                        println("openvr: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
+                        // println("openvr: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                         runtimeOnly("org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                     }
                 }
 
                 else -> {
-                    println("else: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
+                    // println("else: org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                     runtimeOnly("org.lwjgl:lwjgl$p:$lwjglVersion:$native")
                 }
             }
@@ -329,7 +328,7 @@ tasks {
                         "\${$propertyName}")
 
                     // Custom per artifact tweaks
-                    println(artifactId)
+                    // println(artifactId)
                     if("\\-bom".toRegex().find(artifactId) != null) {
                         node.appendNode("type", "pom")
                     }
@@ -410,15 +409,6 @@ jacoco {
 }
 
 java.withSourcesJar()
-
-sonarqube {
-    properties {
-        property("sonar.projectKey", "scenerygraphics_scenery")
-        property("sonar.organization", "scenerygraphics-1")
-        property("sonar.host.url", "https://sonarcloud.io")
-        property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/fullCodeCoverageReport/fullCodeCoverageReport.xml")
-    }
-}
 
 plugins.withType<JacocoPlugin>() {
     tasks["test"].finalizedBy("jacocoTestReport")

--- a/src/main/kotlin/graphics/scenery/DefaultNode.kt
+++ b/src/main/kotlin/graphics/scenery/DefaultNode.kt
@@ -2,7 +2,7 @@ package graphics.scenery
 
 import graphics.scenery.attribute.DefaultAttributesMap
 import graphics.scenery.net.Networkable
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
@@ -50,7 +50,7 @@ open class DefaultNode(name: String = "Node") : Node, Networkable {
 
     override var nodeType = "Node"
     override var boundingBox: OrientedBoundingBox? = null
-    override val logger by LazyLogger()
+    override val logger by lazyLogger()
 
     @Transient private val attributes = DefaultAttributesMap()
 

--- a/src/main/kotlin/graphics/scenery/Hub.kt
+++ b/src/main/kotlin/graphics/scenery/Hub.kt
@@ -8,7 +8,7 @@ import graphics.scenery.controls.TrackerInput
 import graphics.scenery.net.NodePublisher
 import graphics.scenery.net.NodeSubscriber
 import graphics.scenery.repl.REPL
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.Statistics
 import java.util.concurrent.ConcurrentHashMap
 
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class Hub(val name: String = "default") {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     /** Hash map storage for all the [SceneryElement] and their instances */
     val elements: ConcurrentHashMap<SceneryElement, Any> = ConcurrentHashMap()
 

--- a/src/main/kotlin/graphics/scenery/Mesh.kt
+++ b/src/main/kotlin/graphics/scenery/Mesh.kt
@@ -12,7 +12,7 @@ import graphics.scenery.geometry.GeometryType
 import graphics.scenery.primitives.PointCloud
 import graphics.scenery.textures.Texture
 import graphics.scenery.utils.Image
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.times
@@ -79,7 +79,7 @@ open class Mesh(override var name: String = "Mesh") : DefaultNode(name), HasRend
      * @return A HashMap storing material name and [Material].
      */
     fun readFromMTL(filename: String): HashMap<String, Material> {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         val materials = HashMap<String, Material>()
 
@@ -223,7 +223,7 @@ open class Mesh(override var name: String = "Mesh") : DefaultNode(name), HasRend
      * @param[flipNormals] Whether to flip the normals after reading them.
      */
     fun readFromOBJ(filename: String, importMaterials: Boolean = true, flipNormals: Boolean = false, useObjGroups: Boolean = true): Mesh {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         var name = ""
 
@@ -659,7 +659,7 @@ open class Mesh(override var name: String = "Mesh") : DefaultNode(name), HasRend
      * @param[filename] The filename to read from.
      */
     fun readFromSTL(filename: String): Mesh {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         var name = ""
         val vbuffer = ArrayList<Float>()

--- a/src/main/kotlin/graphics/scenery/Node.kt
+++ b/src/main/kotlin/graphics/scenery/Node.kt
@@ -8,13 +8,12 @@ import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.attribute.spatial.Spatial
 import graphics.scenery.net.Networkable
 import graphics.scenery.utils.MaybeIntersects
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import net.imglib2.Localizable
 import net.imglib2.RealLocalizable
 import org.joml.Matrix4f
 import org.joml.Quaternionf
 import org.joml.Vector3f
+import org.slf4j.Logger
 import java.nio.FloatBuffer
 import java.nio.IntBuffer
 import java.util.*
@@ -51,7 +50,7 @@ interface Node : Networkable {
     /** Initialisation function for the object */
     fun init(): Boolean
 
-    val logger: org.slf4j.Logger
+    val logger: Logger
 
     /** bounding box **/
     var boundingBox: OrientedBoundingBox?
@@ -214,7 +213,8 @@ interface Node : Networkable {
      */
     fun getShaderProperty(name: String): Any?
 
-    companion object NodeHelpers {
+    companion object {
+
         /**
          * Depth-first search for elements in a Scene.
          *

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -76,7 +76,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     protected var registerNewRenderer: NewRendererParameters? = null
 
     /** Logger for this application, will be instantiated upon first use. */
-    protected val logger by LazyLogger(System.getProperty("scenery.LogLevel", "info"))
+    protected val logger by lazyLogger(System.getProperty("scenery.LogLevel", "info"))
 
     /** An optional update function to call during the main loop. */
     var updateFunction: (() -> Any)? = null
@@ -526,7 +526,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     }
 
     companion object {
-        private val logger by LazyLogger(System.getProperty("scenery.LogLevel", "info"))
+        private val logger by lazyLogger(System.getProperty("scenery.LogLevel", "info"))
         private var xinitThreadsCalled: Boolean = false
 
         /**

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -28,6 +28,7 @@ import java.nio.file.Paths
 import java.util.*
 import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.nanoseconds
 
 /**
  * Base class to use scenery with, keeping the needed boilerplate
@@ -163,30 +164,12 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
 
         loadInputHandler(renderer)
 
-        // start & show REPL -- note: REPL will only exist if not running in headless mode
-        repl?.start()
-        thread {
-            val r = renderer ?: return@thread
-
-            while(!r.firstImageReady) {
-                Thread.sleep(100)
-            }
-
-            val isClient = !server && serverAddress != null
-            if (!headless && !isClient) {
-                logger.debug("Client: $isClient, showing REPL window")
-                repl?.showConsoleWindow()
-            }
-        }
-
         val statsRequested = parseBoolean(System.getProperty("scenery.PrintStatistics", "false"))
 
         // setup additional key bindings, if requested by the user
         inputSetup()
 
         val startTime = System.nanoTime()
-
-
 
         var frameTime = 0.0f
         var lastFrameTime: Float
@@ -393,10 +376,20 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
      */
     fun loadInputHandler(renderer: Renderer?) {
         renderer?.let {
-            repl?.addAccessibleObject(it)
-
             inputHandler = InputHandler(scene, it, hub)
             inputHandler?.useDefaultBindings(System.getProperty("user.home") + "/.$applicationName.bindings")
+
+            if(wantREPL) {
+                inputHandler?.addBehaviour("show_repl", ClickBehaviour { _, _ ->
+                    repl = REPL(hub, scijavaContext, scene, stats, hub)
+                    repl?.addAccessibleObject(settings)
+                    repl?.addAccessibleObject(inputHandler!!)
+                    repl?.addAccessibleObject(it)
+                    repl?.showConsoleWindow()
+                })
+
+                inputHandler?.addKeyBinding("show_repl", "shift R")
+            }
         }
     }
 
@@ -437,6 +430,16 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
     }
 
     open fun main() {
+        thread {
+            val start = System.nanoTime()
+            while(renderer?.firstImageReady != true) {
+                Thread.sleep(5)
+            }
+
+            val duration = (System.nanoTime() - start).nanoseconds
+            logger.info("Full startup took ${duration.inWholeMilliseconds}ms")
+        }
+
         System.getProperties().forEach { prop ->
             val name = prop.key as? String ?: return@forEach
             val value = prop.value as? String ?: return@forEach
@@ -477,11 +480,6 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
         hub.add(SceneryElement.Settings, settings)
 
         settings.set("System.PID", getProcessID())
-
-        if (wantREPL) {
-            repl = REPL(hub, scijavaContext, scene, stats, hub)
-            repl?.addAccessibleObject(settings)
-        }
 
         // initialize renderer, etc first in init, then setup key bindings
         init()

--- a/src/main/kotlin/graphics/scenery/Settings.kt
+++ b/src/main/kotlin/graphics/scenery/Settings.kt
@@ -1,6 +1,6 @@
 package graphics.scenery
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class Settings(override var hub: Hub? = null) : Hubable {
     private var settingsStore = ConcurrentHashMap<String, Any>()
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         val properties = System.getProperties()

--- a/src/main/kotlin/graphics/scenery/VolumeMeasurer.kt
+++ b/src/main/kotlin/graphics/scenery/VolumeMeasurer.kt
@@ -1,7 +1,7 @@
 package graphics.scenery
 
 import graphics.scenery.geometry.GeometryType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import kotlin.math.absoluteValue
 
 /**
@@ -11,7 +11,7 @@ import kotlin.math.absoluteValue
  * @author  Justin Buerger <burger@mpi-cbg.de>
  */
 class VolumeMeasurer {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * calculates the volume of a given [mesh] and returns its volume with double precision

--- a/src/main/kotlin/graphics/scenery/attribute/geometry/DefaultGeometry.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/geometry/DefaultGeometry.kt
@@ -4,7 +4,7 @@ import graphics.scenery.BufferUtils
 import graphics.scenery.Node
 import graphics.scenery.OrientedBoundingBox
 import graphics.scenery.geometry.GeometryType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import java.nio.FloatBuffer
 import java.nio.IntBuffer
@@ -18,7 +18,7 @@ open class DefaultGeometry(private var node: Node): Geometry {
     override var texcoordSize = 2
     override var dirty: Boolean = true
     override var geometryType = GeometryType.TRIANGLES
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     override fun generateBoundingBox(children: List<Node>): OrientedBoundingBox? {
         val vertexBufferView = vertices.asReadOnlyBuffer()
         val boundingBoxCoords = floatArrayOf(0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f)

--- a/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
@@ -4,7 +4,7 @@ import graphics.scenery.DefaultNode
 import graphics.scenery.Node
 import graphics.scenery.Scene
 import graphics.scenery.net.Networkable
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.MaybeIntersects
 import graphics.scenery.utils.extensions.*
 import net.imglib2.Localizable
@@ -57,7 +57,7 @@ open class DefaultSpatial(@Transient protected var node: Node = DefaultNode()) :
 
     override var modifiedAt = 0L
 
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     @Suppress("UNUSED_PARAMETER")
     override fun <R> propertyChanged(property: KProperty<*>, old: R, new: R, custom: String) {

--- a/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
+++ b/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import graphics.scenery.Blending
 import graphics.scenery.utils.JsonDeserialisers
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector4f
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -37,7 +37,7 @@ fun RenderConfigReader.RenderConfig.getInputsOfTarget(targetName: String): Set<S
  * it as a [List] of Strings.
  */
 fun RenderConfigReader.RenderConfig.createRenderpassFlow(): List<String> {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
     val passes = renderpasses
     val dag = ArrayList<String>()
 

--- a/src/main/kotlin/graphics/scenery/backends/Renderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/Renderer.kt
@@ -6,7 +6,7 @@ import graphics.scenery.backends.opengl.OpenGLRenderer
 import graphics.scenery.backends.vulkan.VulkanRenderer
 import graphics.scenery.textures.Texture
 import graphics.scenery.utils.ExtractsNatives
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SceneryPanel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
@@ -123,7 +123,7 @@ abstract class Renderer : Hubable {
      */
     @Suppress("UNUSED")
     fun toggleVR() {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
         logger.info("Toggling VR!")
         val isStereo = renderConfigFile.substringBeforeLast(".").indexOf("Stereo") != -1
 
@@ -226,7 +226,7 @@ abstract class Renderer : Hubable {
      * Factory methods for creating renderers.
      */
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         /**
          * Creates a new [Renderer] instance, based on what is available on the current platform, or set via

--- a/src/main/kotlin/graphics/scenery/backends/ShaderCompiler.kt
+++ b/src/main/kotlin/graphics/scenery/backends/ShaderCompiler.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.util.shaderc.Shaderc
 import picocli.CommandLine
 import java.io.File
@@ -13,7 +13,7 @@ import kotlin.system.exitProcess
  */
 @CommandLine.Command(name = "CompileShader", mixinStandardHelpOptions = true, description = ["Compiles GLSL shader code to SPIRV bytecode."])
 class ShaderCompiler: AutoCloseable, Callable<ByteArray> {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     protected val compiler = Shaderc.shaderc_compiler_initialize()
 

--- a/src/main/kotlin/graphics/scenery/backends/ShaderIntrospection.kt
+++ b/src/main/kotlin/graphics/scenery/backends/ShaderIntrospection.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.backends
 
 import graphics.scenery.backends.vulkan.toHexString
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3i
 import org.lwjgl.system.MemoryStack.stackPush
 import org.lwjgl.system.MemoryUtil
@@ -23,7 +23,7 @@ class ShaderIntrospection(
     val vulkanSemantics: Boolean = true,
     val version: Int = 450
 ): AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     protected val resources: Long
     protected val compiler: Long

--- a/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
+++ b/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers.Companion.toIntArray
 import org.lwjgl.system.MemoryUtil
 import java.nio.IntBuffer
@@ -21,7 +21,7 @@ data class ShaderPackage(val baseClass: Class<*>,
                          val spirv: ByteArray?,
                          val code: String?,
                          var priority: SourceSPIRVPriority) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         val sourceNewer = if(code != null) {

--- a/src/main/kotlin/graphics/scenery/backends/Shaders.kt
+++ b/src/main/kotlin/graphics/scenery/backends/Shaders.kt
@@ -1,7 +1,6 @@
 package graphics.scenery.backends
 
-import graphics.scenery.utils.LazyLogger
-import org.lwjgl.util.shaderc.Shaderc
+import graphics.scenery.utils.lazyLogger
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -10,7 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 sealed class Shaders() {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
     var stale: Boolean = false
     val type: HashSet<ShaderType> = hashSetOf()
 

--- a/src/main/kotlin/graphics/scenery/backends/UBO.kt
+++ b/src/main/kotlin/graphics/scenery/backends/UBO.kt
@@ -3,7 +3,7 @@ package graphics.scenery.backends
 import cleargl.GLMatrix
 import cleargl.GLVector
 import gnu.trove.map.hash.TIntObjectHashMap
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.*
 import org.lwjgl.system.MemoryUtil
 import java.nio.ByteBuffer
@@ -24,7 +24,7 @@ open class UBO {
 
     protected var members = LinkedHashMap<String, () -> Any>()
     protected var memberOffsets = HashMap<String, Int>()
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     /** Hash value of all the members, gets updated by [populate()] */
     var hash: Int = 0

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLObjectState.kt
@@ -2,7 +2,7 @@ package graphics.scenery.backends.opengl
 
 import cleargl.GLTexture
 import graphics.scenery.NodeMetadata
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import java.nio.ByteBuffer
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -16,7 +16,7 @@ import kotlin.collections.HashSet
  *  default consumers.
  */
 class OpenGLObjectState : NodeMetadata {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     /** List of consumers of this metadata, e.g. [OpenGLRenderer] */
     override val consumers: MutableList<String> = ArrayList()
 

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderer.kt
@@ -87,7 +87,7 @@ open class OpenGLRenderer(hub: Hub,
                           final override var embedIn: SceneryPanel? = null,
                           var embedInDrawable: GLAutoDrawable? = null) : Renderer(), Hubable, ClearGLEventListener {
     /** slf4j logger */
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val className = this.javaClass.simpleName
     /** [GL4] instance handed over, coming from [ClearGLDefaultEventListener]*/
     private lateinit var gl: GL4

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLRenderpass.kt
@@ -4,7 +4,7 @@ import cleargl.GLFramebuffer
 import org.joml.Vector3f
 import graphics.scenery.Settings
 import graphics.scenery.backends.RenderConfigReader
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.StickyBoolean
 import org.joml.Vector2f
 import org.joml.Vector4f
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class OpenGLRenderpass(var passName: String = "", var passConfig: RenderConfigReader.RenderpassConfig) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /** OpenGL metadata */
     var openglMetadata: OpenGLMetadata = OpenGLMetadata()

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderModule.kt
@@ -6,7 +6,7 @@ import com.jogamp.opengl.GL4
 import graphics.scenery.backends.ShaderIntrospection
 import graphics.scenery.backends.ShaderPackage
 import graphics.scenery.backends.ShaderType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import java.util.concurrent.ConcurrentHashMap
 
 
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @author Ulrik Günther <hello@ulrik.is>
  */
 open class OpenGLShaderModule(gl: GL4, entryPoint: String, sp: ShaderPackage) {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     var shader: GLShader
         private set

--- a/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderProgram.kt
+++ b/src/main/kotlin/graphics/scenery/backends/opengl/OpenGLShaderProgram.kt
@@ -8,7 +8,7 @@ import com.jogamp.opengl.GL4
 import gnu.trove.map.hash.THashMap
 import graphics.scenery.backends.ShaderIntrospection
 import graphics.scenery.backends.ShaderType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 
 /**
  * Class to handle OpenGL shader programs, for a context [gl], consisting of [OpenGLShaderModule] [modules].
@@ -16,7 +16,7 @@ import graphics.scenery.utils.LazyLogger
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 open class OpenGLShaderProgram(var gl: GL4, val modules: HashMap<ShaderType, OpenGLShaderModule>) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /** The ClearGL program object */
     var program: GLProgram

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VU.kt
@@ -1,8 +1,7 @@
 package graphics.scenery.backends.vulkan
 
 import graphics.scenery.Blending
-import graphics.scenery.backends.RenderConfigReader
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.PointerBuffer
 import org.lwjgl.system.MemoryStack.stackPush
 import org.lwjgl.system.MemoryUtil.*
@@ -181,7 +180,7 @@ class VU {
      * Companion object for [VU] to access methods statically.
      */
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         /**
          * Runs a lambda [function] containing a Vulkan call, and checks it for errors. Allowed error codes

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBuffer.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends.vulkan
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.PointerBuffer
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.system.MemoryUtil.*
@@ -23,7 +23,7 @@ import kotlin.math.roundToInt
 open class VulkanBuffer(val device: VulkanDevice, var size: Long,
                    val usage: Int, val requestedMemoryProperties: Int = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                    val wantAligned: Boolean = true, var suballocation: VulkanSuballocation? = null): AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private var currentPosition = 0L
     private var currentPointer: PointerBuffer? = null
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBufferAllocation.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBufferAllocation.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends.vulkan
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 
 typealias VulkanBufferUsage = Int
 /**
@@ -29,7 +29,7 @@ class VulkanBufferAllocation(val usage: VulkanBufferUsage,
                              val buffer: VulkanBuffer,
                              val alignment: Int,
                              private val suballocations: ArrayList<VulkanSuballocation> = ArrayList<VulkanSuballocation>()) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Adds a new [suballocation].

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBufferPool.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanBufferPool.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends.vulkan
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.vulkan.VK10
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -20,7 +20,7 @@ class VulkanBufferPool(
     val properties: Int = VK10.VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
 ) {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     protected val backingStore = CopyOnWriteArrayList<VulkanBufferAllocation>()
 
     /**

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanCommandBuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanCommandBuffer.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends.vulkan
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil.*
 import org.lwjgl.vulkan.*
 import org.lwjgl.vulkan.VK10.*
@@ -14,7 +14,7 @@ import java.nio.LongBuffer
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class VulkanCommandBuffer(val device: VulkanDevice, var commandBuffer: VkCommandBuffer?, val fenced: Boolean = true): AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     /** Whether this command buffer is stale and needs to be re-recorded. */
     var stale: Boolean = true
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanComputePass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanComputePass.kt
@@ -4,7 +4,7 @@ import graphics.scenery.geometry.GeometryType
 import graphics.scenery.Node
 import graphics.scenery.backends.vulkan.VulkanPostprocessPass.setRequiredDescriptorSetsPostprocess
 import graphics.scenery.compute.ComputeMetadata
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3i
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.vulkan.KHRSwapchain
@@ -16,7 +16,7 @@ import org.lwjgl.vulkan.VK10
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 object VulkanComputePass {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * Records a new compute render [pass] into the [commandBuffer] given. Eventual further buffers

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.backends.vulkan
 
 import graphics.scenery.backends.vulkan.VulkanDevice.DescriptorPool.Companion.maxSets
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryStack.stackPush
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.system.MemoryUtil.memUTF8
@@ -31,7 +31,7 @@ open class VulkanDevice(
     val debugEnabled: Boolean = false
 ) {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     /** Stores available memory types on the device. */
     val memoryProperties: VkPhysicalDeviceMemoryProperties
     /** Stores the Vulkan-internal device. */
@@ -768,7 +768,7 @@ open class VulkanDevice(
      * Utility functions for [VulkanDevice].
      */
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         /**
          * Data class for defining device/driver-specific workarounds.

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.backends.vulkan
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil.*
 import org.lwjgl.system.Struct
 import org.lwjgl.vulkan.*
@@ -25,7 +25,7 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
                              var height: Int,
                              val commandBuffer: VkCommandBuffer,
                              var shouldClear: Boolean = true, val sRGB: Boolean = false): AutoCloseable {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     /** Raw Vulkan framebuffer reference. */
     var framebuffer = memAllocLong(1)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
@@ -6,7 +6,7 @@ import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.textures.Texture
 import graphics.scenery.textures.UpdatableTexture
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.jemalloc.JEmalloc
 import org.lwjgl.vulkan.VK10
 import org.lwjgl.vulkan.VkBufferCopy
@@ -26,7 +26,7 @@ import kotlin.reflect.full.memberProperties
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 object VulkanNodeHelpers {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * Creates vertex buffers for a given [node] on [device].

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -7,7 +7,7 @@ import graphics.scenery.NodeMetadata
 import graphics.scenery.backends.RenderConfigReader
 import graphics.scenery.backends.RendererFlags
 import graphics.scenery.attribute.renderable.Renderable
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.DurationUnit
@@ -20,7 +20,7 @@ import kotlin.time.measureTime
  * @author Ulrik Günther <hello@ulrik.is>
  */
 open class VulkanObjectState : NodeMetadata {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     /** Consumers for this metadata object. */
     override val consumers: MutableList<String> = ArrayList(setOf("VulkanRenderer"))
@@ -241,7 +241,7 @@ open class VulkanObjectState : NodeMetadata {
      * Utility class for [VulkanObjectState].
      */
     companion object {
-        protected val logger by LazyLogger()
+        protected val logger by lazyLogger()
 
         protected val cache = HashMap<TextureKey, Long>()
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPipeline.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPipeline.kt
@@ -3,7 +3,7 @@ package graphics.scenery.backends.vulkan
 import graphics.scenery.backends.ShaderConsistencyException
 import graphics.scenery.backends.ShaderIntrospection
 import graphics.scenery.geometry.GeometryType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil.*
 import org.lwjgl.vulkan.*
 import org.lwjgl.vulkan.VK10.*
@@ -15,7 +15,7 @@ import java.nio.IntBuffer
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class VulkanPipeline(val device: VulkanDevice, val renderpass: VulkanRenderpass, val vulkanRenderpass: Long, val pipelineCache: Long? = null): AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     var type: PipelineType = PipelineType.Graphics
 
     enum class PipelineType { Graphics, Compute }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPostprocessPass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanPostprocessPass.kt
@@ -3,7 +3,7 @@ package graphics.scenery.backends.vulkan
 import graphics.scenery.geometry.GeometryType
 import graphics.scenery.Node
 import graphics.scenery.backends.vulkan.VulkanNodeHelpers.rendererMetadata
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil
 import org.lwjgl.vulkan.VK10
 
@@ -13,7 +13,7 @@ import org.lwjgl.vulkan.VK10
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 object VulkanPostprocessPass {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * Records a new command buffer for [pass] into [commandBuffer]. Eventually necessary further buffers

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -8,7 +8,6 @@ import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.backends.*
 import graphics.scenery.textures.Texture
 import graphics.scenery.utils.*
-import io.github.classgraph.ClassGraph
 import kotlinx.coroutines.*
 import org.joml.*
 import org.lwjgl.PointerBuffer
@@ -420,6 +419,12 @@ open class VulkanRenderer(hub: Hub,
         private const val MATERIAL_HAS_NORMAL = 0x0008
         private const val MATERIAL_HAS_ALPHAMASK = 0x0010
 
+        private val availableSwapchains = mutableListOf(
+            SwingSwapchain::class.java,
+            HeadlessSwapchain::class.java,
+            OpenGLSwapchain::class.java
+        )
+
         fun getStrictValidation(): Pair<Boolean, List<Int>> {
             val strict = System.getProperty("scenery.VulkanRenderer.StrictValidation")
             val separated = strict?.split(",")?.asSequence()?.mapNotNull { it.toIntOrNull() }?.toList()
@@ -432,6 +437,14 @@ open class VulkanRenderer(hub: Hub,
                 else -> false to emptyList()
             }
         }
+
+        /**
+         * Registers a new special-purpose swapchain with the Vulkan renderer.
+         */
+        fun registerSwapchain(swapchain: Class<VulkanSwapchain>) {
+            availableSwapchains.add(swapchain)
+        }
+
     }
 
     fun getCurrentScene(): Scene {
@@ -558,19 +571,8 @@ open class VulkanRenderer(hub: Hub,
             }
 
             // get available swapchains, but remove default swapchain, will always be there as fallback
-            val start = System.nanoTime()
-            val swapchains = ClassGraph()
-                .acceptPackages("graphics.scenery.backends.vulkan")
-                .enableClassInfo()
-                .scan()
-                .getClassesImplementing("graphics.scenery.backends.vulkan.Swapchain")
-                .filter { cls -> cls.simpleName != "VulkanSwapchain" }
-                .loadClasses()
-            val duration = System.nanoTime() - start
-            logger.debug("Finding swapchains took ${duration/10e6} ms")
-
-            logger.debug("Available special-purpose swapchains are: ${swapchains.joinToString { it.simpleName }}")
-            val selectedSwapchain = swapchains.firstOrNull { (it.kotlin.companionObjectInstance as SwapchainParameters).usageCondition.invoke(embedIn) }
+            logger.debug("Available special-purpose swapchains are: ${availableSwapchains.joinToString { it.simpleName }}")
+            val selectedSwapchain = availableSwapchains.firstOrNull { (it.kotlin.companionObjectInstance as SwapchainParameters).usageCondition.invoke(embedIn) }
             val headless = (selectedSwapchain?.kotlin?.companionObjectInstance as? SwapchainParameters)?.headless ?: false
 
             device = VulkanDevice.fromPhysicalDevice(instance,

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -71,7 +71,7 @@ open class VulkanRenderer(hub: Hub,
                           final override var embedIn: SceneryPanel? = null,
                           renderConfigFile: String) : Renderer(), AutoCloseable {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     // helper classes
     data class PresentHelpers(

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderpass.kt
@@ -8,7 +8,7 @@ import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.Settings
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.backends.*
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.RingBuffer
 import org.joml.Vector2f
 import org.joml.Vector4f
@@ -34,7 +34,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
                        val vertexDescriptors: ConcurrentHashMap<VulkanRenderer.VertexDataKinds, VulkanRenderer.VertexDescription>,
                        val ringBufferSize: Int = 2): AutoCloseable {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     /** [VulkanFramebuffer] inputs of this render pass */
     val inputs = ConcurrentHashMap<String, VulkanFramebuffer>()
@@ -874,7 +874,7 @@ open class VulkanRenderpass(val name: String, var config: RenderConfigReader.Ren
     }
 
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
         var pipelineCache = -1L
 
         fun createPipelineCache(device: VulkanDevice) {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
@@ -12,7 +12,7 @@ import graphics.scenery.attribute.DelegationType
 import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.backends.ShaderIntrospection
 import graphics.scenery.textures.Texture
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.Statistics
 import kotlinx.coroutines.runBlocking
 import org.joml.Vector3i
@@ -27,7 +27,7 @@ import java.util.*
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 object VulkanScenePass {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * Records a new scene command buffer.

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.backends.vulkan
 
 import graphics.scenery.backends.*
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil.*
 import org.lwjgl.vulkan.VK10.*
 import org.lwjgl.vulkan.VkPipelineShaderStageCreateInfo
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 
 open class VulkanShaderModule(val device: VulkanDevice, entryPoint: String, val sp: ShaderPackage) {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     var shader: VkPipelineShaderStageCreateInfo
     var shaderModule: Long
     var uboSpecs = LinkedHashMap<String, ShaderIntrospection.UBOSpec>()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanSwapchain.kt
@@ -3,7 +3,7 @@ package graphics.scenery.backends.vulkan
 import graphics.scenery.Hub
 import graphics.scenery.backends.RenderConfigReader
 import graphics.scenery.backends.SceneryWindow
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SceneryPanel
 import org.lwjgl.glfw.GLFW.*
 import org.lwjgl.glfw.GLFWVulkan
@@ -36,7 +36,7 @@ open class VulkanSwapchain(open val device: VulkanDevice,
                            open val useSRGB: Boolean = true,
                            open val vsync: Boolean = false,
                            open val undecorated: Boolean = false) : Swapchain {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     /** Swapchain handle. */
     override var handle: Long = 0L

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanTexture.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanTexture.kt
@@ -7,7 +7,7 @@ import graphics.scenery.textures.Texture.RepeatMode
 import graphics.scenery.textures.UpdatableTexture
 import graphics.scenery.textures.UpdatableTexture.TextureUpdate
 import graphics.scenery.utils.Image
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.imglib2.type.numeric.NumericType
 import net.imglib2.type.numeric.integer.*
 import net.imglib2.type.numeric.real.DoubleType
@@ -783,7 +783,7 @@ open class VulkanTexture(val device: VulkanDevice,
      * Utility methods for [VulkanTexture].
      */
     companion object {
-        @JvmStatic private val logger by LazyLogger()
+        @JvmStatic private val logger by lazyLogger()
 
         private val cache = HashMap<Texture, VulkanTexture>()
 

--- a/src/main/kotlin/graphics/scenery/compute/EdgeBundler.kt
+++ b/src/main/kotlin/graphics/scenery/compute/EdgeBundler.kt
@@ -5,7 +5,7 @@ import graphics.scenery.*
 import graphics.scenery.primitives.Line
 import graphics.scenery.primitives.LinePair
 import graphics.scenery.attribute.material.Material
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.jocl.cl_mem
 import java.io.File
 import java.lang.Float.MAX_VALUE
@@ -103,7 +103,7 @@ class PointWithMeta(var x: Float = 0.0f, var y: Float = 0.0f, var z: Float = 0.0
  * @author Johannes Waschke <jowaschke@cbs.mpg.de>
  */
 class EdgeBundler(override var hub: Hub?): Hubable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         hub?.add(this)

--- a/src/main/kotlin/graphics/scenery/compute/OpenCLContext.kt
+++ b/src/main/kotlin/graphics/scenery/compute/OpenCLContext.kt
@@ -3,7 +3,7 @@ package graphics.scenery.compute
 import graphics.scenery.Hub
 import graphics.scenery.Hubable
 import graphics.scenery.SceneryElement
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.jocl.*
 import org.jocl.CL.*
 import java.io.File
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 
 class OpenCLContext(override var hub: Hub?, devicePreference: String = System.getProperty("scenery.OpenCLDevice", "0,0")) : Hubable, AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     var device: cl_device_id
     private var kernels = ConcurrentHashMap<String, cl_kernel>()

--- a/src/main/kotlin/graphics/scenery/controls/DTrackTrackerInput.kt
+++ b/src/main/kotlin/graphics/scenery/controls/DTrackTrackerInput.kt
@@ -4,7 +4,7 @@ import art.DTrackSDK
 import graphics.scenery.Camera
 import graphics.scenery.Mesh
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import kotlinx.coroutines.*
 import org.joml.*
 import org.scijava.ui.behaviour.*
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class DTrackTrackerInput(val host: String = "localhost", val port: Int = 5000, var defaultBodyId: String = "body-0"): TrackerInput {
     private var sdk: DTrackSDK = DTrackSDK(InetAddress.getByName(host), port)
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     var numBodies: Int = 0
         protected set

--- a/src/main/kotlin/graphics/scenery/controls/Hololens.kt
+++ b/src/main/kotlin/graphics/scenery/controls/Hololens.kt
@@ -4,7 +4,7 @@ import graphics.scenery.*
 import graphics.scenery.backends.Display
 import graphics.scenery.backends.vulkan.*
 import graphics.scenery.Mesh
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import kotlinx.coroutines.*
 import org.joml.*
 import org.lwjgl.system.MemoryStack
@@ -36,7 +36,7 @@ import kotlin.math.PI
 class Hololens: TrackerInput, Display, Hubable {
     override var hub: Hub? = null
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private val identityQuat = Quaternionf()
     private val nullVector = Vector3f(0.0f)

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -72,20 +72,10 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
                 }
 
                 else -> {
-                    val start = System.nanoTime()
-                    val handlers = ClassGraph()
-                        .acceptPackages("graphics.scenery.controls")
-                        .enableClassInfo()
-                        .enableAnnotationInfo()
-                        .scan()
-                        .getClassesWithAnnotation("graphics.scenery.controls.CanHandleInputFor")
-                        .loadClasses()
-                    val duration = System.nanoTime() - start
-
                     if (logger.isDebugEnabled) {
-                        logger.debug("Found potential input handlers (${duration / 10e6} ms): ${handlers.joinToString { "${it.simpleName} -> ${it.getAnnotation(CanHandleInputFor::class.java).windowTypes.joinToString()}" }}")
+                        logger.debug("Found potential input handlers ${availableInputHandlers.joinToString { "${it.simpleName} -> ${it.getAnnotation(CanHandleInputFor::class.java).windowTypes.joinToString()}" }}")
                     }
-                    val candidate = handlers.find { it.getAnnotation(CanHandleInputFor::class.java).windowTypes.contains(window::class) }
+                    val candidate = availableInputHandlers.find { it.getAnnotation(CanHandleInputFor::class.java).windowTypes.contains(window::class) }
                     handler = candidate?.getConstructor(Hub::class.java)?.newInstance(hub) as MouseAndKeyHandlerBase?
                     handler?.attach(hub, window, inputMap, behaviourMap)
                 }
@@ -364,4 +354,22 @@ class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, for
 
     data class NamedBehaviourWithKeyBinding(val name: String, val behaviour: Behaviour, val key: String)
 
+    /**
+     * Helper objects etc. for the [InputHandler] class.
+     */
+    companion object {
+        private val availableInputHandlers = mutableListOf<Class<*>>(
+            GLFWMouseAndKeyHandler::class.java,
+            JOGLMouseAndKeyHandler::class.java,
+            SwingMouseAndKeyHandler::class.java
+        )
+
+        /**
+         * Registers a new input handler, [handler], for custom usage.
+         */
+        fun registerInputHandler(handler: Class<*>) {
+            availableInputHandlers.add(handler)
+        }
+
+    }
 }

--- a/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/InputHandler.kt
@@ -5,8 +5,7 @@ import graphics.scenery.backends.RenderConfigReader
 import graphics.scenery.backends.Renderer
 import graphics.scenery.backends.SceneryWindow
 import graphics.scenery.controls.behaviours.*
-import graphics.scenery.utils.LazyLogger
-import io.github.classgraph.ClassGraph
+import graphics.scenery.utils.lazyLogger
 import net.java.games.input.Component
 import org.scijava.ui.behaviour.Behaviour
 import org.scijava.ui.behaviour.BehaviourMap
@@ -33,7 +32,7 @@ import javax.swing.JFrame
  */
 class InputHandler(scene: Scene, renderer: Renderer, override var hub: Hub?, forceHandler: Class<*>? = null) : Hubable, AutoCloseable {
     /** logger for the InputHandler **/
-    internal val logger by LazyLogger()
+    internal val logger by lazyLogger()
 
     /** ui-behaviour input trigger map, stores what actions (key presses, etc) trigger which actions. */
     internal val inputMap = InputTriggerMap()

--- a/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
+++ b/src/main/kotlin/graphics/scenery/controls/MouseAndKeyHandlerBase.kt
@@ -8,7 +8,7 @@ import graphics.scenery.controls.behaviours.GamepadBehaviour
 import graphics.scenery.controls.behaviours.GamepadClickBehaviour
 import graphics.scenery.utils.ExtractsNatives
 import graphics.scenery.utils.ExtractsNatives.Platform.*
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.java.games.input.*
 import org.lwjgl.system.Platform
 import org.scijava.ui.behaviour.*
@@ -27,7 +27,7 @@ import kotlin.math.abs
  * @author Ulrik Günther <hello@ulrik.is>
  */
 open class MouseAndKeyHandlerBase : ControllerListener, ExtractsNatives {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     /** ui-behaviour input trigger map */
     protected lateinit var inputTriggerMap: InputTriggerMap
 

--- a/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
+++ b/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
@@ -13,7 +13,7 @@ import graphics.scenery.backends.vulkan.VulkanDevice
 import graphics.scenery.backends.vulkan.VulkanTexture
 import graphics.scenery.backends.vulkan.endCommandBuffer
 import graphics.scenery.utils.JsonDeserialisers
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.Statistics
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -51,7 +51,7 @@ import kotlin.math.absoluteValue
 open class OpenVRHMD(val seated: Boolean = false, val useCompositor: Boolean = true) : TrackerInput, Display, Hubable {
 
     /** slf4j logger instance */
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     /** The Hub to use for communication */
     override var hub: Hub? = null
 
@@ -1200,7 +1200,7 @@ open class OpenVRHMD(val seated: Boolean = false, val useCompositor: Boolean = t
     }
 
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         protected val keyMap: HashMap<Pair<TrackerRole, OpenVRButton>, AWTKey> = hashMapOf(
             (TrackerRole.LeftHand to OpenVRButton.Left) to AWTKey(KeyEvent.VK_H),

--- a/src/main/kotlin/graphics/scenery/controls/ScreenConfig.kt
+++ b/src/main/kotlin/graphics/scenery/controls/ScreenConfig.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import graphics.scenery.utils.JsonDeserialisers
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -104,7 +104,7 @@ class ScreenConfig {
      * ScreenConfig companion class for static functions
      */
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         /**
          * Matches a single screen to the [config] given.

--- a/src/main/kotlin/graphics/scenery/controls/TrackedStereoGlasses.kt
+++ b/src/main/kotlin/graphics/scenery/controls/TrackedStereoGlasses.kt
@@ -4,7 +4,7 @@ import graphics.scenery.*
 import graphics.scenery.backends.Display
 import graphics.scenery.backends.vulkan.VulkanDevice
 import graphics.scenery.Mesh
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.plus
 import org.joml.*
 import org.lwjgl.vulkan.VkInstance
@@ -18,7 +18,7 @@ import org.lwjgl.vulkan.VkQueue
  */
 class TrackedStereoGlasses(var address: String = "device@localhost:5500", var screenConfig: String = "CAVEExample.yml") : Display, TrackerInput, Hubable {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     override var hub: Hub? = null
 
     var tracker = initializeTracker(address)

--- a/src/main/kotlin/graphics/scenery/controls/VRPNTrackerInput.kt
+++ b/src/main/kotlin/graphics/scenery/controls/VRPNTrackerInput.kt
@@ -5,7 +5,7 @@ import org.joml.Vector3f
 import graphics.scenery.Camera
 import graphics.scenery.Mesh
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.times
 import org.joml.Quaternionf
 import vrpn.Loader
@@ -20,7 +20,7 @@ import java.util.*
 */
 
 class VRPNTrackerInput(trackerAddress: String = "device@localhost:5500") : TrackerInput {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     var tracker: TrackerRemote? = null
 

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ArcballCameraControl.kt
@@ -2,7 +2,7 @@ package graphics.scenery.controls.behaviours
 
 import org.joml.Vector3f
 import graphics.scenery.Camera
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
@@ -30,7 +30,7 @@ import java.util.function.Supplier
  */
 open class ArcballCameraControl(private val name: String, camera: () -> Camera?, private val w: Int, private val h: Int, var target: () -> Vector3f) : DragBehaviour, ScrollBehaviour,
     WithCameraDelegateBase(camera) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private var lastX = w / 2
     private var lastY = h / 2
 

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ControllerDrag.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ControllerDrag.kt
@@ -1,12 +1,11 @@
 package graphics.scenery.controls.behaviours
 
 import org.joml.Vector3f
-import com.jogamp.opengl.math.Quaternion
 import graphics.scenery.Node
 import graphics.scenery.controls.TrackedDeviceType
 import graphics.scenery.controls.TrackerInput
 import graphics.scenery.controls.TrackerRole
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import org.joml.Quaternionf
@@ -24,7 +23,7 @@ open class ControllerDrag(val handedness: TrackerRole,
                           val trackPosition: Boolean = true,
                           val trackRotation: Boolean = false,
                           val draggedObjectFinder: () -> Node?): ClickBehaviour {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     protected var lastPosition: Vector3f? = null
     protected var lastRotation: Quaternionf? = null
     // half a second of timeout

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/EnumCycleCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/EnumCycleCommand.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.controls.behaviours
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.scijava.ui.behaviour.ClickBehaviour
 import java.lang.reflect.InvocationTargetException
 
@@ -20,7 +20,7 @@ class EnumCycleCommand<T: Enum<*>>(private val enumClass: Class<T>,
                                    private val receiver: Any,
                                    private val method: String) : ClickBehaviour {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private var currentIndex = 0
 
     /**

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/GamepadRotationControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/GamepadRotationControl.kt
@@ -2,7 +2,7 @@ package graphics.scenery.controls.behaviours
 
 import graphics.scenery.Camera
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.java.games.input.Component
 import org.joml.Quaternionf
 import kotlin.math.abs
@@ -24,7 +24,7 @@ open class GamepadRotationControl(override val axis: List<Component.Identifier>,
     private var lastX: Float = 0.0f
     private var lastY: Float = 0.0f
     private var firstEntered = true
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /** The [graphics.scenery.Node] this behaviour class controls */
     protected var node: Node? by NodeDelegate()

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MeshAdder.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MeshAdder.kt
@@ -4,7 +4,7 @@ import graphics.scenery.Camera
 import graphics.scenery.Scene
 import graphics.scenery.Mesh
 import graphics.scenery.backends.Renderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector2f
 import org.joml.Vector3f
 import org.scijava.ui.behaviour.ClickBehaviour
@@ -21,7 +21,7 @@ open class MeshAdder constructor(protected val name: String,
                                  protected val camera: () -> Camera?,
                                  meshLambda: () -> Mesh
 ) : ClickBehaviour {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     protected val cam: Camera? by CameraDelegate()
 

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragPlane.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragPlane.kt
@@ -31,11 +31,10 @@ package graphics.scenery.controls.behaviours
 import graphics.scenery.BoundingGrid
 import graphics.scenery.Camera
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.scijava.ui.behaviour.DragBehaviour
 import org.scijava.ui.behaviour.ScrollBehaviour
-import kotlin.reflect.KProperty
 
 /**
  * Drag nodes along the viewplane by mouse.
@@ -53,7 +52,7 @@ open class MouseDragPlane(
     protected val fpsSpeedSlow: () -> Float = { 0.05f }
 ) : DragBehaviour, ScrollBehaviour, WithCameraDelegateBase(camera) {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     protected var currentNode: Node? = null
     private var lastX = 0

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragSphere.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MouseDragSphere.kt
@@ -3,7 +3,7 @@ package graphics.scenery.controls.behaviours
 import graphics.scenery.BoundingGrid
 import graphics.scenery.Camera
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
@@ -23,7 +23,7 @@ open class MouseDragSphere(
     var filter: (Node) -> Boolean
 ) : DragBehaviour, WithCameraDelegateBase(camera) {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     protected var currentNode: Node? = null
     protected var currentHit: Vector3f = Vector3f()

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MouseRotate.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MouseRotate.kt
@@ -3,10 +3,9 @@ package graphics.scenery.controls.behaviours
 import graphics.scenery.BoundingGrid
 import graphics.scenery.Camera
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Quaternionf
 import org.scijava.ui.behaviour.DragBehaviour
-import kotlin.reflect.KProperty
 
 /**
  * Control behavior for rotating a Node
@@ -23,7 +22,7 @@ open class MouseRotate(
     protected val mouseSpeed: () -> Float = { 0.25f }
 ) : DragBehaviour, WithCameraDelegateBase(camera) {
 
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
     protected var currentNode: Node? = null
     private var lastX = 0

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/MovementCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/MovementCommand.kt
@@ -2,7 +2,7 @@ package graphics.scenery.controls.behaviours
 
 import graphics.scenery.Camera
 import graphics.scenery.Node
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
@@ -20,7 +20,7 @@ import kotlin.reflect.KProperty
 open class MovementCommand(private val direction: String, private var n: () -> Node?) : ClickBehaviour {
 
     private val node: Node? by NodeDelegate()
-    private val logger: Logger by LazyLogger()
+    private val logger: Logger by lazyLogger()
 
     protected inner class NodeDelegate {
         /** Returns the [graphics.scenery.Node] resulting from the evaluation of [n] */

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/RollingBallCameraControl.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/RollingBallCameraControl.kt
@@ -2,7 +2,7 @@ package graphics.scenery.controls.behaviours
 
 import com.jogamp.opengl.math.FloatUtil.sqrt
 import graphics.scenery.Camera
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
@@ -30,7 +30,7 @@ import java.util.function.Supplier
  */
 open class RollingBallCameraControl(private val name: String, camera: () -> Camera?, private val w: Int, private val h: Int, var target: () -> Vector3f) : DragBehaviour, ScrollBehaviour,
     WithCameraDelegateBase(camera) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private var lastX = w / 2
     private var lastY = h / 2
     private var firstEntered = true

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/Ruler.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/Ruler.kt
@@ -4,7 +4,7 @@ import graphics.scenery.Camera
 import graphics.scenery.Scene
 import graphics.scenery.primitives.Line
 import graphics.scenery.primitives.TextBoard
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector2f
 import org.joml.Vector3f
 import org.joml.Vector4f
@@ -22,7 +22,7 @@ class Ruler(private val name: String, private val camera: () -> Camera?, private
     //position on the mouse click; start of the line
     private val origin = Vector3f()
     private val finalLength = Vector3f()
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val cam = camera.invoke()
 
     /** Setup the line and delete the old one */

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/SelectCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/SelectCommand.kt
@@ -4,9 +4,8 @@ import graphics.scenery.BoundingGrid
 import graphics.scenery.Camera
 import graphics.scenery.Scene
 import graphics.scenery.backends.Renderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.scijava.ui.behaviour.ClickBehaviour
-import kotlin.reflect.KProperty
 
 /**
  * Raycasting-based selection command. Needs to be given a
@@ -29,7 +28,7 @@ open class SelectCommand @JvmOverloads constructor(protected val name: String,
                                                    var ignoredObjects: List<Class<*>> = listOf<Class<*>>(BoundingGrid::class.java),
                                                    protected var action: ((Scene.RaycastResult, Int, Int) -> Unit) = { _, _, _ -> Unit }) : ClickBehaviour,
     WithCameraDelegateBase(camera) {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
 
 
     /**

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/ToggleCommand.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/ToggleCommand.kt
@@ -1,8 +1,7 @@
 package graphics.scenery.controls.behaviours
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.scijava.ui.behaviour.ClickBehaviour
-import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException
 
 /**
@@ -15,7 +14,7 @@ import java.lang.reflect.InvocationTargetException
  */
 class ToggleCommand(private val receiver: Any, private val method: String) : ClickBehaviour {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * This function is called upon arrival of an event that concerns

--- a/src/main/kotlin/graphics/scenery/controls/behaviours/VRTwoHandDragBehavior.kt
+++ b/src/main/kotlin/graphics/scenery/controls/behaviours/VRTwoHandDragBehavior.kt
@@ -5,7 +5,7 @@ import graphics.scenery.attribute.spatial.Spatial
 import graphics.scenery.controls.OpenVRHMD
 import graphics.scenery.controls.TrackedDeviceType
 import graphics.scenery.controls.TrackerRole
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.scijava.ui.behaviour.DragBehaviour
 import java.util.concurrent.CompletableFuture
@@ -20,7 +20,7 @@ abstract class VRTwoHandDragBehavior(
     private val offhand: VRTwoHandDragOffhand,
 ) : DragBehaviour, Enablable {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     // --- two hand drag behavior ---
     //TODO fix make order of presses irrelevant, waits on issue #432

--- a/src/main/kotlin/graphics/scenery/controls/eyetracking/PupilEyeTracker.kt
+++ b/src/main/kotlin/graphics/scenery/controls/eyetracking/PupilEyeTracker.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import graphics.scenery.Camera
 import graphics.scenery.Node
 import graphics.scenery.backends.Display
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
 import kotlinx.coroutines.*
@@ -34,7 +34,7 @@ class PupilEyeTracker(val calibrationType: CalibrationType, val host: String = "
     /** Shall we do a screen-space or world-space calibration? */
     enum class CalibrationType { ScreenSpace, WorldSpace}
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private val zmqContext = ZContext(4)
     private val req = zmqContext.createSocket(ZMQ.REQ)

--- a/src/main/kotlin/graphics/scenery/fonts/SDFFontAtlas.kt
+++ b/src/main/kotlin/graphics/scenery/fonts/SDFFontAtlas.kt
@@ -5,7 +5,7 @@ import graphics.scenery.geometry.GeometryType
 import graphics.scenery.Hub
 import graphics.scenery.Mesh
 import graphics.scenery.compute.OpenCLContext
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers
 import org.jocl.cl_mem
 import org.joml.Vector4f
@@ -36,7 +36,7 @@ import kotlin.collections.LinkedHashMap
  * @constructor Generates a SDF of the given font
  */
 open class SDFFontAtlas(var hub: Hub, val fontName: String, val distanceFieldSize: Int = 512, val maxDistance: Int = 10, var cache: Boolean = true) {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     /** default charset for the SDF font atlas, default is ASCII charset */
     var charset = (32..127)
     /** Hash map of the char linked to it's width and a byte buffer with the SDF of the char */

--- a/src/main/kotlin/graphics/scenery/geometry/CatmullRomSpline.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/CatmullRomSpline.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.geometry
 
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
 import org.joml.Vector3f
@@ -22,7 +22,7 @@ import kotlin.math.pow
 class CatmullRomSpline(private val controlPoints: List<Vector3f>, private val n: Int = 100, private val alpha: Float = 0.5f,
                        private val addRandomLastAndFirstPoint: Boolean = false): Spline {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Calculates the parameter t; t is an intermediate product for the calculation of the spline

--- a/src/main/kotlin/graphics/scenery/geometry/UniformBSpline.kt
+++ b/src/main/kotlin/graphics/scenery/geometry/UniformBSpline.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.geometry
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.xyz
 import org.joml.Matrix4f
 import org.joml.Vector3f
@@ -22,7 +22,7 @@ import java.lang.IllegalArgumentException
  */
 class UniformBSpline(protected val controlPoints: ArrayList<Vector3f>, val n: Int = 100): Spline {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     /**
      * This is a list of the equidistant parameters at which the curve is calculated.
      */

--- a/src/main/kotlin/graphics/scenery/net/NodePublisher.kt
+++ b/src/main/kotlin/graphics/scenery/net/NodePublisher.kt
@@ -7,7 +7,7 @@ import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy
 import de.javakaffee.kryoserializers.UUIDSerializer
 import graphics.scenery.*
 import graphics.scenery.serialization.*
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.Statistics
 import graphics.scenery.volumes.VolumeManager
 import net.imglib2.img.basictypeaccess.array.ByteArray
@@ -40,7 +40,7 @@ class NodePublisher(
     portBackchannel: Int = 6666,
     val context: ZContext
 ) : Agent(), Hubable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private val addressMain = "$ip:$portMain"
     private val addressBackchannel = "$ip:$portBackchannel"

--- a/src/main/kotlin/graphics/scenery/net/NodeSubscriber.kt
+++ b/src/main/kotlin/graphics/scenery/net/NodeSubscriber.kt
@@ -5,7 +5,7 @@ import graphics.scenery.Hub
 import graphics.scenery.Hubable
 import graphics.scenery.Node
 import graphics.scenery.Scene
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.zeromq.SocketType
 import org.zeromq.ZContext
 import org.zeromq.ZMQ
@@ -26,7 +26,7 @@ class NodeSubscriber(
     val context: ZContext,
     startNetworkActivity: Boolean = true //disables network stuff for testing
 ) : Agent(), Hubable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     val kryo = NodePublisher.freeze()
 
     private val addressSubscribe = "$ip:$portPublish"

--- a/src/main/kotlin/graphics/scenery/proteins/Axis.kt
+++ b/src/main/kotlin/graphics/scenery/proteins/Axis.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.proteins
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import kotlin.math.sqrt
 
@@ -13,7 +13,7 @@ import kotlin.math.sqrt
 class Axis(positions: List<Vector3f?>) {
     val direction = Vector3f()
     val position = Vector3f()
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     init {
         if(positions.size >= 4) {
             val axisPoints = calculateAxisPoints(positions)

--- a/src/main/kotlin/graphics/scenery/proteins/PeriodicTable.kt
+++ b/src/main/kotlin/graphics/scenery/proteins/PeriodicTable.kt
@@ -2,7 +2,7 @@ package graphics.scenery.proteins
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import kotlin.collections.ArrayList
 
@@ -34,7 +34,7 @@ open class PeriodicTable {
     data class PeriodicTableau(@JsonProperty("Table") val table: ChemTable)
 
     val elementList = ArrayList<ChemicalElement>()
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         //parsing the json file

--- a/src/main/kotlin/graphics/scenery/proteins/Protein.kt
+++ b/src/main/kotlin/graphics/scenery/proteins/Protein.kt
@@ -3,7 +3,7 @@ package graphics.scenery.proteins
 import graphics.scenery.Mesh
 import graphics.scenery.proteins.Protein.MyProtein.fromFile
 import graphics.scenery.proteins.Protein.MyProtein.fromID
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.biojava.nbio.structure.Structure
 import org.biojava.nbio.structure.StructureException
 import org.biojava.nbio.structure.StructureIO
@@ -22,7 +22,7 @@ import java.nio.file.InvalidPathException
 class Protein(val structure: Structure): Mesh("Protein") {
 
     companion object MyProtein {
-        private val proteinLogger by LazyLogger()
+        private val proteinLogger by lazyLogger()
 
         fun fromID(id: String): Protein {
             try {

--- a/src/main/kotlin/graphics/scenery/serialization/ByteBufferSerializer.kt
+++ b/src/main/kotlin/graphics/scenery/serialization/ByteBufferSerializer.kt
@@ -4,11 +4,11 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import java.nio.ByteBuffer
 
 class ByteBufferSerializer: Serializer<ByteBuffer>() {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     override fun write(kryo: Kryo, output: Output, buffer: ByteBuffer) {
         kryo.writeClass(output, buffer.javaClass)

--- a/src/main/kotlin/graphics/scenery/serialization/VectorSerializer.kt
+++ b/src/main/kotlin/graphics/scenery/serialization/VectorSerializer.kt
@@ -4,11 +4,11 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 
 class Vector3fSerializer: Serializer<Vector3f>() {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
     override fun write(kryo: Kryo, output: Output, vector: Vector3f) {
         kryo.writeClassAndObject(output, floatArrayOf(vector.x, vector.y, vector.z))
 //        logger.info("Serialized ${vector.x}/${vector.y}/${vector.z}")

--- a/src/main/kotlin/graphics/scenery/utils/ExtractsNatives.kt
+++ b/src/main/kotlin/graphics/scenery/utils/ExtractsNatives.kt
@@ -21,7 +21,7 @@ interface ExtractsNatives {
     }
 
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
         /**
          * Returns the platform based on the os.name system property.
          */

--- a/src/main/kotlin/graphics/scenery/utils/Image.kt
+++ b/src/main/kotlin/graphics/scenery/utils/Image.kt
@@ -24,7 +24,7 @@ import javax.imageio.ImageIO
 open class Image(val contents: ByteBuffer, val width: Int, val height: Int, val depth: Int = 1) {
 
     companion object {
-        protected val logger by LazyLogger()
+        protected val logger by lazyLogger()
 
         private val StandardAlphaColorModel = ComponentColorModel(
             ColorSpace.getInstance(ColorSpace.CS_sRGB),

--- a/src/main/kotlin/graphics/scenery/utils/LazyLogger.kt
+++ b/src/main/kotlin/graphics/scenery/utils/LazyLogger.kt
@@ -2,15 +2,6 @@ package graphics.scenery.utils
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import kotlin.reflect.full.companionObject
-
-private fun <T : Any> unwrapCompanionClass(ofClass: Class<T>): Class<*> {
-    return if (ofClass.enclosingClass != null && ofClass.enclosingClass.kotlin.companionObject?.java == ofClass) {
-        ofClass.enclosingClass
-    } else {
-        ofClass
-    }
-}
 
 /**
  * LazyLogger - Extension function to flexibly return correct logger names for classes implementing this interface
@@ -19,9 +10,9 @@ private fun <T : Any> unwrapCompanionClass(ofClass: Class<T>): Class<*> {
  *
  * @author Ulrik Guenther <hello@ulrik.is>
  */
-fun <R : Any> R.LazyLogger(logLevel: String? = null): Lazy<Logger> {
+fun <R : Any> R.lazyLogger(logLevel: String? = null): Lazy<Logger> {
     if(logLevel != null) {
         System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", logLevel)
     }
-    return lazyOf(LoggerFactory.getLogger(unwrapCompanionClass(this.javaClass).simpleName))
+    return lazyOf(LoggerFactory.getLogger(this::class.java.simpleName))
 }

--- a/src/main/kotlin/graphics/scenery/utils/NvidiaGPUStats.kt
+++ b/src/main/kotlin/graphics/scenery/utils/NvidiaGPUStats.kt
@@ -20,7 +20,7 @@ interface NVAPI : StdCallLibrary {
 }
 
 class NvidiaGPUStats: GPUStats {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     override val utilisations: HashMap<String, Float> = HashMap()
 

--- a/src/main/kotlin/graphics/scenery/utils/RemoteryProfiler.kt
+++ b/src/main/kotlin/graphics/scenery/utils/RemoteryProfiler.kt
@@ -20,7 +20,7 @@ import org.lwjgl.util.remotery.Remotery.rmt_SetCurrentThreadName
  */
 class RemoteryProfiler(override var hub : Hub?) : Hubable, Profiler, AutoCloseable {
     private var instance = PointerBuffer.allocateDirect(1)
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         val error = rmt_CreateGlobalInstance(instance)

--- a/src/main/kotlin/graphics/scenery/utils/Renderdoc.kt
+++ b/src/main/kotlin/graphics/scenery/utils/Renderdoc.kt
@@ -45,7 +45,7 @@ enum class RenderdocVersion(val versionNumber: Int) {
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class Renderdoc : AutoCloseable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     init {
         logger.info("Initialising Renderdoc")

--- a/src/main/kotlin/graphics/scenery/utils/SceneryJPanel.kt
+++ b/src/main/kotlin/graphics/scenery/utils/SceneryJPanel.kt
@@ -21,7 +21,7 @@ class SceneryJPanel : JPanel(), SceneryPanel {
     /** Updates the backing buffer of the window. Does nothing for Swing. */
     override fun update(buffer: ByteBuffer, id: Int) { }
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /** Width of the panel, cannot be reset. */
     @Suppress("UNUSED_PARAMETER")

--- a/src/main/kotlin/graphics/scenery/utils/Statistics.kt
+++ b/src/main/kotlin/graphics/scenery/utils/Statistics.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class Statistics(override var hub: Hub?) : Hubable {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val dataSize = 100
     private val threadContext = Executors.newSingleThreadExecutor()
 

--- a/src/main/kotlin/graphics/scenery/utils/SystemHelpers.kt
+++ b/src/main/kotlin/graphics/scenery/utils/SystemHelpers.kt
@@ -4,13 +4,10 @@ import java.io.File
 import java.io.FileOutputStream
 import java.lang.reflect.InvocationTargetException
 import java.net.URI
-import java.net.URL
-import java.net.URLEncoder
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.file.*
 import java.text.SimpleDateFormat
-import java.time.Instant
 import java.util.*
 
 /**
@@ -21,7 +18,7 @@ import java.util.*
  */
 class SystemHelpers {
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         /**
          * Sets environment variables during runtime of the process. This code is fractally nasty,

--- a/src/main/kotlin/graphics/scenery/utils/VideoDecoder.kt
+++ b/src/main/kotlin/graphics/scenery/utils/VideoDecoder.kt
@@ -27,7 +27,7 @@ import kotlin.concurrent.thread
 
 class VideoDecoder(val filename: String) {
 
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val formatContext = AVFormatContext(null)
     private val pkt = AVPacket()
     private var vidStreamIdx = -1

--- a/src/main/kotlin/graphics/scenery/utils/VideoEncoder.kt
+++ b/src/main/kotlin/graphics/scenery/utils/VideoEncoder.kt
@@ -62,7 +62,7 @@ class VideoEncoder(
     override var hub: Hub? = null,
     val networked: Boolean = hub?.get<Settings>()?.get("VideoEncoder.StreamVideo", false) ?: false
 ): Hubable {
-    protected val logger by LazyLogger()
+    protected val logger by lazyLogger()
     protected lateinit var frame: AVFrame
     protected lateinit var tmpframe: AVFrame
 

--- a/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
@@ -1,10 +1,9 @@
 package graphics.scenery.volumes
 
 import graphics.scenery.utils.Image
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.imagej.lut.LUTService
 import net.imglib2.display.ColorTable
-import org.joml.Vector3f
 import org.joml.Vector4f
 import org.scijava.plugin.Parameter
 import java.io.FileNotFoundException
@@ -53,7 +52,7 @@ class Colormap(val buffer: ByteBuffer, val width: Int, val height: Int) {
     }
 
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
 
         @Parameter
         protected var lutService: LUTService? = null

--- a/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
@@ -7,7 +7,7 @@ import graphics.scenery.textures.Texture.RepeatMode
 import graphics.scenery.textures.UpdatableTexture.TextureUpdate
 import graphics.scenery.backends.ShaderType
 import graphics.scenery.textures.UpdatableTexture
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.imglib2.type.numeric.NumericType
 import net.imglib2.type.numeric.integer.UnsignedByteType
 import net.imglib2.type.numeric.integer.UnsignedShortType
@@ -33,7 +33,7 @@ import tpietzsch.backend.Texture as BVVTexture
  * @author Tobias Pietzsch <pietzsch@mpi-cbg.de>
  */
 open class SceneryContext(val node: VolumeManager, val useCompute: Boolean = false) : GpuContext {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     data class BindingState(var binding: Int, var uniformName: String?, var reallocate: Boolean = false)
 

--- a/src/main/kotlin/graphics/scenery/volumes/SceneryStackManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/SceneryStackManager.kt
@@ -1,6 +1,6 @@
 package graphics.scenery.volumes
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.imglib2.RandomAccessibleInterval
 import net.imglib2.type.numeric.ARGBType
 import net.imglib2.type.numeric.integer.UnsignedByteType
@@ -18,7 +18,7 @@ import java.util.function.Consumer
 import kotlin.collections.HashMap
 
 open class SceneryStackManager: SimpleStackManager {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val texturesU8 : HashMap<Int, VolumeTextureU8> = HashMap()
     private val texturesU16 : HashMap<Int, VolumeTextureU16> = HashMap()
     private val texturesRGBA8 : HashMap<Int, VolumeTextureRGBA8> = HashMap()

--- a/src/main/kotlin/graphics/scenery/volumes/TransferFunction.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransferFunction.kt
@@ -1,10 +1,9 @@
 package graphics.scenery.volumes
 
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.lwjgl.system.MemoryUtil
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import java.util.ArrayList
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.math.abs
 import kotlin.math.max
@@ -12,7 +11,7 @@ import kotlin.math.min
 
 /** Transfer function class with an optional [name]. */
 open class TransferFunction(val name: String = "") {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Data class to contain control points for transfer functions.

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -32,7 +32,7 @@ import graphics.scenery.attribute.spatial.HasCustomSpatial
 import graphics.scenery.net.Networkable
 import graphics.scenery.numerics.OpenSimplexNoise
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.times
 import graphics.scenery.utils.forEachIndexedAsync
 import graphics.scenery.volumes.Volume.VolumeDataSource.SpimDataMinimalSource
@@ -502,7 +502,7 @@ open class Volume(
     companion object {
         val setupId = AtomicInteger(0)
         val scifio: SCIFIO = SCIFIO()
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         @JvmStatic @JvmOverloads fun fromSpimData(
             spimData: SpimDataMinimal,

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/TexturedCubeExample.kt
@@ -52,6 +52,11 @@ class TexturedCubeExample : SceneryBase("TexturedCubeExample") {
                 Thread.sleep(20)
             }
         }
+
+        thread {
+            Thread.sleep(5000)
+            System.gc()
+        }
     }
 
     companion object {

--- a/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
@@ -4,7 +4,7 @@ import graphics.scenery.SceneryBase
 import graphics.scenery.SceneryElement
 import graphics.scenery.backends.Renderer
 import graphics.scenery.utils.ExtractsNatives
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers
 import io.github.classgraph.ClassGraph
 import kotlinx.coroutines.*
@@ -27,7 +27,7 @@ class ExampleRunner(
     private val renderer: String,
     private val pipeline: String
 ) {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun runExample() = runBlocking {
@@ -106,7 +106,7 @@ class ExampleRunner(
     }
 
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         var maxRuntimePerTest =
             System.getProperty("scenery.ExampleRunner.maxRuntimePerTest", "5").toInt().minutes

--- a/src/test/kotlin/graphics/scenery/tests/unit/AxisTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/AxisTests.kt
@@ -2,7 +2,7 @@ package graphics.scenery.tests.unit
 
 import graphics.scenery.numerics.Random
 import graphics.scenery.proteins.Axis
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.junit.Test
 import kotlin.math.absoluteValue
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
  * @author  Justin Buerger <burger@mpi-cbg.de>
  */
 class AxisTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests what happens when the axis gets a list of less then four points as a parameter

--- a/src/test/kotlin/graphics/scenery/tests/unit/BoxTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/BoxTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit
 import graphics.scenery.Box
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class BoxTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testCreation() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/BufferUtilsTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/BufferUtilsTests.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.tests.unit
 
 import graphics.scenery.BufferUtils
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import java.nio.ByteOrder
 import kotlin.test.assertEquals
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
  */
 
 class BufferUtilsTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests allocation of a Float buffer

--- a/src/test/kotlin/graphics/scenery/tests/unit/CameraTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/CameraTests.kt
@@ -4,7 +4,7 @@ import org.joml.Vector3f
 import graphics.scenery.*
 import graphics.scenery.numerics.Random
 import graphics.scenery.primitives.TextBoard
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class CameraTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests [Camera.showMessage] by showing a message, expecting

--- a/src/test/kotlin/graphics/scenery/tests/unit/CatmullRomSplineTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/CatmullRomSplineTests.kt
@@ -2,7 +2,7 @@ package graphics.scenery.tests.unit
 
 import graphics.scenery.geometry.CatmullRomSpline
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.junit.Test
 import kotlin.math.roundToInt
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
  * @author  Justin Buerger <burger@mpi-cbg.de>
  */
 class CatmullRomSplineTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests if the Catmull Rom Spline object has actually the number of points defined in the class.

--- a/src/test/kotlin/graphics/scenery/tests/unit/ConeTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/ConeTests.kt
@@ -4,7 +4,7 @@ import org.joml.Vector3f
 import graphics.scenery.primitives.Cone
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -16,7 +16,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class ConeTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests the creation of cones and their bounding boxes.

--- a/src/test/kotlin/graphics/scenery/tests/unit/CylinderTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/CylinderTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit
 import graphics.scenery.primitives.Cylinder
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class CylinderTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testCreation() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/HelixTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/HelixTests.kt
@@ -4,7 +4,7 @@ import graphics.scenery.numerics.Random
 import graphics.scenery.geometry.CatmullRomSpline
 import graphics.scenery.proteins.Helix
 import graphics.scenery.proteins.MathLine
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.junit.Test
 import kotlin.math.absoluteValue
@@ -20,7 +20,7 @@ import kotlin.test.assertTrue
  */
 
 class HelixTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Test that a null vector can never be a direction vector.

--- a/src/test/kotlin/graphics/scenery/tests/unit/IcosphereTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/IcosphereTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit
 import graphics.scenery.Icosphere
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class IcosphereTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testCreation() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/MeshTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/MeshTests.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.tests.unit
 
 import graphics.scenery.Mesh
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -12,7 +12,7 @@ import kotlin.test.assertNotNull
  * @author Aryaman Gupta <aryaman1994@gmail.com>
  */
 class MeshTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests reading a [Mesh] from an OBJ file and verifies correct input and

--- a/src/test/kotlin/graphics/scenery/tests/unit/NodeTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/NodeTests.kt
@@ -7,7 +7,7 @@ import graphics.scenery.numerics.Random
 import graphics.scenery.Mesh
 import graphics.scenery.attribute.material.DefaultMaterial
 import graphics.scenery.attribute.material.Material
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.compare
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.toFloatArray
@@ -28,7 +28,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class NodeTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests matrix propagation through the scene graph.

--- a/src/test/kotlin/graphics/scenery/tests/unit/ProteinTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/ProteinTests.kt
@@ -1,11 +1,10 @@
 package graphics.scenery.tests.unit
 
 import graphics.scenery.proteins.Protein
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
-import kotlin.test.assertTrue
 
 /**
  * Unit test for the Protein class
@@ -13,7 +12,7 @@ import kotlin.test.assertTrue
  * @author  Justin Buerger <burger@mpi-cbg.de>
  */
 class ProteinTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testInvalidPath() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/RibbonDiagramTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/RibbonDiagramTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit
 import graphics.scenery.geometry.DummySpline
 import graphics.scenery.proteins.Protein
 import graphics.scenery.proteins.RibbonDiagram
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.biojava.nbio.structure.Group
 import org.biojava.nbio.structure.secstruc.SecStrucElement
 import org.joml.Vector3f
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
  * @author Justin Buerger, burger@mpi-cbg.com
  */
 class RibbonDiagramTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests coherence of curve size and number of residues.

--- a/src/test/kotlin/graphics/scenery/tests/unit/SceneTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/SceneTests.kt
@@ -2,11 +2,10 @@ package graphics.scenery.tests.unit
 
 import org.joml.Vector3f
 import graphics.scenery.Box
-import graphics.scenery.Node
 import graphics.scenery.RichNode
 import graphics.scenery.Scene
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.roundToInt
@@ -18,7 +17,7 @@ import kotlin.test.assertEquals
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class SceneTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testRaycast() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/SettingsTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/SettingsTests.kt
@@ -2,7 +2,7 @@ package graphics.scenery.tests.unit
 
 import graphics.scenery.Hub
 import graphics.scenery.Settings
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.random.Random
 import kotlin.test.assertEquals
@@ -15,7 +15,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class SettingsTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareSettings(): Settings {
         val hub = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/UniformBSplineTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/UniformBSplineTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit
 import org.joml.*
 import graphics.scenery.numerics.Random
 import graphics.scenery.geometry.UniformBSpline
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.math.roundToInt
 import kotlin.test.assertEquals
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
  * @author  Justin Buerger <burger@mpi-cbg.de>
  */
 class UniformBSplineTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests if the Uniform B-Spline object has actually the number of points defined in the class.

--- a/src/test/kotlin/graphics/scenery/tests/unit/backends/ShaderIntrospectionTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/backends/ShaderIntrospectionTests.kt
@@ -5,12 +5,9 @@ import graphics.scenery.backends.ShaderIntrospection
 import graphics.scenery.backends.ShaderType
 import graphics.scenery.backends.Shaders
 import graphics.scenery.tests.examples.compute.ComputeShaderExample
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers.Companion.toIntArray
 import org.junit.Test
-import java.io.File
-import java.nio.ByteBuffer
-import kotlin.experimental.and
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
@@ -20,7 +17,7 @@ import kotlin.test.assertEquals
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class ShaderIntrospectionTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests creation and teardown behaviour.

--- a/src/test/kotlin/graphics/scenery/tests/unit/backends/ShadersTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/backends/ShadersTests.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.tests.unit.backends
 
 import graphics.scenery.backends.*
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -12,7 +12,7 @@ import kotlin.test.assertNotNull
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class ShadersTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests correct behaviour in the case a requested shader type is not found in a [Shaders] package.

--- a/src/test/kotlin/graphics/scenery/tests/unit/backends/UBOTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/backends/UBOTests.kt
@@ -4,7 +4,7 @@ import org.joml.Matrix4f
 import org.joml.Vector3f
 import graphics.scenery.backends.UBO
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.VideoEncodingQuality
 import graphics.scenery.utils.extensions.compare
 import graphics.scenery.utils.extensions.plus
@@ -26,7 +26,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class UBOTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests UBO serialisation in-order of the members

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/GLFWMouseAndKeyHandlerTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/GLFWMouseAndKeyHandlerTests.kt
@@ -10,7 +10,7 @@ import graphics.scenery.backends.SceneryWindow
 import graphics.scenery.controls.GLFWMouseAndKeyHandler
 import graphics.scenery.controls.InputHandler
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import org.lwjgl.glfw.GLFW.*
 import org.scijava.ui.behaviour.ClickBehaviour
@@ -29,7 +29,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class GLFWMouseAndKeyHandlerTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareInputHandler(preparedWindow: SceneryWindow? = null): Triple<InputHandler, Scene, GLFWMouseAndKeyHandler> {
         val h = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/InputHandlerTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/InputHandlerTests.kt
@@ -6,7 +6,7 @@ import graphics.scenery.Scene
 import graphics.scenery.Settings
 import graphics.scenery.controls.InputHandler
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.ui.behaviour.InputTrigger
@@ -20,7 +20,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class InputHandlerTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareInputHandler(): InputHandler {
         val hub = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/JOGLMouseAndKeyHandlerTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/JOGLMouseAndKeyHandlerTests.kt
@@ -11,7 +11,7 @@ import graphics.scenery.backends.SceneryWindow
 import graphics.scenery.controls.InputHandler
 import graphics.scenery.controls.JOGLMouseAndKeyHandler
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.ui.behaviour.DragBehaviour
@@ -29,7 +29,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class JOGLMouseAndKeyHandlerTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareInputHandler(preparedWindow: SceneryWindow? = null): Triple<InputHandler, Scene, JOGLMouseAndKeyHandler> {
         val h = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/OpenVRHMDTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/OpenVRHMDTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit.controls
 import graphics.scenery.Mesh
 import graphics.scenery.controls.OpenVRHMD
 import graphics.scenery.controls.TrackedDeviceType
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -16,13 +16,13 @@ import kotlin.test.assertTrue
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class OpenVRHMDTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Companion object for checking whether OpenVR is installed.
      */
     companion object {
-        private val logger by LazyLogger()
+        private val logger by lazyLogger()
 
         /**
          * Checks if OpenVR and associated libraries are available, skips

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/SwingMouseAndKeyHandlerTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/SwingMouseAndKeyHandlerTests.kt
@@ -8,7 +8,7 @@ import graphics.scenery.backends.SceneryWindow
 import graphics.scenery.controls.InputHandler
 import graphics.scenery.controls.SwingMouseAndKeyHandler
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Test
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.ui.behaviour.DragBehaviour
@@ -31,7 +31,7 @@ import kotlin.test.assertTrue
  * @author Ulrik Günther <hello@ulrik.is>
  */
 class SwingMouseAndKeyHandlerTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareInputHandler(preparedWindow: SceneryWindow? = null): Triple<InputHandler, Scene, SwingMouseAndKeyHandler> {
         val h = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/ArcballCameraControlTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/ArcballCameraControlTests.kt
@@ -5,10 +5,9 @@ import graphics.scenery.Camera
 import graphics.scenery.DetachedHeadCamera
 import graphics.scenery.Hub
 import graphics.scenery.Scene
-import graphics.scenery.backends.SceneryWindow
 import graphics.scenery.controls.behaviours.ArcballCameraControl
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Quaternionf
 import org.junit.Assert
 import org.junit.Test
@@ -24,7 +23,7 @@ import kotlin.test.assertNotNull
  * @author Aryaman Gupta <aryaman1994@gmail.com>
  */
 class ArcballCameraControlTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
     private val seqLength = 100
 
     private fun prepareArcballCameraControl(scene: Scene) : ArcballCameraControl {

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/GamepadRotationControlTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/GamepadRotationControlTests.kt
@@ -8,7 +8,7 @@ import graphics.scenery.Scene
 import graphics.scenery.controls.behaviours.GamepadRotationControl
 import graphics.scenery.numerics.Random
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import net.java.games.input.Component
 import org.junit.Assert
 import org.junit.Test
@@ -23,7 +23,7 @@ import kotlin.test.assertNotNull
  * @author Aryaman Gupta <aryaman1994@gmail.com>
  */
 class GamepadRotationControlTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     private fun prepareGamepadCameraControl(scene: Scene) : GamepadRotationControl {
         val hub: Hub = Hub()

--- a/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/SelectionTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/controls/behaviours/SelectionTests.kt
@@ -10,7 +10,7 @@ import graphics.scenery.SceneryElement
 import graphics.scenery.Settings
 import graphics.scenery.controls.behaviours.SelectCommand
 import graphics.scenery.tests.unit.backends.FauxRenderer
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.joml.Vector3f
 import org.junit.Ignore
 import org.junit.Test
@@ -19,7 +19,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertSame
 
 class SelectionTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /**
      * Tests initialisation of [SelectCommand].

--- a/src/test/kotlin/graphics/scenery/tests/unit/fonts/SDFFontAtlasTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/fonts/SDFFontAtlasTests.kt
@@ -3,7 +3,7 @@ package graphics.scenery.tests.unit.fonts
 import graphics.scenery.Hub
 import graphics.scenery.compute.OpenCLContext
 import graphics.scenery.fonts.SDFFontAtlas
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.BeforeClass
 import org.junit.Test
 import org.lwjgl.system.Platform
@@ -14,13 +14,13 @@ import kotlin.test.assertTrue
  * Tests for [SDFFontAtlas]
  */
 class SDFFontAtlasTests {
-    val logger by LazyLogger()
+    val logger by lazyLogger()
 
     /**
      * Companion object for checking OpenCL availability.
      */
     companion object {
-        val logger by LazyLogger()
+        val logger by lazyLogger()
         @JvmStatic @BeforeClass
         fun checkOpenCLAvailability() {
             val openCLunavailable = ((System.getenv("GITHUB_ACTIONS").toBoolean() && Platform.get() == Platform.MACOSX)

--- a/src/test/kotlin/graphics/scenery/tests/unit/numerics/OpenSimplexNoiseTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/numerics/OpenSimplexNoiseTests.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.tests.unit.numerics
 
 import graphics.scenery.numerics.OpenSimplexNoise
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.Assert
 import org.junit.Test
 import java.util.zip.GZIPInputStream
@@ -16,7 +16,7 @@ import kotlin.random.Random
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class OpenSimplexNoiseTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun test1DNoise() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/numerics/RandomTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/numerics/RandomTests.kt
@@ -1,10 +1,9 @@
 package graphics.scenery.tests.unit.numerics
 
 import graphics.scenery.numerics.Random
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.extensions.toFloatArray
 import org.junit.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -14,7 +13,7 @@ import kotlin.test.assertTrue
  */
 
 class RandomTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     @Test
     fun testRandomFromRange() {

--- a/src/test/kotlin/graphics/scenery/tests/unit/repl/REPLTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/repl/REPLTests.kt
@@ -2,7 +2,7 @@ package graphics.scenery.tests.unit.repl
 
 import graphics.scenery.Hub
 import graphics.scenery.repl.REPL
-import graphics.scenery.utils.LazyLogger
+import graphics.scenery.utils.lazyLogger
 import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -14,7 +14,7 @@ import kotlin.test.assertNotNull
  * @author Ulrik Guenther <hello@ulrik.is>
  */
 class REPLTests {
-    private val logger by LazyLogger()
+    private val logger by lazyLogger()
 
     /** Companion object for test setup */
     companion object {


### PR DESCRIPTION
This PR adds the following optimisations:
* LazyLogger is not using Kotlin reflection anymore for determining class names, significantly improving memory usage
* In SceneryBase, the REPL is not created and shown by default anymore. Access to the REPL can be obtained by pressing Shift-R when not running in headless mode. This saves around 300MiB of memory needed for Jython initialisation.
* VulkanRenderer is not using ClassGraph anymore for discovery of available special-purporse swapchains. The swapchains shipped with scenery are checked by default, custom swapchains can be added via `VulkanRenderer.registerSwapchain()`
* InputHandler is not using ClassGraph anymore for the discovery of available InputHandlers. The InputHandlers shipped with scenery are available by default, custom InputHandlers can be added via `InputHandler.registerInputHandler()`

On my machine, this improves the startup time of `TexturedCubeExample` from 5s to 1.8s, and the memory usage from around 900 MiB to 250MiB.