### PR TITLE
this allows to add mavenLocal by CLI

### DIFF
--- a/gradle/mavenLocal.init.gradle.kts
+++ b/gradle/mavenLocal.init.gradle.kts
@@ -1,0 +1,5 @@
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}


### PR DESCRIPTION
More https://docs.gradle.org/current/userguide/init_scripts.html

Essentially, run it with `-I ./gradle/mavenLocal.init.gradle.kts` and mavenLocal will be add for the current command

@ctrueden 