### PR TITLE
Volume Scene Graph Visibility Fix

### DIFF
--- a/src/main/resources/graphics/scenery/volumes/AccumulateBlockVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/AccumulateBlockVolume.frag
@@ -1,3 +1,8 @@
+// sceneGraphVisibility should be in main BDVVolume.frag but doing per
+// volume uniforms there is wonky and doing them here in a shader segment works better
+uniform int sceneGraphVisibility;
+
+vis = vis && bool(sceneGraphVisibility);
 if (vis)
 {
     vec4 x = sampleVolume(wpos, volumeCache, cacheSize, blockSize, paddedBlockSize, cachePadOffset);

--- a/src/main/resources/graphics/scenery/volumes/AccumulateSimpleVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/AccumulateSimpleVolume.frag
@@ -1,3 +1,8 @@
+// sceneGraphVisibility should be in main BDVVolume.frag but doing per
+// volume uniforms there is wonky and doing them here in a shader segment works better
+uniform int sceneGraphVisibility;
+
+vis = vis && bool(sceneGraphVisibility);
 if (vis)
 {
     vec4 x = sampleVolume(wpos);


### PR DESCRIPTION
VolumeManager, AccumulateBlockVolume.frag, AccumulateSimpleVolume.frag: Respect Volume visibilty of the volume node.

Add sceneGraphVisibility per volume shader uniform. Should solve https://github.com/scenerygraphics/sciview/issues/422