### PR TITLE
Revert bigvolumeviewer to official version and remove deprecated APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ dependencies {
 
     api("sc.fiji:bigdataviewer-core:10.4.1")
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
-    api("sc.fiji:bigvolumeviewer:0.3.0") {
+    api("sc.fiji:bigvolumeviewer:0.3.1") {
         exclude("org.jogamp.gluegen", "gluegen-rt")
         exclude("org.jogamp.jogl", "jogl-all")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.scijava.org/content/groups/public")
-    maven("https://jitpack.io")
+//    maven("https://jitpack.io")
 //    mavenLocal()
 }
 
@@ -100,11 +100,9 @@ dependencies {
 
     api("sc.fiji:bigdataviewer-core:10.4.1")
     api("sc.fiji:bigdataviewer-vistools:1.0.0-beta-28")
-
-    //TODO revert to official BVV
-    api("graphics.scenery:bigvolumeviewer:7698a01") {
-        exclude("org.jogamp.gluegen", "gluegen-rt-main")
-        exclude("org.jogamp.jogl", "jogl-all-main")
+    api("sc.fiji:bigvolumeviewer:0.3.0") {
+        exclude("org.jogamp.gluegen", "gluegen-rt")
+        exclude("org.jogamp.jogl", "jogl-all")
     }
 
     implementation("com.github.skalarproduktraum:lwjgl3-awt:d7a7369")
@@ -197,9 +195,6 @@ tasks {
             parent.appendNode("relativePath")
 
             val repositories = asNode().appendNode("repositories")
-            val jitpackRepo = repositories.appendNode("repository")
-            jitpackRepo.appendNode("id", "jitpack.io")
-            jitpackRepo.appendNode("url", "https://jitpack.io")
 
             val scijavaRepo = repositories.appendNode("repository")
             scijavaRepo.appendNode("id", "scijava.public")

--- a/src/main/kotlin/graphics/scenery/volumes/BufferedSimpleStack3D.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/BufferedSimpleStack3D.kt
@@ -1,9 +1,9 @@
 package graphics.scenery.volumes
 
+import bvv.core.multires.SimpleStack3D
 import java.nio.ByteBuffer
 import net.imglib2.RandomAccessibleInterval
 import net.imglib2.realtransform.AffineTransform3D
-import tpietzsch.multires.SimpleStack3D
 
 open class BufferedSimpleStack3D<T>(internal val backingBuffer : ByteBuffer, internal val type : T, val dimensions : IntArray) : SimpleStack3D<T> {
 

--- a/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.volumes
 
 import bdv.tools.transformation.TransformedSource
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.Hub
 import graphics.scenery.OrientedBoundingBox
 import graphics.scenery.utils.extensions.minus
@@ -12,7 +13,6 @@ import net.imglib2.type.numeric.real.FloatType
 import org.joml.Vector3f
 import org.joml.Vector3i
 import org.lwjgl.system.MemoryUtil
-import tpietzsch.example2.VolumeViewerOptions
 import java.nio.ByteBuffer
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.math.floor

--- a/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
@@ -2,6 +2,7 @@ package graphics.scenery.volumes
 
 import bdv.tools.brightness.ConverterSetup
 import bdv.viewer.SourceAndConverter
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.Hub
 import graphics.scenery.OrientedBoundingBox
 import graphics.scenery.Origin
@@ -11,7 +12,6 @@ import net.imglib2.type.numeric.integer.UnsignedByteType
 import org.joml.Matrix4f
 import org.joml.Vector3f
 import org.joml.Vector3i
-import tpietzsch.example2.VolumeViewerOptions
 
 class RAIVolume(@Transient val ds: VolumeDataSource, options: VolumeViewerOptions, hub: Hub): Volume(
     ds,

--- a/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/SceneryContext.kt
@@ -1,5 +1,10 @@
 package graphics.scenery.volumes
 
+import bvv.core.backend.*
+import bvv.core.backend.Texture as BVVTexture
+import bvv.core.cache.TextureCache
+import bvv.core.render.LookupTextureARGB
+import bvv.core.shadergen.Shader
 import graphics.scenery.textures.Texture
 import graphics.scenery.textures.Texture.BorderColor
 import graphics.scenery.textures.UpdatableTexture.TextureExtents
@@ -14,17 +19,12 @@ import net.imglib2.type.numeric.integer.UnsignedShortType
 import net.imglib2.type.numeric.real.FloatType
 import org.joml.*
 import org.lwjgl.system.MemoryUtil
-import tpietzsch.backend.*
-import tpietzsch.cache.TextureCache
-import tpietzsch.example2.LookupTextureARGB
-import tpietzsch.shadergen.Shader
 import java.nio.Buffer
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.FloatBuffer
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.ExperimentalTime
-import tpietzsch.backend.Texture as BVVTexture
 
 /**
  * Context class for interaction with BigDataViewer-generated shaders.

--- a/src/main/kotlin/graphics/scenery/volumes/SceneryStackManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/SceneryStackManager.kt
@@ -1,5 +1,9 @@
 package graphics.scenery.volumes
 
+import bvv.core.backend.GpuContext
+import bvv.core.backend.Texture3D
+import bvv.core.multires.SimpleStack3D
+import bvv.core.render.*
 import graphics.scenery.utils.lazyLogger
 import net.imglib2.RandomAccessibleInterval
 import net.imglib2.type.numeric.ARGBType
@@ -8,10 +12,6 @@ import net.imglib2.type.numeric.integer.UnsignedShortType
 import net.imglib2.util.Intervals
 import net.imglib2.view.Views
 import org.joml.Vector3f
-import tpietzsch.backend.GpuContext
-import tpietzsch.backend.Texture3D
-import tpietzsch.example2.*
-import tpietzsch.multires.SimpleStack3D
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.function.Consumer

--- a/src/main/kotlin/graphics/scenery/volumes/TransformedBufferedSimpleStack3D.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransformedBufferedSimpleStack3D.kt
@@ -1,10 +1,10 @@
 package graphics.scenery.volumes
 
+import bvv.core.multires.SimpleStack3D
 import graphics.scenery.Node
 import net.imglib2.RandomAccessibleInterval
 import net.imglib2.realtransform.AffineTransform3D
 import org.joml.Matrix4f
-import tpietzsch.multires.SimpleStack3D
 import java.nio.ByteBuffer
 
 /**

--- a/src/main/kotlin/graphics/scenery/volumes/TransformedMultiResolutionStack3D.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransformedMultiResolutionStack3D.kt
@@ -1,9 +1,9 @@
 package graphics.scenery.volumes
 
+import bvv.core.multires.MultiResolutionStack3D
+import bvv.core.multires.ResolutionLevel3D
 import net.imglib2.realtransform.AffineTransform3D
 import org.joml.Matrix4f
-import tpietzsch.multires.MultiResolutionStack3D
-import tpietzsch.multires.ResolutionLevel3D
 
 /**
  * Class for wrapping [MultiResolutionStack3D] [stack]s with custom transformations

--- a/src/main/kotlin/graphics/scenery/volumes/TransformedSimpleStack3D.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/TransformedSimpleStack3D.kt
@@ -1,10 +1,10 @@
 package graphics.scenery.volumes
 
+import bvv.core.multires.SimpleStack3D
 import graphics.scenery.Node
 import net.imglib2.RandomAccessibleInterval
 import net.imglib2.realtransform.AffineTransform3D
 import org.joml.Matrix4f
-import tpietzsch.multires.SimpleStack3D
 
 /**
  * Class for wrapping [SimpleStack3D] [stack]s with custom transformations

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -19,6 +19,7 @@ import bdv.viewer.DisplayMode
 import bdv.viewer.Source
 import bdv.viewer.SourceAndConverter
 import bdv.viewer.state.ViewerState
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.attribute.DelegationType
 import graphics.scenery.attribute.geometry.DelegatesGeometry
@@ -56,7 +57,6 @@ import org.joml.Vector3i
 import org.joml.Vector4f
 import org.lwjgl.system.MemoryUtil
 import org.scijava.io.location.FileLocation
-import tpietzsch.example2.VolumeViewerOptions
 import java.io.FileInputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeManager.kt
@@ -44,6 +44,7 @@ import java.nio.IntBuffer
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ForkJoinPool
+import java.util.function.BiConsumer
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.system.measureTimeMillis
@@ -462,13 +463,13 @@ class VolumeManager(
                 .forEachIndexed { i, state ->
                     val s = state.stack
                     currentProg.setConverter(i, state.converterSetup)
-                    currentProg.registerCustomSampler(i, "transferFunction", state.transferFunction)
-                    currentProg.registerCustomSampler(i, "colorMap", state.colorMap)
-                    currentProg.setCustomFloatArrayUniformForVolume(i, "slicingPlanes", 4, state.node.slicingArray())
-                    currentProg.setCustomUniformForVolume(i, "slicingMode", state.node.slicingMode.id)
-                    currentProg.setCustomUniformForVolume(i,"usedSlicingPlanes",
+                    currentProg.setUniform(i, "transferFunction", state.transferFunction)
+                    currentProg.setUniform(i, "colorMap", state.colorMap)
+                    currentProg.setUniform(i, "slicingPlanes", 4, state.node.slicingArray())
+                    currentProg.setUniform(i, "slicingMode", state.node.slicingMode.id)
+                    currentProg.setUniform(i,"usedSlicingPlanes",
                         min(state.node.slicingPlaneEquations.size, Volume.MAX_SUPPORTED_SLICING_PLANES))
-                    currentProg.setCustomUniformForVolume(i, "sceneGraphVisibility", if (state.node.visible) 1 else 0)
+                    currentProg.setUniform(i, "sceneGraphVisibility", if (state.node.visible) 1 else 0)
 
                     context.bindTexture(state.transferFunction)
                     context.bindTexture(state.colorMap)

--- a/src/main/kotlin/graphics/scenery/volumes/VolumeShaderFactory.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/VolumeShaderFactory.kt
@@ -1,7 +1,7 @@
 package graphics.scenery.volumes
 
+import bvv.core.shadergen.Shader
 import graphics.scenery.backends.*
-import tpietzsch.shadergen.Shader
 import kotlin.IllegalStateException
 import kotlin.math.max
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/advanced/VRVolumeCroppingExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/advanced/VRVolumeCroppingExample.kt
@@ -1,5 +1,6 @@
 package graphics.scenery.tests.examples.advanced
 
+import bvv.core.VolumeViewerOptions
 import bdv.util.AxisOrder
 import org.joml.Vector3f
 import graphics.scenery.*
@@ -20,7 +21,6 @@ import net.imglib2.img.Img
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.scijava.ui.behaviour.ClickBehaviour
-import tpietzsch.example2.VolumeViewerOptions
 import kotlin.concurrent.thread
 import kotlin.system.exitProcess
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/compute/CustomVolumeManagerExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/compute/CustomVolumeManagerExample.kt
@@ -1,6 +1,9 @@
 package graphics.scenery.tests.examples.compute
 
 import bdv.util.AxisOrder
+import bvv.core.VolumeViewerOptions
+import bvv.core.shadergen.generate.SegmentTemplate
+import bvv.core.shadergen.generate.SegmentType
 import org.joml.Vector3f
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
@@ -15,9 +18,6 @@ import net.imglib2.img.Img
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.lwjgl.system.MemoryUtil
-import tpietzsch.example2.VolumeViewerOptions
-import tpietzsch.shadergen.generate.SegmentTemplate
-import tpietzsch.shadergen.generate.SegmentType
 
 /**
  * Example showing using a custom [graphics.scenery.volumes.VolumeManager] with

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/BDVExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/BDVExample.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.tests.examples.volumes
 
 import bdv.spimdata.XmlIoSpimDataMinimal
+import bvv.core.VolumeViewerOptions
 import org.joml.Vector3f
 import graphics.scenery.Camera
 import graphics.scenery.DetachedHeadCamera
@@ -16,7 +17,6 @@ import org.scijava.Context
 import org.scijava.ui.UIService
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.widget.FileWidget
-import tpietzsch.example2.VolumeViewerOptions
 import java.io.File
 import java.util.*
 import kotlin.math.roundToInt

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/BigAndSmallVolumeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/BigAndSmallVolumeExample.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.tests.examples.volumes
 
 import bdv.spimdata.XmlIoSpimDataMinimal
+import bvv.core.VolumeViewerOptions
 import org.joml.Vector3f
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
@@ -12,7 +13,6 @@ import org.scijava.Context
 import org.scijava.ui.UIService
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.widget.FileWidget
-import tpietzsch.example2.VolumeViewerOptions
 import java.nio.ByteBuffer
 import java.util.*
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/NetworkVolumeExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/NetworkVolumeExample.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.tests.examples.volumes
 
 import bdv.util.AxisOrder
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.attribute.material.Material
 import graphics.scenery.backends.Renderer
@@ -14,7 +15,6 @@ import net.imglib2.img.Img
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.joml.Vector3f
-import tpietzsch.example2.VolumeViewerOptions
 import kotlin.concurrent.thread
 
 /**

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/OrthoViewExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/OrthoViewExample.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.tests.examples.volumes
 
 import bdv.util.AxisOrder
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
 import graphics.scenery.attribute.material.Material
@@ -11,7 +12,6 @@ import net.imglib2.img.Img
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.type.numeric.integer.UnsignedShortType
 import org.joml.Vector3f
-import tpietzsch.example2.VolumeViewerOptions
 
 /**
  * Volume Ortho View Example using the "BDV Rendering Example loading a RAII"

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/OutOfCoreRAIExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/OutOfCoreRAIExample.kt
@@ -2,6 +2,7 @@ package graphics.scenery.tests.examples.volumes
 
 import bdv.util.AxisOrder
 import bdv.util.volatiles.VolatileViews
+import bvv.core.VolumeViewerOptions
 import org.joml.Vector3f
 import graphics.scenery.Camera
 import graphics.scenery.DetachedHeadCamera
@@ -21,7 +22,6 @@ import org.janelia.saalfeldlab.n5.GzipCompression
 import org.janelia.saalfeldlab.n5.N5FSReader
 import org.janelia.saalfeldlab.n5.N5FSWriter
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils
-import tpietzsch.example2.VolumeViewerOptions
 import java.nio.file.Files
 
 

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/RAIExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/RAIExample.kt
@@ -1,6 +1,7 @@
 package graphics.scenery.tests.examples.volumes
 
 import bdv.util.AxisOrder
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import org.joml.Vector3f
 import graphics.scenery.backends.Renderer
@@ -12,7 +13,6 @@ import ij.ImagePlus
 import net.imglib2.img.Img
 import net.imglib2.img.display.imagej.ImageJFunctions
 import net.imglib2.type.numeric.integer.UnsignedShortType
-import tpietzsch.example2.VolumeViewerOptions
 
 /**
  * BDV Rendering Example loading a RAII

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
@@ -1,5 +1,6 @@
 package graphics.scenery.tests.examples.volumes
 
+import bvv.core.VolumeViewerOptions
 import graphics.scenery.*
 import graphics.scenery.backends.Renderer
 import graphics.scenery.ui.SwingBridgeFrame
@@ -12,7 +13,6 @@ import graphics.scenery.volumes.Volume
 import org.joml.Vector3f
 import org.scijava.ui.behaviour.ClickBehaviour
 import org.scijava.ui.behaviour.DragBehaviour
-import tpietzsch.example2.VolumeViewerOptions
 
 
 /**


### PR DESCRIPTION
This PR reverts to the official bigvolumeviewer, in version 0.3.1. Thanks @tpietzsch for merging our PRs and the new version, and thanks @ctrueden for the work on this PR 🥳 Fixes #385.