### PR TITLE
TransferFunctionEditor -Mig-Layout change to support dynamic resizes + Major BugFix

### DIFF
--- a/src/main/kotlin/graphics/scenery/ui/RangeSliderUI.kt
+++ b/src/main/kotlin/graphics/scenery/ui/RangeSliderUI.kt
@@ -42,7 +42,7 @@ THE SOFTWARE.
 class RangeSliderUI(b: RangeSlider?) : BasicSliderUI(b) {
 
     /** Color of selected range.  */
-    private val rangeColor = Color.GREEN
+    private val rangeColor = Color.DARK_GRAY
 
     /** Location and size of thumb for upper value.  */
     private var upperThumbRect: Rectangle? = null
@@ -251,9 +251,9 @@ class RangeSliderUI(b: RangeSlider?) : BasicSliderUI(b) {
             RenderingHints.VALUE_ANTIALIAS_ON
         )
         g2d.translate(knobBounds.x, knobBounds.y)
-        g2d.color = Color.CYAN
+        g2d.color = Color.GRAY
         g2d.fill(thumbShape)
-        g2d.color = Color.BLUE
+        g2d.color = Color.DARK_GRAY
         g2d.draw(thumbShape)
 
         // Dispose graphics.
@@ -280,9 +280,9 @@ class RangeSliderUI(b: RangeSlider?) : BasicSliderUI(b) {
             RenderingHints.VALUE_ANTIALIAS_ON
         )
         g2d.translate(knobBounds.x, knobBounds.y)
-        g2d.color = Color.PINK
+        g2d.color = Color.GRAY
         g2d.fill(thumbShape)
-        g2d.color = Color.RED
+        g2d.color = Color.DARK_GRAY
         g2d.draw(thumbShape)
 
         // Dispose graphics.

--- a/src/main/kotlin/graphics/scenery/ui/SwingBridgeFrame.kt
+++ b/src/main/kotlin/graphics/scenery/ui/SwingBridgeFrame.kt
@@ -3,10 +3,13 @@ package graphics.scenery.ui
 
 import graphics.scenery.utils.Image
 import java.awt.Component
+import java.awt.Dimension
+import java.awt.Panel
 import java.awt.event.*
 import java.awt.image.BufferedImage
 import java.nio.ByteBuffer
 import javax.swing.JFrame
+import javax.swing.JPanel
 import javax.swing.SwingUtilities
 
 /**
@@ -46,6 +49,16 @@ open class SwingBridgeFrame(title: String) : JFrame(title) {
             override fun keyTyped(e : KeyEvent?) {}
             override fun keyReleased(e : KeyEvent?) {}
         })
+    }
+
+    /**
+     * This add function wraps frame.add.
+     * It also packs the [panel] and makes it visible.
+     */
+    fun addPanel(panel: JPanel) {
+        this.add(panel)
+        this.pack()
+        this.isVisible = true
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/volumes/HasTransferFunction.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/HasTransferFunction.kt
@@ -10,4 +10,5 @@ interface HasTransferFunction {
     var transferFunction : TransferFunction
     var minDisplayRange : Float
     var maxDisplayRange : Float
+    var range: Pair<Float, Float>
 }

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
@@ -64,7 +64,7 @@ class TransferFunctionEditorExample : SceneryBase("TransferFunctionEditor Exampl
 
         val options = VolumeViewerOptions().maxCacheSizeInMB(maxCacheSize)
         //Currently only .xml volume formats are usable
-        val v = Volume.fromXML("../models/volumes/t1-head.xml", hub, options)
+        val v = Volume.fromXML(getDemoFilesPath() + "/volumes/t1-head.xml", hub, options)
         v.name = "t1-head"
         v.colormap = Colormap.get("grays")
         v.spatial().position = Vector3f(0.0f, 0.0f, 0.0f)

--- a/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/volumes/TransferFunctionEditorExample.kt
@@ -64,7 +64,7 @@ class TransferFunctionEditorExample : SceneryBase("TransferFunctionEditor Exampl
 
         val options = VolumeViewerOptions().maxCacheSizeInMB(maxCacheSize)
         //Currently only .xml volume formats are usable
-        val v = Volume.fromXML("models/volumes/t1-head.xml", hub, options)
+        val v = Volume.fromXML("../models/volumes/t1-head.xml", hub, options)
         v.name = "t1-head"
         v.colormap = Colormap.get("grays")
         v.spatial().position = Vector3f(0.0f, 0.0f, 0.0f)
@@ -75,9 +75,7 @@ class TransferFunctionEditorExample : SceneryBase("TransferFunctionEditor Exampl
 
         val bridge = SwingBridgeFrame("1DTransferFunctionEditor")
         val tfUI = TransferFunctionEditor(v)
-        bridge.add(tfUI)
-        bridge.pack()
-        bridge.isVisible = true
+        bridge.addPanel(tfUI)
         tfUI.name = v.name
         val swingUiNode = bridge.uiNode
         swingUiNode.spatial() {


### PR DESCRIPTION
This PR changes the Mig-Layout of the TransferFunctionEditor to support dynamic window resizes down to 0,0

There was also a major bug, where adding a control point, when the window size was smaller then the internal minimum chart draw size, results in a control point not at mouse-position. This bug was fixed by setting the minimum draw-sizes of the ChartPanel to 0.


Also: Refactored the panel adding to the SwingBridgeFrame, which now packs and sets visibility as well to simplify the API