### PR TITLE
Cylinder: Add top and bottom lids, make smooth shading optional

### DIFF
--- a/src/main/kotlin/graphics/scenery/primitives/Cylinder.kt
+++ b/src/main/kotlin/graphics/scenery/primitives/Cylinder.kt
@@ -3,12 +3,12 @@ package graphics.scenery.primitives
 import graphics.scenery.BufferUtils
 import graphics.scenery.Mesh
 import graphics.scenery.geometry.GeometryType
+import org.joml.Vector2f
 import org.joml.Vector3f
-import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
-import kotlin.math.sqrt
 
 /**
  * Constructs a cylinder with the given [radius] and number of [segments].
@@ -18,61 +18,93 @@ import kotlin.math.sqrt
  * @param[segments] Number of segments in latitude and longitude.
  */
 
-class Cylinder(var radius: Float, var height: Float, var segments: Int) : Mesh("cylinder") {
+class Cylinder(var radius: Float, var height: Float, var segments: Int, fillCaps: Boolean = false, smoothSides: Boolean = false) : Mesh("cylinder") {
     init {
         geometry {
-            geometryType = GeometryType.TRIANGLE_STRIP
+            geometryType = GeometryType.TRIANGLES
 
-            val vbuffer = ArrayList<Float>(segments * segments * 2 * 3)
-            val nbuffer = ArrayList<Float>(segments * segments * 2 * 3)
-            val tbuffer = ArrayList<Float>(segments * segments * 2 * 2)
+            val vBuffer = ArrayList<Float>(segments * 12) // 12 = number of vertices per segment
+            val nBuffer = ArrayList<Float>(segments * 12)
+            val tBuffer = ArrayList<Float>(segments * 12)
 
             val delta = 2.0f * PI.toFloat() / segments.toFloat()
-            val c = cos(delta * 1.0).toFloat()
-            val s = sin(delta * 1.0).toFloat()
 
-            var x2 = radius
-            var z2 = 0.0f
+            val vTop = Vector3f(0f, height, 0f)
+            val vBottom = Vector3f(0f, 0f, 0f)
 
-            for (i: Int in 0..segments) {
+            for (i: Int in 0..segments-1) {
+                val theta = i * delta
+                val theta1 = (i + 1) * delta
                 val texcoord = i / segments.toFloat()
-                val normal = 1.0f / sqrt(x2 * x2 * 1.0 + z2 * z2 * 1.0).toFloat()
-                val xn = x2 * normal
-                val zn = z2 * normal
+                val texcoord1 = (i + 1) / segments.toFloat()
+                val x = radius * cos(theta)
+                val x1 = radius * cos(theta1)
+                val z = radius * sin(theta)
+                val z1 = radius * sin(theta1)
 
-                nbuffer.add(xn)
-                nbuffer.add(0.0f)
-                nbuffer.add(zn)
+                // 4 vertices per segment
+                val v1 = Vector3f(x, 0f, z)
+                val v2 = Vector3f(x1, 0f, z1)
+                val v3 = Vector3f(x1, height, z1)
+                val v4 = Vector3f(x, height, z)
 
-                tbuffer.add(texcoord)
-                tbuffer.add(0.0f)
+                val n1 = Vector3f(x, 0f, z).normalize()
+                val n2 = if (smoothSides) Vector3f(x1, 0f, z1).normalize() else n1
+                val nTop = Vector3f(0f, 1f, 0f)
+                val nBottom = Vector3f(0f, -1f, 0f)
 
-                vbuffer.add(0.0f + x2)
-                vbuffer.add(0.0f)
-                vbuffer.add(0.0f + z2)
+                val t1 = Vector2f(texcoord, 0f)
+                val t2 = Vector2f(texcoord1, 0f)
+                val t3 = Vector2f(texcoord1, 1f)
+                val t4 = Vector2f(texcoord, 1f)
+                val tCenter = Vector2f((texcoord+texcoord1)/2, 1f)
 
-                nbuffer.add(xn)
-                nbuffer.add(0.0f)
-                nbuffer.add(zn)
+                // Face 1
+                putAll(vBuffer, v1, v4, v3)
+                putAll(nBuffer, n1, n1, n2)
+                putAll(tBuffer, t1, t4, t3)
 
-                tbuffer.add(texcoord)
-                tbuffer.add(1.0f)
+                // Face 2
+                putAll(vBuffer, v1, v3, v2)
+                putAll(nBuffer, n1, n2, n2)
+                putAll(tBuffer, t1, t3, t2)
 
-                vbuffer.add(0.0f + x2)
-                vbuffer.add(0.0f + height)
-                vbuffer.add(0.0f + z2)
+                if (fillCaps) {
+                    // Face top
+                    putAll(vBuffer, v4, vTop, v3)
+                    putAll(nBuffer, nTop, nTop, nTop)
+                    putAll(tBuffer, t1, tCenter, t2)
 
-                val x3 = x2
-                x2 = c * x2 - s * z2
-                z2 = s * x3 + c * z2
+                    // Face bottom
+                    putAll(vBuffer, v2, vBottom, v1)
+                    putAll(nBuffer, nBottom, nBottom, nBottom)
+                    putAll(tBuffer, t2, tCenter, t1)
+                }
             }
 
-            vertices = BufferUtils.allocateFloatAndPut(vbuffer.toFloatArray())
-            normals = BufferUtils.allocateFloatAndPut(nbuffer.toFloatArray())
-            texcoords = BufferUtils.allocateFloatAndPut(tbuffer.toFloatArray())
+            vertices = BufferUtils.allocateFloatAndPut(vBuffer.toFloatArray())
+            normals = BufferUtils.allocateFloatAndPut(nBuffer.toFloatArray())
+            texcoords = BufferUtils.allocateFloatAndPut(tBuffer.toFloatArray())
         }
 
         boundingBox = generateBoundingBox()
+    }
+
+    // add 3D coordinates to buffer
+    private fun putAll(buffer: ArrayList<Float>, vararg vectors: Vector3f) {
+        for (v in vectors) {
+            buffer.add(v.x)
+            buffer.add(v.y)
+            buffer.add(v.z)
+        }
+    }
+
+    // add 2D coordinates to buffer
+    private fun putAll(buffer: ArrayList<Float>, vararg vectors: Vector2f) {
+        for (v in vectors) {
+            buffer.add(v.x)
+            buffer.add(v.y)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/graphics/scenery/primitives/Cylinder.kt
+++ b/src/main/kotlin/graphics/scenery/primitives/Cylinder.kt
@@ -18,7 +18,7 @@ import kotlin.math.sin
  * @param[segments] Number of segments in latitude and longitude.
  */
 
-class Cylinder(var radius: Float, var height: Float, var segments: Int, fillCaps: Boolean = false, smoothSides: Boolean = false) : Mesh("cylinder") {
+open class Cylinder @JvmOverloads constructor(var radius: Float, var height: Float, var segments: Int, fillCaps: Boolean = false, smoothSides: Boolean = false) : Mesh("cylinder") {
     init {
         geometry {
             geometryType = GeometryType.TRIANGLES
@@ -32,7 +32,7 @@ class Cylinder(var radius: Float, var height: Float, var segments: Int, fillCaps
             val vTop = Vector3f(0f, height, 0f)
             val vBottom = Vector3f(0f, 0f, 0f)
 
-            for (i: Int in 0..segments-1) {
+            for (i: Int in 0 until segments) {
                 val theta = i * delta
                 val theta1 = (i + 1) * delta
                 val texcoord = i / segments.toFloat()

--- a/src/test/kotlin/graphics/scenery/tests/unit/VolumeMeasuererTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/VolumeMeasuererTests.kt
@@ -30,6 +30,6 @@ class VolumeMeasurerTests {
     fun testVolumeCylinder() {
         val c = Cylinder(2f, 10f, 5)
         val volume = VolumeMeasurer().calculateVolume(c)
-        assertEquals(volume, 63.40377712249756)
+        assertEquals(volume, 63.40377712249756, absoluteTolerance = 0.00001)
     }
 }

--- a/src/test/kotlin/graphics/scenery/tests/unit/VolumeMeasuererTests.kt
+++ b/src/test/kotlin/graphics/scenery/tests/unit/VolumeMeasuererTests.kt
@@ -20,7 +20,7 @@ class VolumeMeasurerTests {
     fun testVolumeSphere() {
         val s = Icosphere(2f, 2)
         val volume = VolumeMeasurer().calculateVolume(s)
-        assertEquals(volume, 32.376359045505524)
+        assertEquals(volume, 32.376, absoluteTolerance = 0.001)
     }
 
     /**
@@ -30,6 +30,6 @@ class VolumeMeasurerTests {
     fun testVolumeCylinder() {
         val c = Cylinder(2f, 10f, 5)
         val volume = VolumeMeasurer().calculateVolume(c)
-        assertEquals(volume, 63.40377712249756, absoluteTolerance = 0.00001)
+        assertEquals(volume, 63.404, absoluteTolerance = 0.001)
     }
 }


### PR DESCRIPTION
Fixes #556 

Refactors the code to work with geometryType Triangles instead of Triangle_Strip to support fan-like face structure of top and bottom caps, default is off (can be turned on with `fillCaps=true`). Normal interpolation can be turned on by passing the attribute `smoothSides`, default is false.

Flat shading with filled caps:
<img width="461" alt="Screenshot 2023-06-20 100418" src="https://github.com/scenerygraphics/scenery/assets/83579186/902dabda-0dc9-44d2-9320-b0edd6be1132">

Smooth shading & texture mapping:
<img width="382" alt="Screenshot 2023-06-20 104840" src="https://github.com/scenerygraphics/scenery/assets/83579186/7156dbfb-100d-4535-9cc1-482cea2a1051">
