### PR TITLE
CI: Adjust pagefile size on Windows to avoid unnecessary noise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build scenery
-        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --no-daemon
 
   windows-unittests:
     name: 'Windows'
@@ -63,7 +63,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Build scenery
-        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --no-daemon
 
   mac-unittests:
     name: 'macOS'
@@ -89,4 +89,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build scenery
-        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --info --no-daemon
+        run: ./gradlew build -x dokkaHtml -x dokkaHtmlJar -x javadoc -x dokkaJavadocJar --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
+      - name: configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 8GB
+          maximum-size: 32GB
+          disk-root: "D:"
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/buildSrc/src/main/kotlin/scenery/base.gradle.kts
+++ b/buildSrc/src/main/kotlin/scenery/base.gradle.kts
@@ -11,6 +11,17 @@ tasks {
 
     // https://docs.gradle.org/current/userguide/java_testing.html#test_filtering
     test {
+        testLogging {
+            events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+
+            showExceptions = true
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showStackTraces = true
+
+            showStandardStreams = false
+        }
+
         if(JavaVersion.current() > JavaVersion.VERSION_11) {
             allJvmArgs = allJvmArgs + listOf(
                 // kryo compatability


### PR DESCRIPTION
This PR adjusts the pagefile size on the Github Actions Windows runners, to avoid random out-of-memory errors for memory-intensive unit tests.