### PR TITLE
REPL: Fix issue where startup script would not be executed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
     implementation("org.scijava:scijava-common")
     implementation("org.scijava:script-editor")
     implementation("org.scijava:ui-behaviour")
-    implementation("org.scijava:scripting-javascript")
     implementation("org.scijava:scripting-jython")
     implementation("net.java.dev.jna:jna-platform:5.11.0")
 

--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -381,6 +381,7 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
             if(wantREPL) {
                 inputHandler?.addBehaviour("show_repl", ClickBehaviour { _, _ ->
                     repl = REPL(hub, scijavaContext, scene, stats, hub)
+                    repl?.start()
                     repl?.addAccessibleObject(settings)
                     repl?.addAccessibleObject(inputHandler!!)
                     repl?.addAccessibleObject(it)

--- a/src/main/kotlin/graphics/scenery/repl/REPL.kt
+++ b/src/main/kotlin/graphics/scenery/repl/REPL.kt
@@ -97,7 +97,6 @@ class REPL @JvmOverloads constructor(override var hub : Hub?, scijavaContext: Co
      * Launches the REPL and evaluates any set startup code.
      */
     fun start() {
-        repl?.lang("Python (Jython)")
         eval(startupScriptCode)
     }
 


### PR DESCRIPTION
This PR fixes an issue where the REPL's startup code would not be executed when the REPL is first shown. It also removes the dependency on the Nashorn-based JavaScript interpreter, as it's not used in scenery anymore, and deprecated in OpenJDK.