### PR TITLE
Gradle: Bump lwjgl to 3.3.2 and lwjgl3-awt to official repo version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,12 @@ dependencies {
         exclude("org.jogamp.jogl", "jogl-all")
     }
 
-    implementation("com.github.skalarproduktraum:lwjgl3-awt:d7a7369")
+    implementation("com.github.lwjglx:lwjgl3-awt:bc8daf5") {
+        // we exclude the LWJGL binaries here, as the lwjgl3-awt POM uses
+        // Maven properties for natives, which is not supported by Gradle
+        exclude("org.lwjgl", "lwjgl-bom")
+        exclude("org.lwjgl", "lwjgl")
+    }
     implementation("org.janelia.saalfeldlab:n5")
     implementation("org.janelia.saalfeldlab:n5-imglib2")
     listOf("core", "structure", "modfinder").forEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@ org.gradle.caching=true
 kotlinVersion=1.9.0
 dokkaVersion=1.8.20
 scijavaParentPOMVersion=35.1.1
-lwjglVersion=3.3.1
+lwjglVersion=3.3.2
 jvmTarget=11
 


### PR DESCRIPTION
This PR bumps lwjgl and lwjgl3-awt to the latest official versions.