### PR TITLE
Finer-grained intersection testing for Nodes

### DIFF
--- a/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
+++ b/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
@@ -3,6 +3,7 @@ package graphics.scenery
 import graphics.scenery.utils.extensions.minus
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
+import org.joml.Intersectionf
 import org.joml.Vector3f
 import java.lang.Math.max
 import java.lang.Math.min
@@ -30,6 +31,21 @@ open class OrientedBoundingBox(val n: Node, val min: Vector3f, val max: Vector3f
      */
     constructor(n: Node, boundingBox: FloatArray) : this(n, Vector3f(boundingBox[0], boundingBox[2], boundingBox[4]), Vector3f(boundingBox[1], boundingBox[3], boundingBox[5]))
 
+    val center: Vector3f
+        get() {
+            val worldMin = n.spatialOrNull()!!.worldPosition(min)
+            val worldMax = n.spatialOrNull()!!.worldPosition(max)
+
+            return worldMin + (worldMax - worldMin) * 0.5f
+        }
+
+    val halfSize: Vector3f
+        get() {
+            return (max - min) * 0.5f
+        }
+
+
+
     /**
      * Returns the maximum bounding sphere of this bounding box.
      */
@@ -55,8 +71,24 @@ open class OrientedBoundingBox(val n: Node, val min: Vector3f, val max: Vector3f
      * Checks this [OrientedBoundingBox] for intersection with [other], and returns
      * true if the bounding boxes do intersect.
      */
-    fun intersects(other: OrientedBoundingBox): Boolean {
-        return other.getBoundingSphere().radius + getBoundingSphere().radius > (other.getBoundingSphere().origin - getBoundingSphere().origin).length()
+    @JvmOverloads
+    fun intersects(other: OrientedBoundingBox, fine: Boolean = false): Boolean {
+        return if(fine) {
+            Intersectionf.testObOb(
+                this.center,
+                this.n.spatialOrNull()!!.localX,
+                this.n.spatialOrNull()!!.localY,
+                this.n.spatialOrNull()!!.localZ,
+                this.halfSize,
+                other.center,
+                other.n.spatialOrNull()!!.localX,
+                other.n.spatialOrNull()!!.localY,
+                other.n.spatialOrNull()!!.localZ,
+                other.halfSize
+            )
+        } else {
+            other.getBoundingSphere().radius + getBoundingSphere().radius > (other.getBoundingSphere().origin - getBoundingSphere().origin).length()
+        }
     }
 
     /**

--- a/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
+++ b/src/main/kotlin/graphics/scenery/OrientedBoundingBox.kt
@@ -70,10 +70,13 @@ open class OrientedBoundingBox(val n: Node, val min: Vector3f, val max: Vector3f
     /**
      * Checks this [OrientedBoundingBox] for intersection with [other], and returns
      * true if the bounding boxes do intersect.
+     *
+     * If [precise] is true, the intersection test will be performed using oriented bounding boxes (OBBs),
+     * otherwise, a faster, but less precise bounding sphere test is performed.
      */
     @JvmOverloads
-    fun intersects(other: OrientedBoundingBox, fine: Boolean = false): Boolean {
-        return if(fine) {
+    fun intersects(other: OrientedBoundingBox, precise: Boolean = false): Boolean {
+        return if(precise) {
             Intersectionf.testObOb(
                 this.center,
                 this.n.spatialOrNull()!!.localX,

--- a/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
@@ -51,6 +51,28 @@ open class DefaultSpatial(@Transient protected var node: Node = DefaultNode()) :
             propertyChanged(::position, field, value)
             field = value
         }
+
+    /** Local X vector */
+    override val localX: Vector3f
+        get() {
+            val v = Vector3f(1.0f, 0.0f, 0.0f)
+            return world.transformDirection(v).normalize()
+        }
+
+    /** Local Y vector */
+    override val localY: Vector3f
+        get() {
+            val v = Vector3f(0.0f, 1.0f, 0.0f)
+            return world.transformDirection(v).normalize()
+        }
+
+    /** Local Z vector */
+    override val localZ: Vector3f
+        get() {
+            val v = Vector3f(0.0f, 0.0f, 1.0f)
+            return world.transformDirection(v).normalize()
+        }
+
     override var wantsComposeModel = true
     @Transient override var needsUpdate = true
     @Transient override var needsUpdateWorld = true
@@ -199,10 +221,10 @@ open class DefaultSpatial(@Transient protected var node: Node = DefaultNode()) :
     }
 
 
-    override fun intersects(other: Node): Boolean {
+    override fun intersects(other: Node, fine: Boolean): Boolean {
         node.boundingBox?.let { ownOBB ->
             other.boundingBox?.let { otherOBB ->
-                return ownOBB.intersects(otherOBB)
+                return ownOBB.intersects(otherOBB, fine)
             }
         }
 

--- a/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/DefaultSpatial.kt
@@ -221,10 +221,17 @@ open class DefaultSpatial(@Transient protected var node: Node = DefaultNode()) :
     }
 
 
-    override fun intersects(other: Node, fine: Boolean): Boolean {
+    /**
+     * Checks whether this node's bounding box intersects the one of [other] using a simple bounding sphere test.
+     * If [precise] is true, the intersection test will be performed using oriented bounding boxes (OBBs),
+     * otherwise, a faster, but less precise bounding sphere test is performed.
+     *
+     * If any of the nodes to test do not have a bounding box defined, the result will be false.
+     */
+    override fun intersects(other: Node, precise: Boolean): Boolean {
         node.boundingBox?.let { ownOBB ->
             other.boundingBox?.let { otherOBB ->
-                return ownOBB.intersects(otherOBB, fine)
+                return ownOBB.intersects(otherOBB, precise)
             }
         }
 

--- a/src/main/kotlin/graphics/scenery/attribute/spatial/Spatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/Spatial.kt
@@ -78,9 +78,11 @@ interface Spatial: RealLocalizable, RealPositionable, Networkable {
     fun worldPosition(v: Vector3f? = null): Vector3f
 
     /**
-     * Checks whether two node's bounding boxes do intersect using a simple bounding sphere test.
+     * Checks whether this node's bounding box intersects the one of [other] using a simple bounding sphere test.
+     * If [precise] is true, the intersection test will be performed using oriented bounding boxes (OBBs),
+     * otherwise, a faster, but less precise bounding sphere test is performed.
      */
-    fun intersects(other: Node, fine: Boolean = false): Boolean
+    fun intersects(other: Node, precise: Boolean = false): Boolean
 
     /**
      * Fits the [Node] within a box of the given dimension.

--- a/src/main/kotlin/graphics/scenery/attribute/spatial/Spatial.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/spatial/Spatial.kt
@@ -32,6 +32,13 @@ interface Spatial: RealLocalizable, RealPositionable, Networkable {
     /** Stores whether the [world] matrix needs an update. */
     var needsUpdateWorld: Boolean
 
+    /** Local X vector */
+    val localX: Vector3f
+    /** Local Y vector */
+    val localY: Vector3f
+    /** Local Z vector */
+    val localZ: Vector3f
+
     /**
      * Update the the [world] matrix of the [Spatial] node.
      *
@@ -73,7 +80,7 @@ interface Spatial: RealLocalizable, RealPositionable, Networkable {
     /**
      * Checks whether two node's bounding boxes do intersect using a simple bounding sphere test.
      */
-    fun intersects(other: Node): Boolean
+    fun intersects(other: Node, fine: Boolean = false): Boolean
 
     /**
      * Fits the [Node] within a box of the given dimension.

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/IntersectionExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/IntersectionExample.kt
@@ -27,22 +27,21 @@ class IntersectionExample: SceneryBase("IntersectionExample") {
             metallic = 1.0f
         }
 
-//        val box = Box(Random.random3DVectorFromRange(0.1f, 1.0f))
-        val box = Icosphere(1.0f, 2)
-//        val box = Box()
-        box.name = "le box du win"
+        val sphere = Icosphere(0.5f, 2)
+        sphere.name = "le box du win"
 
-//        val box2 = Box()
         val box2 = Box(Random.random3DVectorFromRange(0.1f, 1.0f))
 
-        with(box) {
-            box.addAttribute(Material::class.java, boxmaterial)
+        with(sphere) {
+            sphere.addAttribute(Material::class.java, boxmaterial)
             scene.addChild(this)
         }
 
         with(box2) {
             spatial {
-                position = Vector3f(-1.5f, 0.0f, 0.0f)
+                // shift box2 such that it'll always slightly intersect the sphere
+                val shift = -1.0f * (box2.boundingBox?.getBoundingSphere()?.radius ?: 0.5f) * 0.9f
+                position = Vector3f(shift, 0.0f, 0.0f)
             }
             box2.addAttribute(Material::class.java,  boxmaterial)
             scene.addChild(this)
@@ -71,10 +70,10 @@ class IntersectionExample: SceneryBase("IntersectionExample") {
         thread {
             val aa = AxisAngle4f(0.1f, Random.random3DVectorFromRange(0.2f, 0.8f).normalize())
             while (true) {
-                if (box.spatial().intersects(box2, true)) {
-                    box.material().diffuse = Vector3f(1.0f, 0.0f, 0.0f)
+                if (sphere.spatial().intersects(box2, true)) {
+                    sphere.material().diffuse = Vector3f(1.0f, 0.0f, 0.0f)
                 } else {
-                    box.material().diffuse = Vector3f(0.0f, 1.0f, 0.0f)
+                    sphere.material().diffuse = Vector3f(0.0f, 1.0f, 0.0f)
                 }
 
                 aa.angle += 0.01f

--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/IntersectionExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/IntersectionExample.kt
@@ -5,6 +5,8 @@ import graphics.scenery.*
 import graphics.scenery.backends.Renderer
 import graphics.scenery.attribute.material.DefaultMaterial
 import graphics.scenery.attribute.material.Material
+import graphics.scenery.numerics.Random
+import org.joml.AxisAngle4f
 import kotlin.concurrent.thread
 
 /**
@@ -25,10 +27,13 @@ class IntersectionExample: SceneryBase("IntersectionExample") {
             metallic = 1.0f
         }
 
-        val box = Box(Vector3f(1.0f, 1.0f, 1.0f))
+//        val box = Box(Random.random3DVectorFromRange(0.1f, 1.0f))
+        val box = Icosphere(1.0f, 2)
+//        val box = Box()
         box.name = "le box du win"
 
-        val box2 = Box(Vector3f(1.0f, 1.0f, 1.0f))
+//        val box2 = Box()
+        val box2 = Box(Random.random3DVectorFromRange(0.1f, 1.0f))
 
         with(box) {
             box.addAttribute(Material::class.java, boxmaterial)
@@ -50,6 +55,9 @@ class IntersectionExample: SceneryBase("IntersectionExample") {
         light.emissionColor = Vector3f(1.0f, 1.0f, 1.0f)
         scene.addChild(light)
 
+        val ambientLight = AmbientLight(0.1f)
+        scene.addChild(ambientLight)
+
         val cam: Camera = DetachedHeadCamera()
         with(cam) {
             spatial {
@@ -61,12 +69,16 @@ class IntersectionExample: SceneryBase("IntersectionExample") {
         }
 
         thread {
+            val aa = AxisAngle4f(0.1f, Random.random3DVectorFromRange(0.2f, 0.8f).normalize())
             while (true) {
-                if (box.spatial().intersects(box2)) {
+                if (box.spatial().intersects(box2, true)) {
                     box.material().diffuse = Vector3f(1.0f, 0.0f, 0.0f)
                 } else {
                     box.material().diffuse = Vector3f(0.0f, 1.0f, 0.0f)
                 }
+
+                aa.angle += 0.01f
+                box2.spatial().rotation = box2.spatial().rotation.rotationAxis(aa)
 
                 Thread.sleep(20)
             }


### PR DESCRIPTION
This PR extends the `intersects()` method to perform actual oriented bounding box tests, not just bounding sphere tests, as currently performed.

https://github.com/scenerygraphics/scenery/assets/586495/4fc7c125-7110-4e69-99c9-d5cabb7bc79f


https://github.com/scenerygraphics/scenery/assets/586495/5ee394f9-854d-47fb-8d50-53057b7c85bb

