### PR TITLE
VulkanDevice: Fix descriptor pool allocation

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanDevice.kt
@@ -362,13 +362,27 @@ open class VulkanDevice(
         vkDestroySemaphore(this.vulkanDevice, semaphore, null)
     }
 
-    data class DescriptorPool(val handle: Long, var free: Int = maxTextures + maxUBOs + maxInputAttachments + maxUBOs) {
+    data class DescriptorPool(
+        val handle: Long,
+        var free: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(
+            mutableMapOf(
+                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER to maxUBOs,
+                VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC to maxUBOs,
+                VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT to maxInputAttachments,
+                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER to maxTextures,
+                VK_DESCRIPTOR_TYPE_STORAGE_IMAGE to maxTextures)
+        )
+    ) {
 
         companion object {
             val maxTextures = 2048 * 16
             val maxUBOs = 2048
             val maxInputAttachments = 32
             val maxSets = maxUBOs * 2 + maxInputAttachments + maxTextures
+        }
+
+        fun decreaseAvailable(type: Int, by: Int = 1) {
+            free[type] = free[type]!! - by
         }
     }
 
@@ -409,7 +423,7 @@ open class VulkanDevice(
             val handle = VU.getLong("vkCreateDescriptorPool",
                 { vkCreateDescriptorPool(vulkanDevice, descriptorPoolInfo, null, this) }, {})
 
-            DescriptorPool(handle, maxSets)
+            DescriptorPool(handle)
         }
     }
 
@@ -422,8 +436,8 @@ open class VulkanDevice(
         ubo: VulkanUBO.UBODescriptor,
         type: Int = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
     ): Long {
-        val pool = findAvailableDescriptorPool()
-        pool.free -= 1
+        val pool = findAvailableDescriptorPool(type)
+        pool.decreaseAvailable(type, 1)
 
         logger.debug("Creating descriptor set with $bindingCount bindings, DSL=$descriptorSetLayout")
         return stackPush().use { stack ->
@@ -432,7 +446,7 @@ open class VulkanDevice(
             val allocInfo = VkDescriptorSetAllocateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)
                 .pNext(MemoryUtil.NULL)
-                .descriptorPool(findAvailableDescriptorPool().handle)
+                .descriptorPool(pool.handle)
                 .pSetLayouts(pDescriptorSetLayout)
 
             val descriptorSet = VU.getLong("createDescriptorSet",
@@ -472,8 +486,8 @@ open class VulkanDevice(
         buffer: VulkanBuffer,
         size: Long = 2048L
     ): Long {
-        val pool = findAvailableDescriptorPool()
-        pool.free -= 1
+        val pool = findAvailableDescriptorPool(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)
+        pool.decreaseAvailable(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1)
 
         logger.debug("Creating dynamic descriptor set with $bindingCount bindings, DSL=${descriptorSetLayout.toHexString()}")
 
@@ -483,7 +497,7 @@ open class VulkanDevice(
             val allocInfo = VkDescriptorSetAllocateInfo.calloc()
                 .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)
                 .pNext(MemoryUtil.NULL)
-                .descriptorPool(findAvailableDescriptorPool().handle)
+                .descriptorPool(pool.handle)
                 .pSetLayouts(pDescriptorSetLayout)
 
             val descriptorSet = VU.getLong("createDescriptorSet",
@@ -634,8 +648,6 @@ open class VulkanDevice(
         imageLoadStore: Boolean = false,
         onlyFor: List<VulkanFramebuffer.VulkanFramebufferAttachment>? = null
     ): Long {
-        val pool = findAvailableDescriptorPool()
-        pool.free -= 1
 
         return stackPush().use { stack ->
             val (type, layout) = if (!imageLoadStore) {
@@ -644,12 +656,15 @@ open class VulkanDevice(
                 VK_DESCRIPTOR_TYPE_STORAGE_IMAGE to VK_IMAGE_LAYOUT_GENERAL
             }
 
+            val pool = findAvailableDescriptorPool(type)
+            pool.decreaseAvailable(type)
+
             val pDescriptorSetLayout = stack.callocLong(1).put(0, descriptorSetLayout)
 
             val allocInfo = VkDescriptorSetAllocateInfo.calloc(stack)
                 .sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)
                 .pNext(MemoryUtil.NULL)
-                .descriptorPool(findAvailableDescriptorPool().handle)
+                .descriptorPool(pool.handle)
                 .pSetLayouts(pDescriptorSetLayout)
 
             val descriptorSet = VU.getLong("createDescriptorSet",
@@ -697,12 +712,12 @@ open class VulkanDevice(
      *
      * Creates a new pool if necessary.
      */
-    fun findAvailableDescriptorPool(requiredSets: Int = 1): DescriptorPool {
-        val available = descriptorPools.firstOrNull { it.free >= requiredSets }
+    fun findAvailableDescriptorPool(type: Int, requiredSets: Int = 1): DescriptorPool {
+        val available = descriptorPools.firstOrNull { it.free[type]!! >= requiredSets }
 
         return if(available == null) {
             descriptorPools.add(createDescriptorPool())
-            descriptorPools.first { it.free >= requiredSets }
+            descriptorPools.first { it.free[type]!! >= requiredSets }
         } else {
             available
         }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanObjectState.kt
@@ -189,8 +189,8 @@ open class VulkanObjectState {
             val pDescriptorSetLayout = memAllocLong(1)
             pDescriptorSetLayout.put(0, descriptorSetLayout)
 
-            val pool = device.findAvailableDescriptorPool()
-            pool.free -= 1
+            val pool = device.findAvailableDescriptorPool(VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
+            pool.decreaseAvailable(VK10.VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
 
             val allocInfo = VkDescriptorSetAllocateInfo.calloc()
                 .sType(VK10.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)


### PR DESCRIPTION
This PR fixes a problem in Vulkan descriptor pool allocation, which lead to the problem that no more descriptors could be allocated.