### PR TITLE
VulkanRenderer: Correctly hand over vsync parameter to swapchains

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/vulkan/SwingSwapchain.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/SwingSwapchain.kt
@@ -180,7 +180,7 @@ open class SwingSwapchain(override val device: VulkanDevice,
                 val mainFrame = JFrame(applicationName)
                 mainFrame.layout = BorderLayout()
 
-                val sceneryPanel = SceneryJPanel()
+                val sceneryPanel = SceneryJPanel(owned = true)
                 sceneryPanel.preferredSize = Dimension(windowWidth, windowHeight)
                 mainFrame.add(sceneryPanel, BorderLayout.CENTER)
                 mainFrame.pack()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -691,13 +691,13 @@ open class VulkanRenderer(hub: Hub,
                     }
 
                     val validationsEnabled = if (validation) {
-                        " - VALIDATIONS ENABLED"
+                        ", validation layers enabled"
                     } else {
                         ""
                     }
 
-                    if(embedIn == null) {
-                        window.title = "$applicationName [${this@VulkanRenderer.javaClass.simpleName}, ${this@VulkanRenderer.renderConfig.name}] $validationsEnabled - $fps fps"
+                    if(embedIn == null || (embedIn as? SceneryJPanel)?.owned == true) {
+                        window.title = "$applicationName [${this@VulkanRenderer.renderConfig.name}$validationsEnabled] $fps fps"
                     }
                 }
             }, 0, 1000)

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRenderer.kt
@@ -613,13 +613,14 @@ open class VulkanRenderer(hub: Hub,
             swapchain = when {
                 selectedSwapchain != null -> {
                     logger.info("Using swapchain ${selectedSwapchain.simpleName}")
-                    val params = selectedSwapchain.kotlin.primaryConstructor!!.parameters.associate { param ->
-                        param to when(param.name) {
+                    val params = selectedSwapchain.kotlin.primaryConstructor!!.parameters.associateWith { param ->
+                        when(param.name) {
                             "device" -> device
                             "queue" -> queue
                             "commandPools" -> commandPools
                             "renderConfig" -> renderConfig
                             "useSRGB" -> renderConfig.sRGB
+                            "vsync" -> !settings.get<Boolean>("Renderer.DisableVsync")
                             else -> null
                         }
                     }.filter { it.value != null }

--- a/src/main/kotlin/graphics/scenery/utils/SceneryJPanel.kt
+++ b/src/main/kotlin/graphics/scenery/utils/SceneryJPanel.kt
@@ -13,7 +13,7 @@ import javax.swing.JPanel
  *
  * @author Ulrik Guenther <hello@ulrik.is>
  */
-class SceneryJPanel : JPanel(), SceneryPanel {
+class SceneryJPanel(val owned: Boolean = false) : JPanel(), SceneryPanel {
     /** Refresh rate. */
     override var refreshRate: Int = 60
 


### PR DESCRIPTION
This PR resolves and issue where vsync would not be enabled/disabled correctly if a swapchain other than the default VulkanSwapchain was used.