### PR TITLE
Improve shader hot reloading

### DIFF
--- a/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
+++ b/src/main/kotlin/graphics/scenery/backends/ShaderPackage.kt
@@ -20,7 +20,8 @@ data class ShaderPackage(val baseClass: Class<*>,
                          val codePath: String?,
                          val spirv: ByteArray?,
                          val code: String?,
-                         var priority: SourceSPIRVPriority) {
+                         var priority: SourceSPIRVPriority,
+                         val disableCaching: Boolean = false) {
     private val logger by lazyLogger()
 
     init {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanShaderModule.kt
@@ -224,8 +224,12 @@ open class VulkanShaderModule(val device: VulkanDevice, entryPoint: String, val 
         fun getFromCacheOrCreate(device: VulkanDevice, entryPoint: String, sp: ShaderPackage): VulkanShaderModule {
             val signature = ShaderSignature(device, sp).hashCode()
 
-            return shaderModuleCache.getOrPut(signature) {
+            return if(sp.disableCaching) {
                 VulkanShaderModule(device, entryPoint, sp)
+            } else {
+                shaderModuleCache.getOrPut(signature) {
+                    VulkanShaderModule(device, entryPoint, sp)
+                }
             }
         }
 


### PR DESCRIPTION
This PR improves hot reloading of shaders:

* when any shader file is requested, the shader compiler will look for that shader in the current working directory, and in the `shaders/` subdirectory - the first file found will be watched for changes and reloaded on-the-fly
* hot-reloadable shaders from the filesystem will only be marked as stale if their compilation succeeds
* hot-reloadable shaders will not be cached

Nice hack for Linux and macOS: symlink `src/main/resources/graphics/scenery/backends/shaders` to `./shaders`, so all of scenery's default shaders become hot-reloadable.