### PR TITLE
Gradle: Bump Kotlin to 1.9.21, and lwjgl to 3.3.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,8 @@ val lwjglArtifacts = listOf(
         "lwjgl-remotery",
         "lwjgl-spvc",
         "lwjgl-shaderc",
-        "lwjgl-tinyexr"
+        "lwjgl-tinyexr",
+        "lwjgl-jawt"
 )
 
 dependencies {
@@ -80,6 +81,9 @@ dependencies {
                         runtimeOnly("org.lwjgl:$artifact:$lwjglVersion:$native")
                     }
                 }
+
+                // JAWT doesn't bring natives along
+                artifact.endsWith("jawt") -> {}
 
                 else -> {
                     logger.info("else: org.lwjgl:$artifact:$lwjglVersion:$native")
@@ -223,6 +227,11 @@ tasks {
                     // OpenVR does not have macOS binaries, Vulkan only has macOS binaries
                     if(lwjglProject.contains("vulkan")
                         && !nativePlatform.contains("mac")) {
+                        return@pkg
+                    }
+
+                    // JAWT doesn't have any natives
+                    if(lwjglProject.contains("jawt")) {
                         return@pkg
                     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g -XX:MaxHeapSize=4g
 org.gradle.caching=true
-kotlinVersion=1.9.10
-dokkaVersion=1.8.20
+kotlinVersion=1.9.21
+dokkaVersion=1.9.10
 scijavaParentPOMVersion=35.1.1
-lwjglVersion=3.3.2
+lwjglVersion=3.3.3
 jvmTarget=11
 

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanFramebuffer.kt
@@ -702,7 +702,7 @@ open class VulkanFramebuffer(protected val device: VulkanDevice,
     /**
      * Helper function to set up Vulkan structs.
      */
-    fun <T : Struct> T.default(): T {
+    fun <T : Struct<*>> T.default(): T {
         if(this is VkSamplerCreateInfo) {
             this.sType(VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO).pNext(NULL)
         } else if(this is VkFramebufferCreateInfo) {


### PR DESCRIPTION
This PR bumps Kotlin to 1.9.21, dokka to 1.9.10, and lwjgl 3.3.3. It also fixes a missing dependency that was biting sciview in conjunction with jgo.