### PR TITLE
Switch default build to Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            java: 11
-          - os: ubuntu-latest
-            java: 17
+            java: 21
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -47,9 +45,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            java: 11
-          - os: windows-latest
-            java: 17
+            java: 21
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -81,9 +77,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            java: 11
-          - os: macos-latest
-            java: 17
+            java: 21
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "push"
 
 variables:
-  JAVA_HOME: "/usr/lib/jvm/java-17-openjdk-amd64"
+  JAVA_HOME: "/usr/lib/jvm/java-21-openjdk-amd64"
   PDB_CACHE_DIR: "./pdb-store/cache"
   PDB_DIR: "./pdb-store"
   MODEL_DIR: "./models"
@@ -24,11 +24,9 @@ variables:
 
 # simple unit tests without requiring GPUs
 unit-tests-no-gpu:
-  image: ubuntu:bionic
+  image: scenerygraphics/nvidia-vulkan:1.3.261.1-ubuntu20.04-v3
   before_script:
     - mkdir -p ./pdb-store/cache
-    - apt-get update -qq --force-yes > /dev/null
-    - apt-get install -qq -y --allow-downgrades --allow-remove-essential --allow-change-held-packages unzip wget git curl libgl1-mesa-glx sudo sed openjdk-17-jdk-headless > /dev/null
     - if [ ! -d "$MODEL_DIR" ]; then wget -q https://ulrik.is/scenery-demo-models.zip && unzip -q scenery-demo-models.zip; fi
     - chmod +x gradlew
   script:
@@ -40,17 +38,14 @@ unit-tests-no-gpu:
     # $VULKAN_SDK_VERSION comes from Docker image
     - source /opt/vulkan/$VULKAN_SDK_VERSION/setup-env.sh
     - mkdir -p ./pdb-store/cache
-    # Installs Maven, Vulkan development libraries, etc.
-    - apt-get update -qq --force-yes > /dev/null
-    - apt-get install -qq -y curl sudo sed > /dev/null
     - sudo sed -i -e '/^assistive_technologies=/s/^/#/' /etc/java-*-openjdk/accessibility.properties
     # Output Vulkan driver information, but do not fail in case of non-zero
     # return (happens e.g. if $DISPLAY is not set)
-    - echo -e "\e[0Ksection_start:`date +%s`:build_section[collapsed=true]\r\e[0KHardware Information"
+    - echo -e "\e[0Ksection_start:`date +%s`:hw_info_section[collapsed=true]\r\e[0KHardware Information"
     - nvidia-smi || true
     - vulkaninfo || true
     - clinfo || true
-    - echo -e "\e[0Ksection_end:`date +%s`:build_section\r\e[0K"
+    - echo -e "\e[0Ksection_end:`date +%s`:hw_info_section\r\e[0K"
     - if [ ! -d "$MODEL_DIR" ]; then wget -q https://ulrik.is/scenery-demo-models.zip && unzip -q scenery-demo-models.zip; fi
     - chmod +x gradlew
     - ./gradlew --stop # stop any deamon https://stackoverflow.com/a/58397542/1047713
@@ -91,7 +86,7 @@ unit-tests-no-gpu:
       - "hs_err_*"
 
 scenery-nvidia:
-  image: scenerygraphics/nvidia-vulkan:1.3.261.1-ubuntu20.04-v2
+  image: scenerygraphics/nvidia-vulkan:1.3.261.1-ubuntu20.04-v3
   <<: *base-job-gpu
   after_script:
     - tar cvjf results.tar.bz2 screenshots/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -153,14 +153,14 @@ val isRelease: Boolean
 tasks {
     withType<KotlinCompile>().all {
         kotlinOptions {
-            jvmTarget = project.properties["jvmTarget"]?.toString() ?: "11"
+            jvmTarget = project.properties["jvmTarget"]?.toString() ?: "21"
             freeCompilerArgs += listOf("-Xinline-classes", "-opt-in=kotlin.RequiresOptIn")
         }
     }
 
     withType<JavaCompile>().all {
-        targetCompatibility = project.properties["jvmTarget"]?.toString() ?: "11"
-        sourceCompatibility = project.properties["jvmTarget"]?.toString() ?: "11"
+        targetCompatibility = project.properties["jvmTarget"]?.toString() ?: "21"
+        sourceCompatibility = project.properties["jvmTarget"]?.toString() ?: "21"
     }
 
     withType<GenerateMavenPom>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ kotlinVersion=1.9.21
 dokkaVersion=1.9.10
 scijavaParentPOMVersion=35.1.1
 lwjglVersion=3.3.3
-jvmTarget=11
+jvmTarget=21
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=3e1af3ae886920c3ac87f7a91f816c0c7c436f276a6eefdb3da152100fef72ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionSha256Sum=9d926787066a081739e8200858338b4a69e837c3a821a33aca9db09dd4a41026
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
This PR switches the build to Java 21 by default, and will also generate packages with Java 21 bytecode version. In addition, all Gitlab CI builds now use [the same Docker image](https://hub.docker.com/layers/scenerygraphics/nvidia-vulkan/1.3.261.1-ubuntu20.04-v3/images/sha256-ea8c95427e2db6a1623fc989d1251732844a48bbffa276f162cb93ac94080863?context=explore), which includes all prerequisites, such as the JDK, Vulkan SDK, etc. Before, the non-GPU builds used a default Ubuntu image, which required package installations on each run.