### PR TITLE
Per-node UBO population and per-frame cam state access

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -2,14 +2,16 @@ package graphics.scenery
 
 import graphics.scenery.primitives.TextBoard
 import graphics.scenery.attribute.material.HasMaterial
+import graphics.scenery.attribute.populatesubo.DefaultPopulatesUBO
+import graphics.scenery.attribute.populatesubo.HasCustomPopulatesUBO
+import graphics.scenery.attribute.populatesubo.HasPopulatesUBO
+import graphics.scenery.attribute.populatesubo.PopulatesUBO
 import graphics.scenery.attribute.renderable.HasRenderable
 import graphics.scenery.attribute.spatial.DefaultSpatial
 import graphics.scenery.attribute.spatial.HasCustomSpatial
+import graphics.scenery.backends.UBO
 import graphics.scenery.net.Networkable
-import graphics.scenery.utils.extensions.minus
-import graphics.scenery.utils.extensions.plus
-import graphics.scenery.utils.extensions.times
-import graphics.scenery.utils.extensions.xyz
+import graphics.scenery.utils.extensions.*
 import org.joml.*
 import java.lang.Math
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,7 +28,11 @@ import kotlin.math.tan
  * @constructor Creates a new camera with default position and right-handed
  *  coordinate system.
  */
-open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustomSpatial<Camera.CameraSpatial> {
+open class Camera : DefaultNode("Camera"),
+                    HasRenderable,
+                    HasMaterial,
+                    HasCustomSpatial<Camera.CameraSpatial>,
+                    HasCustomPopulatesUBO<Camera.CameraUBOPopulator> {
 
     /** Enum class for camera projection types */
     enum class ProjectionType {
@@ -92,16 +98,20 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     override fun wantsSync(): Boolean = wantsSync
 
     init {
-        this.nodeType = "Camera"
         this.viewSpaceTripod = cameraTripod()
         this.name = "Camera-${counter.incrementAndGet()}"
         addSpatial()
         addRenderable()
         addMaterial()
+        addPopulatesUBO()
     }
 
     override fun createSpatial(): CameraSpatial {
         return CameraSpatial(this)
+    }
+
+    override fun createPopulatesUBO(): PopulatesUBO {
+        return CameraUBOPopulator(this)
     }
 
     override fun update(fresh: Networkable, getNetworkable: (Int) -> Networkable, additionalData: Any?) {
@@ -367,6 +377,19 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
         protected val counter = AtomicInteger(0)
     }
 
+    open class CameraUBOPopulator(open val cam: Camera): DefaultPopulatesUBO() {
+        override fun populate(ubo: UBO) {
+            val camSpatial = cam.spatial()
+
+            ubo.add("projection0", { camSpatial.projection.applyVulkanCoordinateSystem() })
+            ubo.add("projection1", { camSpatial.projection.applyVulkanCoordinateSystem() })
+            ubo.add("inverseProjection0", { camSpatial.projection.applyVulkanCoordinateSystem().invert() })
+            ubo.add("inverseProjection1", { camSpatial.projection.applyVulkanCoordinateSystem().invert() })
+            ubo.add("headShift", { Matrix4f().identity() })
+            ubo.add("IPD", { 0.05f })
+            ubo.add("stereoEnabled", { 0 })
+        }
+    }
 
     open class CameraSpatial(val camera: Camera): DefaultSpatial(camera) {
 

--- a/src/main/kotlin/graphics/scenery/DefaultNode.kt
+++ b/src/main/kotlin/graphics/scenery/DefaultNode.kt
@@ -48,7 +48,6 @@ open class DefaultNode(name: String = "Node") : Node, Networkable {
         return true
     }
 
-    override var nodeType = "Node"
     override var boundingBox: OrientedBoundingBox? = null
     override val logger by lazyLogger()
 

--- a/src/main/kotlin/graphics/scenery/DetachedHeadCamera.kt
+++ b/src/main/kotlin/graphics/scenery/DetachedHeadCamera.kt
@@ -1,7 +1,12 @@
 package graphics.scenery
 
+import graphics.scenery.attribute.populatesubo.DefaultPopulatesUBO
+import graphics.scenery.attribute.populatesubo.HasCustomPopulatesUBO
+import graphics.scenery.attribute.populatesubo.PopulatesUBO
 import graphics.scenery.backends.Display
+import graphics.scenery.backends.UBO
 import graphics.scenery.controls.TrackerInput
+import graphics.scenery.utils.extensions.applyVulkanCoordinateSystem
 import graphics.scenery.utils.extensions.plus
 import graphics.scenery.utils.extensions.times
 import org.joml.Matrix4f
@@ -20,7 +25,7 @@ import kotlin.reflect.KProperty
  * @author Ulrik Günther <hello@ulrik.is>
  */
 
-class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera() {
+open class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera(), HasCustomPopulatesUBO<Camera.CameraUBOPopulator> {
 
     override var width: Int = 0
         get() = if (tracker != null && tracker is Display && tracker?.initializedAndWorking() == true) {
@@ -104,12 +109,42 @@ class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera(
     val headOrientation: Quaternionf by HeadOrientationDelegate()
 
     init {
-        this.nodeType = "Camera"
-        this.name = "DetachedHeadCamera-${tracker ?: "${counter.getAndIncrement()}"}"
+        name = "DetachedHeadCamera-${tracker ?: "${counter.getAndIncrement()}"}"
     }
 
     override fun createSpatial(): CameraSpatial = DetachedHeadCameraSpatial(this)
-    
+
+    override fun createPopulatesUBO(): PopulatesUBO = DetachedHeadCameraUBOPopulator(this)
+    open class DetachedHeadCameraUBOPopulator(override val cam: DetachedHeadCamera): Camera.CameraUBOPopulator(cam) {
+        override fun populate(ubo: UBO) {
+            val camSpatial = cam.spatial()
+            val hmd = (cam.tracker as? Display)
+
+            ubo.add("projection0", {
+                (hmd?.getEyeProjection(0, cam.nearPlaneDistance, cam.farPlaneDistance)
+                    ?: camSpatial.projection).applyVulkanCoordinateSystem()
+            })
+            ubo.add("projection1", {
+                (hmd?.getEyeProjection(1, cam.nearPlaneDistance, cam.farPlaneDistance)
+                    ?: camSpatial.projection).applyVulkanCoordinateSystem()
+            })
+            ubo.add("inverseProjection0", {
+                (hmd?.getEyeProjection(0, cam.nearPlaneDistance, cam.farPlaneDistance)
+                    ?: camSpatial.projection).applyVulkanCoordinateSystem().invert()
+            })
+            ubo.add("inverseProjection1", {
+                (hmd?.getEyeProjection(1, cam.nearPlaneDistance, cam.farPlaneDistance)
+                    ?: camSpatial.projection).applyVulkanCoordinateSystem().invert()
+            })
+            ubo.add("headShift", { hmd?.getHeadToEyeTransform(0) ?: Matrix4f().identity() })
+            ubo.add("IPD", { hmd?.getIPD() ?: 0.05f })
+            ubo.add("stereoEnabled", { cam.stereoEnabled })
+        }
+    }
+
+    var stereoEnabled = false
+        internal set
+
     class DetachedHeadCameraSpatial(private val cam: DetachedHeadCamera) : Camera.CameraSpatial(cam) {
 
         override var projection: Matrix4f = Matrix4f().identity()

--- a/src/main/kotlin/graphics/scenery/Node.kt
+++ b/src/main/kotlin/graphics/scenery/Node.kt
@@ -24,7 +24,6 @@ import kotlin.collections.ArrayList
 
 interface Node : Networkable {
     var name: String
-    var nodeType: String
     /** Children of the Node. */
     var children: CopyOnWriteArrayList<Node>
     /** Other nodes that have linked transforms. */

--- a/src/main/kotlin/graphics/scenery/attribute/populatesubo/DefaultPopulatesUBO.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/populatesubo/DefaultPopulatesUBO.kt
@@ -1,0 +1,8 @@
+package graphics.scenery.attribute.populatesubo
+
+import graphics.scenery.backends.UBO
+
+open class DefaultPopulatesUBO: PopulatesUBO {
+    override fun populate(ubo: UBO) {
+    }
+}

--- a/src/main/kotlin/graphics/scenery/attribute/populatesubo/HasCustomPopulatesUBO.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/populatesubo/HasCustomPopulatesUBO.kt
@@ -1,0 +1,15 @@
+package graphics.scenery.attribute.populatesubo
+
+import graphics.scenery.Node
+
+interface HasCustomPopulatesUBO<T: PopulatesUBO>: Node {
+    fun createPopulatesUBO(): PopulatesUBO
+
+    fun addPopulatesUBO() {
+        addAttribute(PopulatesUBO::class.java, createPopulatesUBO())
+    }
+
+    fun populatesUBO(): T {
+        return getAttribute(PopulatesUBO::class.java)
+    }
+}

--- a/src/main/kotlin/graphics/scenery/attribute/populatesubo/HasPopulatesUBO.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/populatesubo/HasPopulatesUBO.kt
@@ -1,0 +1,7 @@
+package graphics.scenery.attribute.populatesubo
+
+interface HasPopulatesUBO: HasCustomPopulatesUBO<PopulatesUBO> {
+    override fun createPopulatesUBO(): PopulatesUBO {
+        return DefaultPopulatesUBO()
+    }
+}

--- a/src/main/kotlin/graphics/scenery/attribute/populatesubo/PopulatesUBO.kt
+++ b/src/main/kotlin/graphics/scenery/attribute/populatesubo/PopulatesUBO.kt
@@ -1,0 +1,7 @@
+package graphics.scenery.attribute.populatesubo
+
+import graphics.scenery.backends.UBO
+
+interface PopulatesUBO {
+    fun populate(ubo: UBO)
+}

--- a/src/main/kotlin/graphics/scenery/utils/extensions/VectorMath.kt
+++ b/src/main/kotlin/graphics/scenery/utils/extensions/VectorMath.kt
@@ -200,4 +200,17 @@ fun Matrix4f.compare(right: Matrix4fc, explainDiff: Boolean): Boolean {
     return true
 }
 
+private val vulkanProjectionFix =
+    Matrix4f(
+        1.0f,  0.0f, 0.0f, 0.0f,
+        0.0f, -1.0f, 0.0f, 0.0f,
+        0.0f,  0.0f, 0.5f, 0.0f,
+        0.0f,  0.0f, 0.5f, 1.0f)
+fun Matrix4f.applyVulkanCoordinateSystem(): Matrix4f {
+    val m = Matrix4f(vulkanProjectionFix)
+    m.mul(this)
+
+    return m
+}
+
 


### PR DESCRIPTION
This PR introduces:
* the `PopulatesUBO` interface, which enables node to define their own serialisation procedure, aka, how to translate a node's information into something accessible to shaders that goes beyond ShaderProperties
* access to a given frame's camera state in the Vulkan renderer's render() function.