### PR TITLE
Don't let volumes defeat push mode

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -414,23 +414,24 @@ open class Volume(
         return histogram
     }
 
+    private var slicingArray = FloatArray(4 * MAX_SUPPORTED_SLICING_PLANES)
+
     /**
      * Returns array of slicing plane equations for planes assigned to this volume.
      */
     fun slicingArray(): FloatArray {
-        if (slicingPlaneEquations.size > MAX_SUPPORTED_SLICING_PLANES)
-            logger.warn("More than ${MAX_SUPPORTED_SLICING_PLANES} slicing planes for ${this.name} set. Ignoring additional planes.")
-
-        val fa = FloatArray(4 * MAX_SUPPORTED_SLICING_PLANES)
-
-        slicingPlaneEquations.entries.take(MAX_SUPPORTED_SLICING_PLANES).forEachIndexed { i, entry ->
-            fa[0+i*4] = entry.value.x
-            fa[1+i*4] = entry.value.y
-            fa[2+i*4] = entry.value.z
-            fa[3+i*4] = entry.value.w
+        if (slicingPlaneEquations.size > MAX_SUPPORTED_SLICING_PLANES) {
+            logger.warn("More than $MAX_SUPPORTED_SLICING_PLANES slicing planes for ${this.name} set. Ignoring additional planes.")
         }
 
-        return fa
+        slicingPlaneEquations.entries.take(MAX_SUPPORTED_SLICING_PLANES).forEachIndexed { i, entry ->
+            slicingArray[0+i*4] = entry.value.x
+            slicingArray[1+i*4] = entry.value.y
+            slicingArray[2+i*4] = entry.value.z
+            slicingArray[3+i*4] = entry.value.w
+        }
+
+        return slicingArray
     }
 
     /**


### PR DESCRIPTION
Simply using `FloatArray.hashCode()` caused the issue that UBO hashing in order to check for updates got defeated by new float arrays with the same contents being allocated. This happened because bigvolumeviewer copies float arrays behind the scenes when assigning them as a uniform. This PR replaces hashCode() calls on FloatArray and IntArray with contentHashCode(), which does not take the specific reference into account, but only the content of the array. 

In addition, this PR also removes repeated allocations of the slicing equation array in Volume, and allocates the array only once.