### PR TITLE
Stabilise Argos' Screenshot evaluation

### DIFF
--- a/src/main/kotlin/graphics/scenery/numerics/Random.kt
+++ b/src/main/kotlin/graphics/scenery/numerics/Random.kt
@@ -21,6 +21,15 @@ class Random {
         var rng = Random(seed)
 
         /**
+         * Reseeds the PRNG with the new [seed]. If the seed is null, the value given in the
+         * system property `scenery.RandomSeed` will be used.
+         */
+        @JvmStatic fun reseed(seed: Long? = null) {
+            this.seed = seed ?: (System.getProperty("scenery.RandomSeed")?.toLong() ?: Random.nextLong())
+            rng = Random(this.seed)
+        }
+
+        /**
          * Returns a random float from the range [min]-[max].
          */
         @JvmStatic

--- a/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/stresstests/ExampleRunner.kt
@@ -3,6 +3,7 @@ package graphics.scenery.tests.examples.stresstests
 import graphics.scenery.SceneryBase
 import graphics.scenery.SceneryElement
 import graphics.scenery.backends.Renderer
+import graphics.scenery.numerics.Random
 import graphics.scenery.utils.ExtractsNatives
 import graphics.scenery.utils.lazyLogger
 import graphics.scenery.utils.SystemHelpers
@@ -54,6 +55,9 @@ class ExampleRunner(
                 exitProcess(-1)
             }
 
+            // re-seed scenery's PRNG to the seed given via system property
+            Random.reseed()
+
             val exampleRunnable = GlobalScope.launch(handler) {
                 instance.assertions[SceneryBase.AssertionCheckPoint.BeforeStart]?.forEach {
                     it.invoke()
@@ -70,7 +74,7 @@ class ExampleRunner(
                 delay(200)
             }
 
-            delay(2000)
+            delay(3000)
             r.screenshot("$rendererDirectory/${clazz.simpleName}.png", overwrite = true)
             Thread.sleep(2000)
 


### PR DESCRIPTION
Argos at the moment still produces too many false positives. This PR aims to solve this, via:
* enabling `Random` to be re-seeded with a given seed that is either given, or determined from the the `scenery.RandomSeed` system property
* re-seeding `Random`'s PRNG for each run of an example, in order to have a deterministic sequences of pseudorandom numbers