### PR TITLE
Fix uninitialised delegated Nodes

### DIFF
--- a/src/main/kotlin/graphics/scenery/PointLight.kt
+++ b/src/main/kotlin/graphics/scenery/PointLight.kt
@@ -33,7 +33,7 @@ open class PointLight(val radius: Float = 5.0f) : Light("PointLight") {
     @ShaderProperty var lightRadius: Float = radius
         set(value) {
             if(value != lightRadius) {
-                logger.info("Resetting light radius")
+                logger.debug("Resetting light radius")
                 field = value
                 proxySphere = Sphere(value * 1.1f, 10)
                 geometry {

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
@@ -599,7 +599,7 @@ object VulkanScenePass {
             }
 
             if(ds is VulkanRenderer.DescriptorSet.DynamicSet && ds.offset == BUFFER_OFFSET_UNINTIALISED ) {
-                logger.info("${node.name} has uninitialised UBO offset, skipping for rendering")
+                logger.debug("${node.name} has uninitialised UBO offset, skipping for rendering")
                 skip = true
             }
 


### PR DESCRIPTION
This PR fixes an issue where Nodes which delegate rendering (such as Volumes) would be left with initialised metadata (from the delegate), but would themselves not be marked initialised. This leads to an issue where they'd cause constant updates and defeat push mode.

To make push mode defeat issues more easily debuggable in the future, this PR also adds `VulkanRenderer.pushModeDefeats`, which keeps track of the reasons for the last five push mode defeats.