### PR TITLE
Multiresolution-safe histograms

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/HasHistogram.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/HasHistogram.kt
@@ -12,5 +12,5 @@ interface HasHistogram {
      * This is a placeholder function that needs to be overwritten by the implementing class. Currently the output should be of type Histogram1d<*>
      * from imglib2
      */
-    fun generateHistogram() : Histogram1d<*>?
+    fun generateHistogram(maximumResolution: Int = 512, bins: Int = 1024) : Histogram1d<*>?
 }


### PR DESCRIPTION
This PR adapts the histogram creation code so it's safe for multiresolution volumes.

The logic will now also use a lower-resolution volume to generate histograms, such that large multiresolution volumes are not iterated voxel-by-voxel. By default, a maximum side length of 512 voxels is used. This fixes scenerygraphics/sciview#556.