### PR TITLE
Gradle platform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,8 @@ dependencies {
     val scijavaParentPomVersion = project.properties["scijavaParentPOMVersion"]
     val lwjglVersion = project.properties["lwjglVersion"]
     
-    implementation(platform("org.scijava:pom-scijava:$scijavaParentPomVersion"))
+//    implementation(platform("org.scijava:pom-scijava:$scijavaParentPomVersion"))
+    implementation(platform("org.scijava:platform:0.1"))
     annotationProcessor("org.scijava:scijava-common:2.97.1")
 
     implementation(kotlin("reflect"))
@@ -146,6 +147,8 @@ dependencies {
     implementation("org.jfree:jfreechart:1.5.4")
     implementation("net.imagej:imagej-ops:0.45.5")
 }
+
+//configurations.getAt("compileClasspath").incoming.resolutionResult.allDependencies.filter { it.isConstraint }.forEach { println(it) }
 
 val isRelease: Boolean
     get() = System.getProperty("release") == "true"


### PR DESCRIPTION
First implementation of an automatically generated Gradle platform from the SciJava Pom

The current version is based on the latest 38.0.0-SNAPSHOT

I added a commented line which will return all the dependencies constraints for the selected configuration

Note, you can do that only for the configurations which has `isCanBeResolved == true`, "compileClasspath" is one of these.

Unfortunately, it looks like you cant retrieve out-of-the-box all the dependencies constrains brought in by the platform, but you can loop all the dependencies constrains which come into play in the project dependency resolution

I said out-of-the-box, because we can always parse the platform `.module` file and retrieve them ourselves

This PR servers as an hook to play around this first platform implementation

At the moment, the platform has `0.1`, but in the future it will probably be in sync with the upstream Scijava-pom