### PR TITLE
Improving opacity adjustment in volume rendering

### DIFF
--- a/src/main/resources/graphics/scenery/volumes/AccumulateBlockVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/AccumulateBlockVolume.frag
@@ -9,7 +9,7 @@ if (vis)
     float newAlpha = x.a;
     vec3 newColor = x.rgb;
 
-    float adjusted_alpha = adjustOpacity(newAlpha, length(wpos - wprev));
+    float adjusted_alpha = adjustOpacity(newAlpha, (distance(wpos, wprev)/standardStepSize));
 
     v.rgb = v.rgb + (1.0f - v.a) * newColor * adjusted_alpha;
     v.a = v.a + (1.0f - v.a) * adjusted_alpha;

--- a/src/main/resources/graphics/scenery/volumes/AccumulateSimpleVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/AccumulateSimpleVolume.frag
@@ -9,7 +9,7 @@ if (vis)
     float newAlpha = x.a;
     vec3 newColor = x.rgb;
 
-    float adjusted_alpha = adjustOpacity(newAlpha, length(wpos - wprev));
+    float adjusted_alpha = adjustOpacity(newAlpha, (distance(wpos, wprev)/standardStepSize));
 
     v.rgb = v.rgb + (1.0f - v.a) * newColor * adjusted_alpha;
     v.a = v.a + (1.0f - v.a) * adjusted_alpha;

--- a/src/main/resources/graphics/scenery/volumes/BDVVolume.frag
+++ b/src/main/resources/graphics/scenery/volumes/BDVVolume.frag
@@ -149,6 +149,9 @@ void main()
 		}
 
 		float step = tnear;
+		vec4 w_entry = mix(wfront, wback, step);
+
+		float standardStepSize = distance(mix(wfront, wback, step + nw), w_entry);
 
 		float step_prev = step - stepWidth;
 		vec4 wprev = mix(wfront, wback, step_prev);

--- a/src/test/resources/graphics/scenery/tests/examples/compute/ComputeVolume.comp
+++ b/src/test/resources/graphics/scenery/tests/examples/compute/ComputeVolume.comp
@@ -130,6 +130,9 @@ void main()
 		}
 
         float step = tnear;
+        vec4 w_entry = mix(wfront, wback, step);
+
+        float standardStepSize = distance(mix(wfront, wback, step + nw), w_entry);
 
 		float step_prev = step - stepWidth;
 		vec4 wprev = mix(wfront, wback, step_prev);


### PR DESCRIPTION
As noted by @moreApi , the opacity adjustment currently used in volume raycasting makes volumes too transparent. This PR adjusts the opacity relative to a predefined `standardStepSize` - equal to half the side length of a voxel in world space - which alleviates the issue while maintaining the benefits of adjusting the opacity when required.

## Explanation
According to the book Real-Time Volume Graphics (https://dl.acm.org/doi/pdf/10.1145/1103900.1103929 see page 30), opacity adjustment does not need to be applied if the step size is always constant, because the impact of taking finite non-infinitesimal steps is effectively incorporated into the manually defined transfer function. When steps of different size are to be taken, however, the opacity needs to be adjusted to ensure that the overall intensity of the image does not depend on the number of steps through the volume.

This PR assumes a standard step size as half the voxel side length - consistent with the Nyquist sampling theorem. The step size taken is always compared with this size, so that when steps of half the voxel side length are taken, the effect is the same as not applying opacity adjustment. When steps of other sizes are taken, either fixed or adaptive, the opacity adjustment comes into play and ensures that the intensity does not change with the number of steps.

