### PR TITLE
0.11.0 preparations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Add scenery to your project's `pom.xml`:
   <dependency>
     <groupId>graphics.scenery</groupId>
     <artifactId>scenery</artifactId>
-    <version>0.10.1</version>
+    <version>0.11.0</version>
   </dependency>
 </dependencies>
 ```
@@ -141,7 +141,7 @@ Add scenery to your project's `build.gradle`:
 ```kotlin
 dependencies {
     // ...
-    api("graphics.scenery:scenery:0.10.1")
+    api("graphics.scenery:scenery:0.11.0")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g -XX:MaxHeapSize=4g
 org.gradle.caching=true
-kotlinVersion=1.9.21
+kotlinVersion=1.9.23
 dokkaVersion=1.9.10
-scijavaParentPOMVersion=35.1.1
+scijavaParentPOMVersion=37.0.0
 lwjglVersion=3.3.3
 jvmTarget=21
-version=0.10.1
+version=0.11.0
 


### PR DESCRIPTION
This PR prepares for the 0.11.0 release by:
* bumping the scijava parent POM to 37.0.0
* bumping Kotlin to 1.9.23