### PR TITLE
Remove waiting period when closing

### DIFF
--- a/src/main/kotlin/graphics/scenery/SceneryBase.kt
+++ b/src/main/kotlin/graphics/scenery/SceneryBase.kt
@@ -344,15 +344,10 @@ open class SceneryBase @JvmOverloads constructor(var applicationName: String,
      * Sets the shouldClose flag on renderer, causing it to shut down and thereby ending the main loop.
      */
     open fun close() {
+        // Terminate main loop.
         shouldClose = true
-        gracePeriod = 60
+
         renderer?.close()
-
-        while(gracePeriod > 0 || renderer?.initialized == true) {
-            logger.debug("Waiting for grace period to go to 0, current=$gracePeriod")
-            Thread.sleep(100)
-        }
-
         renderer = null
 
         (hub.get(SceneryElement.NodePublisher) as? NodePublisher)?.close()


### PR DESCRIPTION
The gracePeriod variable only decreases in the main loop while it is
looping. But the `shouldClose = true` causes the main loop to stop
looping. So the gracePeriod only had time to decrement once (to 59),
at which point the while loop here in the `close()` function gets stuck.

It may be the case that this looping was only necessary for the OpenGL
renderer anyway, which is no longer an issue, so we can simplify now.
