### PR TITLE
Clean up Node state variables and Node interface

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -92,7 +92,6 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
     override fun wantsSync(): Boolean = wantsSync
 
     init {
-        this.nodeType = "Camera"
         this.viewSpaceTripod = cameraTripod()
         this.name = "Camera-${counter.incrementAndGet()}"
         addSpatial()

--- a/src/main/kotlin/graphics/scenery/DefaultNode.kt
+++ b/src/main/kotlin/graphics/scenery/DefaultNode.kt
@@ -15,7 +15,7 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
 open class DefaultNode(name: String = "Node") : Node, Networkable {
-    override var name = name
+    final override var name = name
         set(v) {
             field = v
             updateModifiedAt()
@@ -48,9 +48,8 @@ open class DefaultNode(name: String = "Node") : Node, Networkable {
         return true
     }
 
-    override var nodeType = "Node"
     override var boundingBox: OrientedBoundingBox? = null
-    override val logger by lazyLogger()
+    val logger by lazyLogger()
 
     @Transient private val attributes = DefaultAttributesMap()
 

--- a/src/main/kotlin/graphics/scenery/DetachedHeadCamera.kt
+++ b/src/main/kotlin/graphics/scenery/DetachedHeadCamera.kt
@@ -104,7 +104,6 @@ class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera(
     val headOrientation: Quaternionf by HeadOrientationDelegate()
 
     init {
-        this.nodeType = "Camera"
         this.name = "DetachedHeadCamera-${tracker ?: "${counter.getAndIncrement()}"}"
     }
 
@@ -130,9 +129,7 @@ class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera(
          */
         override fun getTransformation(): Matrix4f {
             val tr = Matrix4f().translate(this.position * (-1.0f))
-//        val r = Matrix4f.fromQuaternion(this.rotation)
-//        val hr = Matrix4f.fromQuaternion(this.headOrientation)
-            return cam.tracker?.getWorkingTracker()?.getPose()?.times(tr) ?: Matrix4f().set(this.rotation) * tr
+            return cam.tracker?.getWorkingTracker()?.getPose()?.times(tr) ?: (Matrix4f().set(this.rotation) * tr)
         }
 
         /**
@@ -141,9 +138,8 @@ class DetachedHeadCamera(@Transient var tracker: TrackerInput? = null) : Camera(
          */
         override fun getTransformationForEye(eye: Int): Matrix4f {
             val tr = Matrix4f().translate(this.position * (-1.0f))
-//        val r = Matrix4f.fromQuaternion(this.rotation)
-//        val hr = Matrix4f.fromQuaternion(this.headOrientation)
-            return cam.tracker?.getWorkingTracker()?.getPoseForEye(eye)?.times(tr) ?: Matrix4f().set(this.rotation) * tr
+            return cam.tracker?.getWorkingTracker()?.getPoseForEye(eye)?.times(tr)
+                ?: (Matrix4f().set(this.rotation) * tr)
         }
 
         /**

--- a/src/main/kotlin/graphics/scenery/DirectionalLight.kt
+++ b/src/main/kotlin/graphics/scenery/DirectionalLight.kt
@@ -28,9 +28,6 @@ class DirectionalLight(var direction: Vector3f = Vector3f(0.0f, 1.0f, 0.0f)) : L
 
     @ShaderProperty private var lightRadius: Float = 1.0f
 
-    /** Node name of the Point Light */
-    override var name = "PointLight"
-
     @Suppress("unused") // will be serialised into ShaderProperty buffer
     @ShaderProperty val worldPosition
         get() = direction

--- a/src/main/kotlin/graphics/scenery/InstancedNode.kt
+++ b/src/main/kotlin/graphics/scenery/InstancedNode.kt
@@ -12,7 +12,7 @@ import graphics.scenery.attribute.spatial.HasSpatial
 import org.joml.Matrix4f
 import java.util.concurrent.CopyOnWriteArrayList
 
-open class InstancedNode(template: Node, override var name: String = "InstancedNode") : DefaultNode(name), DelegatesRenderable,
+open class InstancedNode(template: Node, name: String = "InstancedNode") : DefaultNode(name), DelegatesRenderable,
     DelegatesGeometry, DelegatesMaterial {
     /** instances */
     val instances = CopyOnWriteArrayList<Instance>()
@@ -64,7 +64,7 @@ open class InstancedNode(template: Node, override var name: String = "InstancedN
         return template?.generateBoundingBox()
     }
 
-    class Instance(val instancedParent : InstancedNode, override var name: String = "Instance") : DefaultNode(name),
+    class Instance(val instancedParent : InstancedNode, name: String = "Instance") : DefaultNode(name),
         HasRenderable, HasSpatial {
         var instancedProperties = LinkedHashMap<String, () -> Any>()
 

--- a/src/main/kotlin/graphics/scenery/Mesh.kt
+++ b/src/main/kotlin/graphics/scenery/Mesh.kt
@@ -33,7 +33,7 @@ import java.nio.file.Files
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-open class Mesh(override var name: String = "Mesh") : DefaultNode(name), HasRenderable, HasMaterial, HasSpatial,
+open class Mesh(name: String = "Mesh") : DefaultNode(name), HasRenderable, HasMaterial, HasSpatial,
     HasGeometry {
 
     init {

--- a/src/main/kotlin/graphics/scenery/Node.kt
+++ b/src/main/kotlin/graphics/scenery/Node.kt
@@ -8,12 +8,12 @@ import graphics.scenery.attribute.renderable.Renderable
 import graphics.scenery.attribute.spatial.Spatial
 import graphics.scenery.net.Networkable
 import graphics.scenery.utils.MaybeIntersects
+import graphics.scenery.utils.lazyLogger
 import net.imglib2.Localizable
 import net.imglib2.RealLocalizable
 import org.joml.Matrix4f
 import org.joml.Quaternionf
 import org.joml.Vector3f
-import org.slf4j.Logger
 import java.nio.FloatBuffer
 import java.nio.IntBuffer
 import java.util.*
@@ -24,7 +24,6 @@ import kotlin.collections.ArrayList
 
 interface Node : Networkable {
     var name: String
-    var nodeType: String
     /** Children of the Node. */
     var children: CopyOnWriteArrayList<Node>
     /** Other nodes that have linked transforms. */
@@ -49,8 +48,6 @@ interface Node : Networkable {
     var lock: ReentrantLock
     /** Initialisation function for the object */
     fun init(): Boolean
-
-    val logger: Logger
 
     /** bounding box **/
     var boundingBox: OrientedBoundingBox?
@@ -215,6 +212,7 @@ interface Node : Networkable {
     fun getShaderProperty(name: String): Any?
 
     companion object {
+        private val logger by lazyLogger()
 
         /**
          * Depth-first search for elements in a Scene.

--- a/src/main/kotlin/graphics/scenery/PointLight.kt
+++ b/src/main/kotlin/graphics/scenery/PointLight.kt
@@ -48,9 +48,6 @@ open class PointLight(val radius: Float = 5.0f) : Light("PointLight") {
             }
         }
 
-    /** Node name of the Point Light */
-    override var name = "PointLight"
-
     @Suppress("unused") // will be serialised into ShaderProperty buffer
     @ShaderProperty val worldPosition: Vector3f
         get(): Vector3f {

--- a/src/main/kotlin/graphics/scenery/RichNode.kt
+++ b/src/main/kotlin/graphics/scenery/RichNode.kt
@@ -7,7 +7,7 @@ import graphics.scenery.volumes.Volume
 import graphics.scenery.volumes.Volume.Companion.fromPathRawSplit
 import org.joml.Vector3f
 
-open class RichNode(override var name: String = "Node") : DefaultNode (name), HasRenderable, HasMaterial, HasSpatial {
+open class RichNode(name: String = "Node") : DefaultNode (name), HasRenderable, HasMaterial, HasSpatial {
     init {
         addRenderable()
         addMaterial()

--- a/src/main/kotlin/graphics/scenery/atomicsimulations/AtomicSimulation.kt
+++ b/src/main/kotlin/graphics/scenery/atomicsimulations/AtomicSimulation.kt
@@ -36,7 +36,7 @@ import org.joml.Vector3f
  *
  * @author Lenz Fiedler <l.fiedler@hzdr.de>
  */
-open class AtomicSimulation(override var name: String = "DFTSimulation", private val scalingFactor: Float,
+open class AtomicSimulation(name: String = "DFTSimulation", private val scalingFactor: Float,
                             private var atomicRadius: Float, private val normalizeVolumetricDataTo: Float=-1.0f,
                             private var cubeStyle: String = "unknown", private val rootFolder: String = "") : Mesh(name) {
     init {

--- a/src/main/kotlin/graphics/scenery/backends/RendererFlags.kt
+++ b/src/main/kotlin/graphics/scenery/backends/RendererFlags.kt
@@ -5,6 +5,8 @@ enum class RendererFlags {
     Initialised,
     Updating,
     Updated,
+    PreDrawSkip,
+    Instanced,
     Rendering,
     MarkedForDeletion
 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanNodeHelpers.kt
@@ -33,17 +33,17 @@ object VulkanNodeHelpers {
      *
      * Will access the node's [state], allocate staging memory from [stagingPool], and GPU memory
      * from [geometryPool]. Command buffer allocation and submission is done via [commandPools] in
-     * the given [queue]. Returns the modified [VulkanObjectState].
+     * the given [queue]. Returns the modified [VulkanRendererMetadata].
      */
     fun createVertexBuffers(
         device: VulkanDevice,
         node: Node,
-        state: VulkanObjectState,
+        state: VulkanRendererMetadata,
         stagingPool: VulkanBufferPool,
         geometryPool: VulkanBufferPool,
         commandPools: VulkanRenderer.CommandPools,
         queue: VulkanDevice.QueueWithMutex
-    ): VulkanObjectState {
+    ): VulkanRendererMetadata {
         val geometry = node.geometryOrNull() ?: return state
         val vertices = geometry.vertices.duplicate()
         val normals = geometry.normals.duplicate()
@@ -156,9 +156,9 @@ object VulkanNodeHelpers {
 
     /**
      * Updates instance buffers for a given [node] on [device]. Modifies the [node]'s [state]
-     * and allocates necessary command buffers from [commandPools] and submits to [queue]. Returns the [node]'s modified [VulkanObjectState].
+     * and allocates necessary command buffers from [commandPools] and submits to [queue]. Returns the [node]'s modified [VulkanRendererMetadata].
      */
-    fun updateInstanceBuffer(device: VulkanDevice, node: InstancedNode, state: VulkanObjectState, commandPools: VulkanRenderer.CommandPools, queue: VulkanDevice.QueueWithMutex): VulkanObjectState {
+    fun updateInstanceBuffer(device: VulkanDevice, node: InstancedNode, state: VulkanRendererMetadata, commandPools: VulkanRenderer.CommandPools, queue: VulkanDevice.QueueWithMutex): VulkanRendererMetadata {
         logger.trace("Updating instance buffer for {}", node.name)
 
         // parentNode.instances is a CopyOnWrite array list, and here we keep a reference to the original.
@@ -261,7 +261,7 @@ object VulkanNodeHelpers {
      *
      * Returns a [Pair] of [Boolean], indicating whether contents or descriptor set have changed.
      */
-    fun loadTexturesForNode(device: VulkanDevice, node: Node, s: VulkanObjectState, defaultTextures: Map<String, VulkanTexture>, textureCache: MutableMap<Texture, VulkanTexture>, commandPools: VulkanRenderer.CommandPools, queue: VulkanDevice.QueueWithMutex, transferQueue: VulkanDevice.QueueWithMutex = queue): Pair<Boolean, Boolean> {
+    fun loadTexturesForNode(device: VulkanDevice, node: Node, s: VulkanRendererMetadata, defaultTextures: Map<String, VulkanTexture>, textureCache: MutableMap<Texture, VulkanTexture>, commandPools: VulkanRenderer.CommandPools, queue: VulkanDevice.QueueWithMutex, transferQueue: VulkanDevice.QueueWithMutex = queue): Pair<Boolean, Boolean> {
         val material = node.materialOrNull() ?: return Pair(false, false)
         val defaultTexture = defaultTextures["DefaultTexture"] ?: throw IllegalStateException("Default fallback texture does not exist.")
         // if a node is not yet initialized, we'll definitely require a new DS
@@ -272,7 +272,7 @@ object VulkanNodeHelpers {
         val now = System.nanoTime()
         material.textures.forEachChanged(last) { (type, texture) ->
             contentUpdated = true
-            val slot = VulkanObjectState.textureTypeToSlot(type)
+            val slot = VulkanRendererMetadata.textureTypeToSlot(type)
             val generateMipmaps = Texture.mipmappedObjectTextures.contains(type)
 
             logger.debug("${node.name} will have $type texture from $texture in slot $slot")
@@ -499,9 +499,9 @@ object VulkanNodeHelpers {
     }
 
     /**
-     * Returns a node's [VulkanRenderer] metadata, [VulkanObjectState], if available.
+     * Returns a node's [VulkanRenderer] metadata, [VulkanRendererMetadata], if available.
      */
-    fun Renderable.rendererMetadata(): VulkanObjectState? {
-        return this.metadata["VulkanRenderer"] as? VulkanObjectState
+    fun Renderable.rendererMetadata(): VulkanRendererMetadata? {
+        return this.metadata["VulkanRenderer"] as? VulkanRendererMetadata
     }
 }

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRendererMetadata.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanRendererMetadata.kt
@@ -19,11 +19,15 @@ import kotlin.time.measureTime
  *
  * @author Ulrik Günther <hello@ulrik.is>
  */
-open class VulkanObjectState {
+open class VulkanRendererMetadata {
     protected val logger by lazyLogger()
 
-    /** Whether this metadata object has been fully initialised. */
-    var initialized = false
+    /**
+     * Whether this metadata object has been fully initialised, now redirects to the respective
+     * flag contained in [flags].
+     */
+    val initialized: Boolean
+        get() = flags.contains(RendererFlags.Initialised)
     /** Indicates whether the mesh is using indexed vertex storage. */
     var isIndexed = false
     /** Indicates the offset to the indices in the vertex buffer in bytes. */
@@ -64,12 +68,8 @@ open class VulkanObjectState {
     /** Time stamp of the last recreation of the texture descriptor sets */
     protected var descriptorSetsRecreated: Long = 0
 
-    /** Whether the node is rendered as instanced */
-    var instanced = false
-
-    var flags = EnumSet.noneOf(RendererFlags::class.java)
-    /** Skip for rendering if this is set. */
-    var preDrawSkip = false
+    /** Set of [RendererFlags] to indicate state and status. */
+    var flags: EnumSet<RendererFlags> = EnumSet.noneOf(RendererFlags::class.java)
 
     /** Last reload time for textures */
     var texturesLastSeen = 0L
@@ -79,7 +79,6 @@ open class VulkanObjectState {
      * given in [passes]. The set will reside on [device] and the descriptor set layout(s) determined from the renderpass.
      * The set will be allocated from [descriptorPool].
      */
-    @OptIn(ExperimentalTime::class)
     fun texturesToDescriptorSets(device: VulkanDevice, passes: Map<String, VulkanRenderpass>, renderable: Renderable) {
         val updateDuration = measureTime {
             // this groups textures by the ones being members of the ObjectTextures array
@@ -283,7 +282,7 @@ open class VulkanObjectState {
     )
 
     /**
-     * Utility class for [VulkanObjectState].
+     * Utility class for [VulkanRendererMetadata].
      */
     companion object {
         protected val logger by lazyLogger()

--- a/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
+++ b/src/main/kotlin/graphics/scenery/backends/vulkan/VulkanScenePass.kt
@@ -80,7 +80,7 @@ object VulkanScenePass {
                 }
             }
 
-            if(node.state != State.Ready || renderable.rendererMetadata()?.preDrawSkip == true) {
+            if(node.state != State.Ready || renderable.rendererMetadata()?.flags?.contains(RendererFlags.PreDrawSkip) == true) {
                 return@forEach
             }
 
@@ -561,7 +561,7 @@ object VulkanScenePass {
         }
     }
 
-    private fun setRequiredDescriptorSetsForNode(pass: VulkanRenderpass, node: Node, s: VulkanObjectState, specs: List<MutableMap.MutableEntry<String, ShaderIntrospection.UBOSpec>>, descriptorSets: Map<String, Long>): Pair<List<VulkanRenderer.DescriptorSet>, Boolean> {
+    private fun setRequiredDescriptorSetsForNode(pass: VulkanRenderpass, node: Node, s: VulkanRendererMetadata, specs: List<MutableMap.MutableEntry<String, ShaderIntrospection.UBOSpec>>, descriptorSets: Map<String, Long>): Pair<List<VulkanRenderer.DescriptorSet>, Boolean> {
         var skip = false
         return specs.mapNotNull { (name, _) ->
             val ds = when {

--- a/src/main/kotlin/graphics/scenery/primitives/PointCloud.kt
+++ b/src/main/kotlin/graphics/scenery/primitives/PointCloud.kt
@@ -16,7 +16,7 @@ import java.nio.file.Files
  * @author Kyle Harrington <kharrington@uidaho.edu>
  * @author Ulrik Günther <hello@ulrik.is>
  */
-open class PointCloud(var pointRadius: Float = 1.0f, override var name: String = "PointCloud") : Mesh(name) {
+open class PointCloud(var pointRadius: Float = 1.0f, name: String = "PointCloud") : Mesh(name) {
 
     init {
         geometry {


### PR DESCRIPTION
This PR cleans up some cruft from the Node interface and unifies state flags. Further, it renames VulkanObjectState to VulkanRendererMetadata.