### PR TITLE
Pass a fixed sun position to the Atmosphere constructor for reproducability

### DIFF
--- a/src/test/kotlin/graphics/scenery/tests/examples/basic/AtmosphereExample.kt
+++ b/src/test/kotlin/graphics/scenery/tests/examples/basic/AtmosphereExample.kt
@@ -34,7 +34,8 @@ class AtmosphereExample : SceneryBase("Atmosphere Example",
 
     lateinit var volume: Volume
 
-    private var atmos = Atmosphere(emissionStrength = 0.3f)
+    // hand over a fixed direction to not mess up the Argos tests
+    private var atmos = Atmosphere(Vector3f(0.2f, 0.6f, -1f))
 
     private lateinit var hmd: OpenVRHMD
 


### PR DESCRIPTION
The default sun position was influenced by local time, thus screwing with the Argos tests for the `AtmosphereExample`.
This PR solves this bug by passing a fixed sun position vector to the constructur.