### PR TITLE
ComputeHistogram.comp: Fix 16 bit histogram calculation on gpu

### DIFF
--- a/src/main/resources/graphics/scenery/volumes/ComputeHistogram.comp
+++ b/src/main/resources/graphics/scenery/volumes/ComputeHistogram.comp
@@ -1,7 +1,7 @@
 #version 450
 
 layout (local_size_x = 16, local_size_y = 16) in;
-layout (set = 0, binding = 0, r16f) uniform image3D Volume16Bit;
+layout (set = 0, binding = 0, r16) uniform image3D Volume16Bit;
 layout (set = 1, binding = 0, r8) uniform image3D Volume8Bit;
 layout (set = 2, binding = 0, r32i) uniform iimage3D Histogram;
 


### PR DESCRIPTION
The largest change in the history of scenery. 
Fixes the generation of 16bit volumes on the gpu.