### PR TITLE
Fixed the sample method. 

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
@@ -41,7 +41,7 @@ class Colormap(val buffer: ByteBuffer, val width: Int, val height: Int) {
         //The number of bytes per pixel are fixed at 4.
         val globalOffset = width * band * 4
 
-        val b = buffer.slice()
+        val b = buffer.duplicate()
         b.position(globalOffset + previous * 4);
         val color = ByteArray(4)
         b.get(color);

--- a/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
@@ -26,37 +26,42 @@ class Colormap(val buffer: ByteBuffer, val width: Int, val height: Int) {
     @Suppress("unused")
     private constructor() : this(ByteBuffer.allocate(0), 0, 0)
 
+    private fun ByteArray.toRGBAColor() = Vector4f(
+            this[0].toUByte().toFloat() / 255f,
+            this[1].toUByte().toFloat() / 255f,
+            this[2].toUByte().toFloat() / 255f,
+            this[3].toUByte().toFloat() / 255f
+        )
+
     /**
      * Returns the value of the color map sampled at the normalized position.
      *
      * position: A floating point value between 0 and 1.
      */
-    @OptIn(ExperimentalUnsignedTypes::class)
     fun sample(position: Float): Vector4f {
         val bufferPosition: Float = position.coerceIn(0.0f, 1.0f) * (width - 1)
         val previous = bufferPosition.toInt()
 
         val band = height/2
 
-        //The number of bytes per pixel are fixed at 4.
+        // The number of bytes per pixel are fixed at 4.
         val globalOffset = width * band * 4
 
         val b = buffer.duplicate()
-        b.position(globalOffset + previous * 4);
+        b.position(globalOffset + previous * 4)
         val color = ByteArray(4)
         b.get(color)
-        //Add to "Image" utility class?
-        val c1 = Vector4f(color[0].toUByte().toFloat() / 255f, color[1].toUByte().toFloat() / 255f, color[2].toUByte().toFloat() / 255f, color[3].toUByte().toFloat() / 255f)
+        // Add to "Image" utility class?
+        val c1 = color.toRGBAColor()
 
-        if (bufferPosition > previous){
+        if(bufferPosition > previous) {
             //interpolate fraction part.
-            b.get(color);
-            val c2 = Vector4f( color[0].toUByte().toFloat() / 255f, color[1].toUByte().toFloat() / 255f, color[2].toUByte().toFloat() / 255f, color[3].toUByte().toFloat() / 255f)
+            b.get(color)
+            val c2 = color.toRGBAColor()
             return c1.lerp(c2, bufferPosition - previous.toFloat())
         } else {
             return c1
         }
-
     }
 
     companion object {

--- a/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Colormap.kt
@@ -44,16 +44,16 @@ class Colormap(val buffer: ByteBuffer, val width: Int, val height: Int) {
         val b = buffer.duplicate()
         b.position(globalOffset + previous * 4);
         val color = ByteArray(4)
-        b.get(color);
+        b.get(color)
         //Add to "Image" utility class?
-        val c1 = Vector4f( color[0].toUByte().toFloat() / 255f, color[1].toUByte().toFloat() / 255f, color[2].toUByte().toFloat() / 255f, color[3].toUByte().toFloat() / 255f)
+        val c1 = Vector4f(color[0].toUByte().toFloat() / 255f, color[1].toUByte().toFloat() / 255f, color[2].toUByte().toFloat() / 255f, color[3].toUByte().toFloat() / 255f)
 
-        if( bufferPosition > previous ){
+        if (bufferPosition > previous){
             //interpolate fraction part.
             b.get(color);
             val c2 = Vector4f( color[0].toUByte().toFloat() / 255f, color[1].toUByte().toFloat() / 255f, color[2].toUByte().toFloat() / 255f, color[3].toUByte().toFloat() / 255f)
             return c1.lerp(c2, bufferPosition - previous.toFloat())
-        } else{
+        } else {
             return c1
         }
 

--- a/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
@@ -304,8 +304,8 @@ class ColormapPanel(val target:Volume?): JPanel() {
 
         internal fun toImage(): BufferedImage {
             val rec: Rectangle = this.bounds
-            val bufferedImage = BufferedImage(rec.width, rec.height, BufferedImage.TYPE_INT_ARGB)
-            paintBackgroundGradient(colorPoints.sortedBy { it.position }, bufferedImage.graphics as Graphics2D)
+            val bufferedImage = BufferedImage(rec.width, rec.height - 10, BufferedImage.TYPE_INT_ARGB)
+            paintBackgroundGradient(colorPoints.sortedBy { it.position }, bufferedImage.createGraphics())
             return bufferedImage
         }
 
@@ -324,8 +324,11 @@ class ColormapPanel(val target:Volume?): JPanel() {
             val h = height
             val pointList = colorPoints.sortedBy { it.position }
 
+
             // background Gradient
-            paintBackgroundGradient(pointList, g2d)
+            //paintBackgroundGradient(pointList, g2d)
+            val img = toImage()
+            g2d.drawImage(img, 0, 0, this)
 
             // color point markers
             val relativeSize = 0.25f //relative to height

--- a/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
@@ -299,7 +299,8 @@ class ColormapPanel(val target:Volume?): JPanel() {
             repaint()
 
             if(width > 0 && height > 0) {
-                target?.colormap = Colormap.fromBuffer(toBuffer(), width, height)
+                val bi = toImage()
+                target?.colormap = Colormap.fromBuffer(Image.bufferedImageToRGBABuffer(bi), bi.width, bi.height)
             }
         }
 
@@ -308,10 +309,6 @@ class ColormapPanel(val target:Volume?): JPanel() {
             val bufferedImage = BufferedImage(rec.width, rec.height - markerSpace, BufferedImage.TYPE_INT_ARGB)
             paintBackgroundGradient(colorPoints.sortedBy { it.position }, bufferedImage.createGraphics())
             return bufferedImage
-        }
-
-        private fun toBuffer(): ByteBuffer {
-            return Image.bufferedImageToRGBABuffer(toImage())
         }
 
         private fun pointAtMouse(e: MouseEvent) =
@@ -325,9 +322,7 @@ class ColormapPanel(val target:Volume?): JPanel() {
             val h = height
             val pointList = colorPoints.sortedBy { it.position }
 
-
             // background Gradient
-            //paintBackgroundGradient(pointList, g2d)
             val img = toImage()
             g2d.drawImage(img, 0, 0, this)
 

--- a/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/ColormapPanel.kt
@@ -208,7 +208,8 @@ class ColormapPanel(val target:Volume?): JPanel() {
         private var hoveredOver: ColorPoint? = null
         private var dragging: ColorPoint? = null
         private var dragged = false
-
+        private var markerSpace = 10
+		
         init {
             this.layout = MigLayout()
             this.preferredSize = Dimension(1000, 40)
@@ -304,7 +305,7 @@ class ColormapPanel(val target:Volume?): JPanel() {
 
         internal fun toImage(): BufferedImage {
             val rec: Rectangle = this.bounds
-            val bufferedImage = BufferedImage(rec.width, rec.height - 10, BufferedImage.TYPE_INT_ARGB)
+            val bufferedImage = BufferedImage(rec.width, rec.height - markerSpace, BufferedImage.TYPE_INT_ARGB)
             paintBackgroundGradient(colorPoints.sortedBy { it.position }, bufferedImage.createGraphics())
             return bufferedImage
         }
@@ -353,10 +354,10 @@ class ColormapPanel(val target:Volume?): JPanel() {
                 // This draws a triangle below the gradient bar to indicate control points
                 g2d.paint = outlineColor
                 g2d.drawPolygon(intArrayOf(p1x.toInt(), (p1x - innerSize).toInt(), (p1x + innerSize).toInt()),
-                                intArrayOf(h-10, h-1, h-1), 3)
+                                intArrayOf(h - markerSpace, h - 1, h - 1), 3)
                 g2d.paint = it.color
-                g2d.fillPolygon(intArrayOf(p1x.toInt(), (p1x - innerSize-1).toInt(), (p1x + innerSize+1).toInt()),
-                                intArrayOf(h-10-1, h, h), 3)
+                g2d.fillPolygon(intArrayOf(p1x.toInt(), (p1x - innerSize - 1).toInt(), (p1x + innerSize + 1).toInt()),
+                                intArrayOf(h - markerSpace - 1, h, h), 3)
             }
         }
 
@@ -365,7 +366,7 @@ class ColormapPanel(val target:Volume?): JPanel() {
             g2d: Graphics2D
         ) {
             val w = width
-            val h = height
+            val h = height - markerSpace
             for (i in 0 until pointList.size - 1) {
                 val p1 = pointList[i]
                 val p2 = pointList[i + 1]
@@ -374,7 +375,7 @@ class ColormapPanel(val target:Volume?): JPanel() {
                 val gp = GradientPaint(p1x, 0f, p1.color, p2x, 0f, p2.color)
 
                 g2d.paint = gp
-                g2d.fillRect(p1x.toInt(), 0, p2x.toInt(), h-10)
+                g2d.fillRect(p1x.toInt(), 0, p2x.toInt(), h)
             }
         }
 


### PR DESCRIPTION
Colormap.sample would go out of bounds. It was also broken for odd h values. [Issue #750](https://github.com/scenerygraphics/scenery/issues/750)

Made a hot fix for generating an image form the ColormapEditor the image was missing 10px so depending on how large the editor was displayed the resulting Colormap always returned black. [Issue #757](https://github.com/scenerygraphics/scenery/issues/757)

If this looks ok I can improve it. 