### PR TITLE
Bump Kotlin to 2.0.0, Dokka to 1.9.23

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g -XX:MaxHeapSize=4g
 org.gradle.caching=true
-kotlinVersion=1.9.23
-dokkaVersion=1.9.10
+kotlinVersion=2.0.0
+dokkaVersion=1.9.20
 scijavaParentPOMVersion=37.0.0
 lwjglVersion=3.3.3
 jvmTarget=21


### PR DESCRIPTION
This PR bumps Kotlin to 2.0.0 and Dokka to 1.9.23.