### PR TITLE
Allow to center camera messages

### DIFF
--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -359,8 +359,8 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
                 var maxX = 0f
                 while (bv.hasRemaining()) {
                     maxX = java.lang.Float.max(bv.get(), maxX)
-                    bv.get()
-                    bv.get()
+                    bv.get() // skip Y
+                    bv.get() // skip Z
                 }
                 maxX *= tb.spatial().scale.x
 

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -350,10 +350,9 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
         tb.fontColor = messageColor
         tb.backgroundColor = backgroundColor
         tb.text = message
-        // Calculate the offset for text centering based on message length.
-        // The second divisor was eyeballed and might need adjustment.
+        // Calculate the offset for text centering based on message length
         val offset = if (centered) {
-            size * message.length.toFloat() / 2f / 5f
+            tb.spatial().scale.x / 2f
         } else {
             0f
         }

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -336,14 +336,30 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
      *
      * It will be shown for [duration] milliseconds, with a default of 3000.
      */
-    @JvmOverloads fun showMessage(message: String, distance: Float = 0.75f, size: Float = 0.05f, messageColor: Vector4f = Vector4f(1.0f), backgroundColor: Vector4f = Vector4f(0.0f), duration: Int = 3000) {
+    @JvmOverloads
+    fun showMessage(
+        message: String,
+        distance: Float = 0.75f,
+        size: Float = 0.05f,
+        messageColor: Vector4f = Vector4f(1.0f),
+        backgroundColor: Vector4f = Vector4f(0.0f),
+        duration: Int = 3000,
+        centered: Boolean = false
+    ) {
         val tb = TextBoard()
         tb.fontColor = messageColor
         tb.backgroundColor = backgroundColor
         tb.text = message
+        // Calculate the offset for text centering based on message length.
+        // The second divisor was eyeballed and might need adjustment.
+        val offset = if (centered) {
+            size * message.length.toFloat() / 2f / 5f
+        } else {
+            0f
+        }
         tb.spatial {
             scale = Vector3f(size, size, size)
-            position = Vector3f(0.0f, 0.0f, -1.0f * distance)
+            position = Vector3f(0.0f - offset, 0.0f, -1.0f * distance)
         }
 
         @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/graphics/scenery/Camera.kt
+++ b/src/main/kotlin/graphics/scenery/Camera.kt
@@ -350,24 +350,46 @@ open class Camera : DefaultNode("Camera"), HasRenderable, HasMaterial, HasCustom
         tb.fontColor = messageColor
         tb.backgroundColor = backgroundColor
         tb.text = message
-        // Calculate the offset for text centering based on message length
-        val offset = if (centered) {
-            tb.spatial().scale.x / 2f
-        } else {
-            0f
+        var textGeom = tb.geometry().vertices
+
+        // get biggest X value, then move the text board along negative X to center it
+        fun centerMessage() {
+            if (textGeom != tb.geometry().vertices) {
+                val bv = tb.geometry().vertices.duplicate().clear()
+                var maxX = 0f
+                while (bv.hasRemaining()) {
+                    maxX = java.lang.Float.max(bv.get(), maxX)
+                    bv.get()
+                    bv.get()
+                }
+                maxX *= tb.spatial().scale.x
+
+                tb.spatial {
+                    position.x -= maxX / 2f
+                    needsUpdate = true
+                }
+                textGeom = tb.geometry().vertices
+            }
         }
+
         tb.spatial {
             scale = Vector3f(size, size, size)
-            position = Vector3f(0.0f - offset, 0.0f, -1.0f * distance)
+            position = Vector3f(0.0f, 0.0f, -1.0f * distance)
+        }
+        if (centered) {
+            centerMessage()
         }
 
         @Suppress("UNCHECKED_CAST")
         val messages = metadata.getOrPut("messages", { mutableListOf<Node>() }) as? MutableList<Node>?
         messages?.forEach { this.removeChild(it) }
         messages?.clear()
-
         messages?.add(tb)
+
         this.addChild(tb)
+        if (centered) {
+            this.update += { centerMessage() }
+        }
 
         thread {
             Thread.sleep(duration.toLong())


### PR DESCRIPTION
This adds a new `centering` parameter to `Camera.showMessage()` (default = false) that attempts to center the text based on message length (bounding boxes are not available for textboards, so can't use those). The scaling factor is a bit eyeballed, but it seems to work for the text sizes I currently use.