### PR TITLE
DSSDO: Fix wrong attachment order for samples

### DIFF
--- a/src/main/resources/graphics/scenery/backends/shaders/DSSDO.frag
+++ b/src/main/resources/graphics/scenery/backends/shaders/DSSDO.frag
@@ -11,8 +11,8 @@
 
 layout(set = 3, binding = 0) uniform sampler2D InputNormalsMaterial;
 layout(set = 3, binding = 1) uniform sampler2D InputDiffuseAlbedo;
-layout(set = 3, binding = 2) uniform sampler2D InputZBuffer;
-layout(set = 3, binding = 3) uniform sampler2D InputEmission;
+layout(set = 3, binding = 2) uniform sampler2D InputEmission;
+layout(set = 3, binding = 3) uniform sampler2D InputZBuffer;
 
 layout(location = 0) out vec4 FragColor;
 layout(location = 0) in VertexData {

--- a/src/main/resources/graphics/scenery/backends/shaders/DSSDOBlur.frag
+++ b/src/main/resources/graphics/scenery/backends/shaders/DSSDOBlur.frag
@@ -11,8 +11,8 @@
 
 layout(set = 1, binding = 0) uniform sampler2D InputNormalsMaterial;
 layout(set = 1, binding = 1) uniform sampler2D InputDiffuseAlbedo;
-layout(set = 1, binding = 2) uniform sampler2D InputZBuffer;
-layout(set = 1, binding = 3) uniform sampler2D InputEmission;
+layout(set = 1, binding = 2) uniform sampler2D InputEmission;
+layout(set = 1, binding = 3) uniform sampler2D InputZBuffer;
 layout(set = 2, binding = 0) uniform sampler2D InputOcclusion;
 
 layout(location = 0) out vec4 FragColor;


### PR DESCRIPTION
This PR fixes an issue in the DSSDO shaders introduced in #594. There, the order of sampled attachments was wrong, causing the DSSDO shader to sample depth from the emissions texture, leading to visual artifacts.