### PR TITLE
Improve naming of hasTransferFunction.range property to make its function clear and avoid confusion with minDisplayRange and maxDisplayRange

### DIFF
--- a/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/BufferedVolume.kt
@@ -204,7 +204,7 @@ class BufferedVolume(val ds: VolumeDataSource.RAISource<*>, options: VolumeViewe
                 else -> throw java.lang.IllegalStateException("Can't determine density for ${ds.type.javaClass.simpleName} data")
             }
 
-            val transferRangeMax = range.second
+            val transferRangeMax = displayRangeLimits.second
 
             val final = transferFunction.evaluate(s / transferRangeMax)
             logger.info("Sample at $index is $s, final is $final $transferRangeMax")

--- a/src/main/kotlin/graphics/scenery/volumes/DisplayRangeEditor.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/DisplayRangeEditor.kt
@@ -46,16 +46,16 @@ class DisplayRangeEditor(private val tfContainer: HasTransferFunction): JPanel()
         // Range editor
         val initMinValue = max(tfContainer.minDisplayRange.toInt(), 100)
         minText = JTextField(initMinValue.toString())
-        minValueLabel = JLabel(String.format("%.1f", tfContainer.range.first))
+        minValueLabel = JLabel(String.format("%.1f", tfContainer.displayRangeLimits.first))
 
         val initMaxValue = max(tfContainer.maxDisplayRange.toInt(), 100)
         maxText = JTextField(initMaxValue.toString())
         maxText.horizontalAlignment = SwingConstants.RIGHT
-        maxValueLabel = JLabel(String.format("%.1f", tfContainer.range.second))
+        maxValueLabel = JLabel(String.format("%.1f", tfContainer.displayRangeLimits.second))
 
         rangeSlider = RangeSlider()
-        rangeSlider.minimum = tfContainer.range.first.roundToInt()
-        rangeSlider.maximum = tfContainer.range.second.roundToInt()
+        rangeSlider.minimum = tfContainer.displayRangeLimits.first.roundToInt()
+        rangeSlider.maximum = tfContainer.displayRangeLimits.second.roundToInt()
         rangeSlider.value = tfContainer.minDisplayRange.toInt()
         rangeSlider.upperValue = tfContainer.maxDisplayRange.toInt()
 
@@ -90,8 +90,8 @@ class DisplayRangeEditor(private val tfContainer: HasTransferFunction): JPanel()
     private fun updateConverter() {
         minText.text = rangeSlider.value.toString()
         maxText.text = rangeSlider.upperValue.toString()
-        minValueLabel.text = String.format("%.1f", tfContainer.range.first)
-        maxValueLabel.text = String.format("%.1f", tfContainer.range.second)
+        minValueLabel.text = String.format("%.1f", tfContainer.displayRangeLimits.first)
+        maxValueLabel.text = String.format("%.1f", tfContainer.displayRangeLimits.second)
 
         tfContainer.minDisplayRange = rangeSlider.value.toFloat()
         tfContainer.maxDisplayRange = rangeSlider.upperValue.toFloat()

--- a/src/main/kotlin/graphics/scenery/volumes/DummyVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/DummyVolume.kt
@@ -40,8 +40,8 @@ class DummyVolume(val counterStart : Int = 0) : DefaultNode("DummyVolume"), HasT
             modifiedAt = System.nanoTime()
         }
 
-    /** A pair containing the min and max display range. */
-    override var range: Pair<Float, Float> = Pair<Float, Float>(minDisplayRange,maxDisplayRange)
+    /** A pair containing the min and max display range limits. */
+    override var displayRangeLimits: Pair<Float, Float> = Pair<Float, Float>(minDisplayRange,maxDisplayRange)
         get() = field
         set(m) {
             field = m

--- a/src/main/kotlin/graphics/scenery/volumes/HasTransferFunction.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/HasTransferFunction.kt
@@ -16,7 +16,11 @@ interface HasTransferFunction {
     var transferFunction : TransferFunction
     var minDisplayRange : Float
     var maxDisplayRange : Float
-    var range: Pair<Float, Float>
+
+    /**
+     * The allowed value range for [minDisplayRange] and [maxDisplayRange]. Eg. 0 and Short.MAX_VALUE
+     */
+    var displayRangeLimits: Pair<Float, Float>
 
     /**
      * Load transfer function and display range from file that was written by [HasTransferFunction.saveTransferFunctionToFile]

--- a/src/main/kotlin/graphics/scenery/volumes/Volume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/Volume.kt
@@ -137,7 +137,7 @@ open class Volume(
         get() = converterSetups.getOrNull(0)?.displayRangeMax?.toFloat() ?: throw IllegalStateException()
         set(value) { setTransferFunctionRange(minDisplayRange, value) }
 
-    override var range: Pair<Float, Float>
+    override var displayRangeLimits: Pair<Float, Float>
         get() = when(dataSource) {
             VolumeDataSource.NullSource -> 0.0f to 0.0f
             is VolumeDataSource.RAISource<*> -> dataSource.type.toRange()


### PR DESCRIPTION
Improve naming of hasTransferFunction.range property to make its function clear and avoid confusion with minDisplayRange and maxDisplayRange