### PR TITLE
Bump scijava parent POM to 39.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g -XX:MaxHeapSize=4g
 org.gradle.caching=true
-kotlinVersion=2.0.0
+kotlinVersion=2.0.21
 dokkaVersion=1.9.20
-scijavaParentPOMVersion=37.0.0
+scijavaParentPOMVersion=39.0.0
 lwjglVersion=3.3.3
 jvmTarget=21
 version=0.11.3-SNAPSHOT

--- a/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
+++ b/src/main/kotlin/graphics/scenery/backends/RenderConfigReader.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.SingletonSupport
 import graphics.scenery.Blending
 import graphics.scenery.utils.JsonDeserialisers
 import graphics.scenery.utils.lazyLogger


### PR DESCRIPTION
This PR bumps the dependency on the scijava parent POM to 39.0.0, and also bumps Kotlin to 2.0.21, while removing a spurious import from RenderConfigReader.