### PR TITLE
OpenVRHMD safe shutdown

### DIFF
--- a/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
+++ b/src/main/kotlin/graphics/scenery/controls/OpenVRHMD.kt
@@ -267,6 +267,7 @@ open class OpenVRHMD(val seated: Boolean = false, val useCompositor: Boolean = t
      * Runs the OpenVR shutdown hooks
      */
     fun close() {
+        initialized = false
         VR_ShutdownInternal()
     }
 

--- a/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
+++ b/src/main/kotlin/graphics/scenery/volumes/RAIVolume.kt
@@ -113,9 +113,10 @@ class RAIVolume(@Transient val ds: VolumeDataSource, options: VolumeViewerOption
 
                 val shift = if (source != null) {
                     val s = source.spimSource.getSource(0, 0)
+                    val voxelScale = volume.getVoxelScale()
                     val min = Vector3f(s.min(0).toFloat(), s.min(1).toFloat(), s.min(2).toFloat())
                     val max = Vector3f(s.max(0).toFloat(), s.max(1).toFloat(), s.max(2).toFloat())
-                    (max - min) * (-0.5f)
+                    (max - min).mul(voxelScale) * (-0.5f)
                 } else {
                     Vector3f(0.0f, 0.0f, 0.0f)
                 }


### PR DESCRIPTION
This PR adds `initalized = false` to `OpenVRHMD.close()` before calling the shutdown logic to prevent the renderer from accessing memory that doesn't exist anymore.