### PR TITLE
Bump lwjgl to 3.4.1, pin lwjgl-openvr to 3.3.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ val lwjglArtifacts = listOf(
         "lwjgl-jemalloc",
         "lwjgl-vulkan",
         "lwjgl-opengl",
-        "lwjgl-openvr",
+//        "lwjgl-openvr",
         "lwjgl-xxhash",
         "lwjgl-remotery",
         "lwjgl-spvc",
@@ -45,6 +45,8 @@ dependencies {
     // POM will be generated incorrectly.
     val scijavaParentPomVersion = project.properties["scijavaParentPOMVersion"]
     val lwjglVersion = project.properties["lwjglVersion"]
+    // Temporary workaround because OpenVR isn't available in 3.4.1 yet
+    val lwjglOpenVRVersion = "3.3.6"
     
     implementation(platform("org.scijava:pom-scijava:$scijavaParentPomVersion"))
     annotationProcessor("org.scijava:scijava-common:2.98.0")
@@ -98,6 +100,14 @@ dependencies {
             }
         }
     }
+
+    api("org.lwjgl:lwjgl-openvr:${lwjglOpenVRVersion}")
+    lwjglNatives.forEach { native ->
+        if (!(native.contains("macos") && native.contains("arm64"))) {
+            runtimeOnly("org.lwjgl:lwjgl-openvr:$lwjglOpenVRVersion:$native")
+        }
+    }
+
     implementation("org.xerial.snappy:snappy-java:1.1.10.5")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.20.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.caching=true
 kotlinVersion=2.2.10
 dokkaVersion=1.9.20
 scijavaParentPOMVersion=39.0.0
-lwjglVersion=3.3.3
+lwjglVersion=3.4.1
 jvmTarget=21
 version=1.0.0-beta-2
 


### PR DESCRIPTION
Newer Nvidia drivers conflict with vulkan initialization in LWJGL 3.3.3 (see http://forum.lwjgl.org/index.php?topic=7334.0). This has been [fixed in 3.4.0](https://github.com/LWJGL/lwjgl3/commit/b5b363e2).

The LWJGL-OpenVR bindings however no longer ship with 3.4.0+, so these are pinned to 3.3.6 for now.

Long-term a rewrite to OpenXR might be required.
